### PR TITLE
Add GitHub Action to track doc-en merged PRs

### DIFF
--- a/.github/scripts/track-en-changes.sh
+++ b/.github/scripts/track-en-changes.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Track merged PRs in php/doc-en and create issues in doc-fr
+# for files that need translation updates.
+#
+# How it works:
+#   - Fetches PRs merged in doc-en during the last 7 days
+#   - For each PR, checks if a matching issue already exists in doc-fr
+#   - If not, creates one listing the FR files to update
+#
+# Why 7 days: the action runs daily, so 7 days gives us 6 days of margin.
+# Even if the action fails for a whole week, nothing is missed.
+# Duplicates are prevented by searching for the PR number in existing issue titles.
+#
+set -euo pipefail
+
+SINCE=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')
+echo "Checking doc-en PRs merged since $SINCE"
+
+# Fetch merged PRs from the last 7 days (max 100 per page, paginate if needed)
+PAGE=1
+ALL_PRS="[]"
+while :; do
+  BATCH=$(gh api "repos/php/doc-en/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=$PAGE" \
+    --jq "[.[] | select(.merged_at != null and .merged_at >= \"$SINCE\")]")
+  COUNT=$(echo "$BATCH" | jq 'length')
+  ALL_PRS=$(echo "$ALL_PRS $BATCH" | jq -s 'add')
+  echo "  Page $PAGE: $COUNT merged PR(s)"
+  if [ "$COUNT" -lt 100 ]; then
+    break
+  fi
+  PAGE=$((PAGE + 1))
+done
+
+TOTAL=$(echo "$ALL_PRS" | jq 'length')
+echo "Total: $TOTAL merged PR(s) in the last 7 days"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "Nothing to do."
+  exit 0
+fi
+
+CREATED=0
+SKIPPED=0
+
+echo "$ALL_PRS" | jq -c '.[]' | while read -r PR; do
+  PR_NUMBER=$(echo "$PR" | jq -r '.number')
+  PR_TITLE=$(echo "$PR" | jq -r '.title')
+  PR_AUTHOR=$(echo "$PR" | jq -r '.user.login')
+  PR_MERGED_AT=$(echo "$PR" | jq -r '.merged_at')
+  PR_MERGE_DATE=$(echo "$PR_MERGED_AT" | cut -dT -f1)
+
+  echo ""
+  echo "PR #$PR_NUMBER: $PR_TITLE"
+
+  # Deduplication: check if an issue already exists for this PR
+  # Search in both open and closed issues to never re-create a closed one
+  EXISTING=$(gh issue list --repo "$GH_REPO" --search "\"[Sync EN]\" \"(#$PR_NUMBER)\" in:title" \
+    --state all --json number --jq 'length')
+  if [ "$EXISTING" -gt 0 ]; then
+    echo "  -> Issue already exists, skipping."
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Get files changed in this PR
+  FILES=$(gh api "repos/php/doc-en/pulls/$PR_NUMBER/files?per_page=100" \
+    --jq '.[].filename' 2>/dev/null || true)
+
+  if [ -z "$FILES" ]; then
+    echo "  -> No files found, skipping."
+    continue
+  fi
+
+  # Categorize files
+  UPDATE_LIST=""
+  NEW_LIST=""
+
+  while IFS= read -r FILE; do
+    if [ -f "$FILE" ]; then
+      UPDATE_LIST="${UPDATE_LIST}- \`${FILE}\`"$'\n'
+    elif [[ "$FILE" == *.xml ]]; then
+      NEW_LIST="${NEW_LIST}- \`${FILE}\`"$'\n'
+    fi
+  done <<< "$FILES"
+
+  # Skip if no FR-relevant files
+  if [ -z "$UPDATE_LIST" ] && [ -z "$NEW_LIST" ]; then
+    echo "  -> No FR-relevant files, skipping."
+    continue
+  fi
+
+  # Build issue body
+  BODY="## PR doc-en mergée"$'\n'
+  BODY+="https://github.com/php/doc-en/pull/$PR_NUMBER"$'\n\n'
+  BODY+="**Mergée le :** $PR_MERGE_DATE"$'\n'
+  BODY+="**Auteur :** @$PR_AUTHOR"$'\n'
+
+  if [ -n "$UPDATE_LIST" ]; then
+    BODY+=$'\n'"## Fichiers FR à mettre à jour"$'\n'
+    BODY+="$UPDATE_LIST"
+  fi
+
+  if [ -n "$NEW_LIST" ]; then
+    BODY+=$'\n'"## Nouveaux fichiers EN (pas encore traduits)"$'\n'
+    BODY+="$NEW_LIST"
+  fi
+
+  # Create the issue
+  ISSUE_TITLE="[Sync EN] $PR_TITLE (#$PR_NUMBER)"
+  echo "$BODY" | gh issue create \
+    --repo "$GH_REPO" \
+    --title "$ISSUE_TITLE" \
+    --label "sync-en" \
+    --body-file -
+
+  echo "  -> Issue created."
+  CREATED=$((CREATED + 1))
+done
+
+echo ""
+echo "Done. Created: $CREATED, Skipped (already exist): $SKIPPED"

--- a/.github/workflows/track-en-changes.yml
+++ b/.github/workflows/track-en-changes.yml
@@ -1,0 +1,25 @@
+name: "Track doc-en changes"
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  track:
+    name: "Check for new doc-en merges"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout doc-fr"
+        uses: "actions/checkout@v4"
+
+      - name: "Check doc-en merges and create issues"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+        run: bash .github/scripts/track-en-changes.sh


### PR DESCRIPTION
Daily workflow (6h UTC) that checks the last 7 days of merged PRs in php/doc-en and creates issues in doc-fr listing the FR files that need updating. Deduplication by issue title prevents duplicates. No external state needed - stateless and resilient to failures.