### PR TITLE
faq/: fix translations, grammar, and apply TRADUCTIONS.txt rules

### DIFF
--- a/faq/build.xml
+++ b/faq/build.xml
@@ -22,17 +22,17 @@
    </question>
    <answer>
     <para>
-     Vous devez avoir le logiciel GNU autoconf d'installé pour générer le
-     script configure à partir de <filename>configure.in</filename>. Lancez
-     juste <command>./buildconf</command> à la racine du répertoire des sources
+     Il est nécessaire d'avoir le logiciel GNU autoconf d'installé pour générer le
+     script configure à partir de <filename>configure.in</filename>. Il suffit de
+     lancer <command>./buildconf</command> à la racine du répertoire des sources
      après avoir récupéré celles-ci à partir du serveur Git. (De plus, à
-     moins que vous ne lanciez <command>configure</command> avec l'option
+     moins de lancer <command>configure</command> avec l'option
      <literal>--enable-maintainer-mode</literal>, le script configure ne sera
      pas automatiquement reconstruit si <filename>configure.in</filename>
-     est mis à jour, vous obligeant à le faire à la main quand vous remarquez
-     que <filename>configure.in</filename> est mis à jour. Une conséquence de
-     ceci est que l'on trouve des choses telles que @VARIABLE@ dans votre
-     Makefile après que configure ou <filename>config.status</filename> soit
+     est mis à jour, obligeant à le faire à la main quand
+     <filename>configure.in</filename> est mis à jour. Une conséquence de
+     ceci est que l'on trouve des choses telles que @VARIABLE@ dans le
+     Makefile après que configure ou <filename>config.status</filename> est
      lancé.)
     </para>
    </answer>
@@ -43,14 +43,14 @@
     <para>
      J'ai des problèmes pour configurer PHP avec Apache.
      On m'indique que <filename>httpd.h</filename> n'est pas trouvé, mais il
-     est bien là ou je l'ai spécifié !
+     est bien là où je l'ai spécifié !
     </para>
    </question>
    <answer>
     <para>
-     Vous devez spécifier au script de configuration (configure)
-     l'emplacement du répertoire ou sont les sources de Apache. Cela signifie
-     que vous devez spécifier
+     Il faut spécifier au script de configuration (configure)
+     l'emplacement du répertoire où sont les sources d'Apache. Cela signifie
+     qu'il faut spécifier
      <option role="configure">--with-apache=/chemin/vers/apache</option> et
      <emphasis>pas</emphasis>
      <option role="configure">--with-apache=/chemin/vers/apache/src</option>.
@@ -61,8 +61,8 @@
   <qandaentry xml:id="faq.build.lex">
    <question>
     <para>
-     Pendant la configuration de PHP (<literal>./configure</literal>), vous
-     rencontrez une erreur semblable à celle-ci :
+     Pendant la configuration de PHP (<literal>./configure</literal>),
+     on rencontre une erreur semblable à celle-ci :
     </para>
     <para>
      <screen>
@@ -73,10 +73,10 @@
    </question>
    <answer>
     <para>
-     Assurez-vous de bien avoir lu les <link
+     Il convient de bien avoir lu les <link
      linkend="install.unix">instructions</link> d'installation et d'avoir
-     flex et bison d'installés pour compiler PHP. Selon votre système, vous
-     devrez installer bison et flex à partir de sources ou bien de paquets,
+     flex et bison d'installés pour compiler PHP. Selon le système, il peut
+     être nécessaire d'installer bison et flex à partir de sources ou bien de paquets,
      tel qu'un RPM.
     </para>
    </answer>
@@ -98,7 +98,7 @@
     <para>
      Cette erreur survient généralement quand quelqu'un compile le cœur
      Apache comme bibliothèque partagée DSO. Essayez de reconfigurer Apache, en
-     vous assurant d'utiliser les options suivantes :
+     s'assurant d'utiliser les options suivantes :
     </para>
     <para>
      <screen>
@@ -106,8 +106,8 @@
      </screen>
     </para>
     <para>
-     Pour davantage d'informations, lisez le fichier
-     <filename>INSTALL</filename> à la racine de votre répertoire source
+     Pour davantage d'informations, consulter le fichier
+     <filename>INSTALL</filename> à la racine du répertoire source
      Apache ou bien <link xlink:href="&url.apachedso;">le manuel des bibliothèques
      DSO</link>.
     </para>
@@ -123,7 +123,7 @@
    </question>
    <answer>
     <para>
-     Vous pouvez forcer le script configure à chercher les fichiers d'en-tête
+     Il est possible de forcer le script configure à chercher les fichiers d'en-tête
      à des endroits non-standard en passant des options supplémentaires au
      préprocesseur C et à l'éditeur de liens, par exemple :
      <programlisting>
@@ -131,7 +131,7 @@
     CPPFLAGS=-I/path/to/include LDFLAGS=-L/path/to/library ./configure
 ]]>
      </programlisting>
-     Si vous utilisez une variante de csh, utilisez plutôt :
+     Dans le cas d'une variante de csh, utiliser plutôt :
      <programlisting>
 <![CDATA[
     env CPPFLAGS=-I/path/to/include LDFLAGS=-L/path/to/library ./configure
@@ -150,8 +150,8 @@
    </question>
    <answer>
     <para>
-     Vous devez mettre à jour votre version de bison. Vous pourrez trouver la
-     dernière version sur <link xlink:href="&url.bison;">&url.bison;</link>.
+     Il est nécessaire de mettre à jour la version de bison. La dernière
+     version est disponible sur <link xlink:href="&url.bison;">&url.bison;</link>.
     </para>
    </answer>
   </qandaentry>
@@ -170,7 +170,7 @@
      les versions compilées des fichiers dans le répertoire functions.
      Essayez de lancer <command>cp *.o functions</command> et de relancer
      <command>make</command> pour voir si le problème est résolu. Si tel est
-     le cas, vous devriez vraiment mettre à jour votre version de GNU make.
+     le cas, il est fortement recommandé de mettre à jour la version de GNU make.
     </para>
    </answer>
   </qandaentry>
@@ -183,10 +183,10 @@
    </question>
    <answer>
     <para>
-     Jetez un oeil à la ligne de lien et assurez-vous que toutes les bibliothèques
+     Il convient de jeter un œil à la ligne de lien et de s'assurer que toutes les bibliothèques
      nécessaires ont été incluses à la fin. Celles qui manquent probablement
-     sont '-ldl' et les bibliothèques relatives aux bases de données dont vous
-     voulez le support.
+     sont '-ldl' et les bibliothèques relatives aux bases de données dont le
+     support est souhaité.
     </para>
     <para>
      Des personnes nous ont rapporté qu'elles devaient ajouter '-ldl'
@@ -207,41 +207,41 @@
    <answer>
     <para>
      Cela signifie que le module PHP n'est pas chargé, pour une raison ou
-     pour une autre. Avant de chercher de l'aide ailleurs, veuillez vérifier
+     pour une autre. Avant de chercher de l'aide ailleurs, il convient de vérifier
      ces quelques points :
      <itemizedlist>
       <listitem>
        <simpara>
-        Assurez-vous que le binaire httpd que vous exécutez est bien le
-        nouveau binaire que vous avez compilé. Pour cela, essayez de lancer :
+        Il faut s'assurer que le binaire httpd exécuté est bien le
+        nouveau binaire compilé. Pour cela, essayer de lancer :
         <literal>/chemin/vers/le/binaire/httpd -l</literal>
        </simpara>
        <simpara>
-        Si vous ne voyez pas <filename>mod_php4.c</filename> dans la liste,
-        c'est que vous n'utilisez pas le bon binaire. Trouvez et installez
+        Si <filename>mod_php4.c</filename> n'apparaît pas dans la liste,
+        c'est que le bon binaire n'est pas utilisé. Il faut trouver et installer
         correctement le bon binaire.
        </simpara>
       </listitem>
       <listitem>
        <simpara>
-        Assurez-vous que vous avez bien ajouté le bon type Mime à un de vos
+        Il faut s'assurer que le bon type Mime a bien été ajouté à un des
         fichiers <literal>Apache .conf</literal>. Ce devrait être :
         <literal>AddType application/x-httpd-php .php</literal>
        </simpara>
        <simpara>
-        Assurez-vous aussi que cette ligne Addtype n'est pas dissimulée dans
+        Il faut aussi s'assurer que cette ligne AddType n'est pas dissimulée dans
         un contexte de &lt;Virtualhost&gt; ou &lt;Directory&gt; qui
-        l'empêcherait de s'appliquer à l'emplacement de vos scripts.
+        l'empêcherait de s'appliquer à l'emplacement des scripts.
        </simpara>
       </listitem>
       <listitem>
        <simpara>
         Enfin, l'emplacement par défaut des fichiers de configuration Apache
-        a changé entre Apache 1.2 et Apache 1.3. Vous devriez vérifier que
-        les fichiers de configuration auxquels vous ajoutez la ligne Addtype
-        sont bien ceux qui sont pris en compte. Vous pouvez introduire une
-        erreur de syntaxe dans votre &httpd.conf; (ou bien tout autre
-        changement incorrect) pour vous assurer que c'est bien ce fichier qui
+        a changé entre Apache 1.2 et Apache 1.3. Il convient de vérifier que
+        les fichiers de configuration auxquels la ligne AddType est ajoutée
+        sont bien ceux qui sont pris en compte. Il est possible d'introduire une
+        erreur de syntaxe dans le &httpd.conf; (ou bien tout autre
+        changement incorrect) pour s'assurer que c'est bien ce fichier qui
         est pris en compte.
        </simpara>
       </listitem>
@@ -261,7 +261,7 @@
    </question>
    <answer>
     <para>
-     Notez que le fichier <filename>libphp4.a</filename> n'est pas supposé
+     Il est à noter que le fichier <filename>libphp4.a</filename> n'est pas supposé
      exister. Le processus apache le créera !
     </para>
    </answer>
@@ -295,11 +295,11 @@
      Il y a trois choses à vérifier ici. Tout d'abord, quand Apache crée le
      script Perl apxs, il s'interrompt parfois en étant compilé sans le bon
      compilateur ou les bonnes options.
-     Trouvez votre script apxs (lancez la commande <command>which
+     Il faut trouver le script apxs (avec la commande <command>which
      apxs</command>), qui se trouve souvent à
      <filename>/usr/local/apache/bin/apxs</filename> ou bien
      <filename>/usr/sbin/apxs</filename>.
-     Éditez-le et vérifiez que des lignes similaires sont présentes :
+     L'éditer et vérifier que des lignes similaires sont présentes :
      <programlisting>
 <![CDATA[
 my $CFG_CFLAGS_SHLIB  = ' ';          # substituted via Makefile.tmpl
@@ -307,9 +307,9 @@ my $CFG_LD_SHLIB      = ' ';          # substituted via Makefile.tmpl
 my $CFG_LDFLAGS_SHLIB = ' ';          # substituted via Makefile.tmpl
 ]]>
      </programlisting>
-     Si c'est ce que vous voyez, vous avez trouvé votre problème. Elles
+     Si c'est le cas, le problème est trouvé. Elles
      peuvent contenir juste des espaces ou d'autres valeurs incorrectes,
-     comme 'q()'. Changez ces lignes pour obtenir :
+     comme 'q()'. Changer ces lignes pour obtenir :
      <programlisting>
 <![CDATA[
 my $CFG_CFLAGS_SHLIB  = '-fpic -DSHARED_MODULE'; # substituted via Makefile.tmpl
@@ -325,14 +325,14 @@ my $CFG_LDFLAGS_SHLIB = q(-shared);              # substituted via Makefile.tmpl
 my $CFG_LIBEXECDIR    = 'modules';         # substituted via APACI install
 ]]>
      </programlisting>
-     Si vous la voyez telle quelle, changez-la en :
+     Si elle apparaît telle quelle, la changer en :
      <programlisting>
 <![CDATA[
 my $CFG_LIBEXECDIR    = '/usr/lib/apache'; # substituted via APACI install
 ]]>
      </programlisting>
-     Enfin, si vous reconfigurez/réinstallez Apache, lancez un <command>make
-     clean</command> entre votre <command>./configure</command> et votre
+     Enfin, en cas de reconfiguration/réinstallation d'Apache, lancer un <command>make
+     clean</command> entre le <command>./configure</command> et le
      <command>make</command>.
     </para>
    </answer>
@@ -347,8 +347,8 @@ my $CFG_LIBEXECDIR    = '/usr/lib/apache'; # substituted via APACI install
    </question>
    <answer>
     <para>
-     Pendant le <command>make</command>, si vous rencontrez des problèmes
-     identiques à celui-ci :
+     Pendant le <command>make</command>, si des problèmes
+     identiques à celui-ci surviennent :
      <programlisting>
 <![CDATA[
 microtime.c: In function `php_if_getrusage':
@@ -368,10 +368,10 @@ make: *** [all-recursive] Error 1
      </programlisting>
     </para>
     <para>
-     Votre système est défectueux. Vous devez corriger vos fichiers
+     Le système est défectueux. Il faut corriger les fichiers
      <filename>/usr/include</filename> en installant un paquet glibc-devel qui
-     correspond à votre version de la glibc. Cela n'a rien à voir avec PHP.
-     Pour vous en convaincre, essayez ceci :
+     correspond à la version de la glibc. Cela n'a rien à voir avec PHP.
+     Pour s'en convaincre, essayer ceci :
      <programlisting>
 <![CDATA[
 $ cat >test.c <<X
@@ -380,7 +380,7 @@ X
 $ gcc -E test.c >/dev/null
 ]]>
      </programlisting>
-     Si vous obtenez des erreurs, c'est que vos fichiers d'en-tête sont
+     Si des erreurs apparaissent, c'est que les fichiers d'en-tête sont
      mauvais.
     </para>
    </answer>
@@ -403,13 +403,13 @@ $ gcc -E test.c >/dev/null
      Tout d'abord, il est important de savoir que ce n'est qu'un <literal>
      Warning</literal> et pas une erreur fatale. Comme c'est souvent la
      dernière erreur vue lors du <literal>make</literal>, ça a l'air d'une
-     erreur fatale, mais ça n'en est pas une. Bien sûr, si vous demandez à
-     votre compilateur de stopper à chaque Warning, ça en deviendra une.
-     Notez aussi que le support de MySQL est activé par défaut.
+     erreur fatale, mais ça n'en est pas une. Bien sûr, si le compilateur est
+     configuré pour stopper à chaque Warning, ça en deviendra une.
+     Il est à noter que le support de MySQL est activé par défaut.
     </para>
     <note>
      <para>
-      Depuis PHP 4.3.2, vous verrez le texte suivant après la compilation
+      À partir de PHP 4.3.2, le texte suivant apparaît après la compilation
       (make) :
      </para>
      <para>
@@ -432,7 +432,7 @@ $ gcc -E test.c >/dev/null
    </question>
    <answer>
     <para>
-     Vous pouvez jetez un oeil au fichier config.nice dans votre répertoire
+     Il est possible de jeter un œil au fichier config.nice dans le répertoire
      source ou sinon simplement exécuter un script
      <programlisting role="php">
 <![CDATA[
@@ -440,8 +440,8 @@ $ gcc -E test.c >/dev/null
 ]]>
      </programlisting>
      Au début du résultat affiché figure la ligne
-     <command>./configure</command> qui fût utilisée lors de la configuration
-     de votre PHP actuel.
+     <command>./configure</command> qui fut utilisée lors de la configuration
+     du PHP actuel.
     </para>
    </answer>
   </qandaentry>
@@ -450,12 +450,12 @@ $ gcc -E test.c >/dev/null
    <question>
     <para>
      Quand je compile PHP avec le support de la bibliothèque GD, j'obtiens des
-     erreurs de compilation étrange, voire même des erreurs de segmentation.
+     erreurs de compilation étranges, voire même des erreurs de segmentation.
     </para>
    </question>
    <answer>
     <para>
-     Assurez-vous que votre bibliothèque GD et PHP sont liés aux mêmes
+     Il faut s'assurer que la bibliothèque GD et PHP sont liés aux mêmes
      bibliothèques (libpng, par exemple).
     </para>
    </answer>
@@ -471,9 +471,9 @@ $ gcc -E test.c >/dev/null
    <answer>
     <para>
      L'utilisation d'utilitaires non-GNU pour compiler PHP peut poser
-     problème. Assurez-vous de bien utiliser des outils GNU pour être certain
-     que votre compilation arrive à terme. Par exemple, sous Solaris,
-     utiliser les version SunOS BSD-compatible ou Solaris de
+     problème. Il convient de bien utiliser des outils GNU pour être certain
+     que la compilation arrive à terme. Par exemple, sous Solaris,
+     utiliser les versions SunOS BSD-compatible ou Solaris de
      <literal>sed</literal> ne fonctionnera pas, mais utiliser les versions
      GNU ou Sun POSIX (xpg4) de <literal>sed</literal> fonctionnera. Liens :
      <link xlink:href="&url.sed;">GNU sed</link>, <link xlink:href="&url.flex;">GNU

--- a/faq/com.xml
+++ b/faq/com.xml
@@ -23,8 +23,8 @@
     <answer>
      <para>
       Si c'est une DLL simple, il n'y a aucun moyen pour le moment de
-      l'utiliser avec PHP. Si la DLL contient un serveur COM, vous pourrez
-      l'utiliser si elle implémente l'interface IDispatch.
+      l'utiliser avec PHP. Si la DLL contient un serveur COM, il sera possible de
+      l'utiliser à condition qu'elle implémente l'interface IDispatch.
      </para>
     </answer>
    </qandaentry>
@@ -37,14 +37,14 @@
     </question>
     <answer>
      <para>
-      Il y a des dizaines de types de VARIANT et de combinaisons entre elles.
+      Il y a des dizaines de types de VARIANT et de combinaisons entre eux.
       La plupart d'entre elles sont déjà supportées, mais quelques-unes ne sont
       toujours pas implémentées.
       Les tableaux ne sont pas complètement supportés. Seuls les tableaux
       unidimensionnels indexés peuvent être transmis entre PHP et COM.
-      Si vous trouvez d'autres types qui ne sont pas supportés, reportez-les
-      nous comme un bogue (si ce n'est pas déjà fait) et fournissez le plus
-      d'informations possibles.
+      Si d'autres types non supportés sont rencontrés, il convient de les signaler
+      comme un bogue (si ce n'est pas déjà fait) et de fournir le plus
+      d'informations possible.
      </para>
     </answer>
    </qandaentry>
@@ -61,7 +61,7 @@
       souvent en tant que langage de script web et dans un environnement de
       serveur web, les objets visuels n'apparaîtront jamais sur le bureau du
       serveur.
-      Si vous voulez utiliser PHP pour scripter des applications, par
+      Pour scripter des applications, par
       exemple avec PHP-GTK, il n'y a aucune limitation à accéder et
       manipuler des objets visuels via COM.
      </para>
@@ -76,7 +76,7 @@
     </question>
     <answer>
      <para>
-      Non, vous ne pouvez pas. Les instances COM sont traitées comme des
+      Non. Les instances COM sont traitées comme des
       ressources, ce qui signifie qu'elles ne sont disponibles que dans un
       seul contexte de script.
      </para>
@@ -92,7 +92,7 @@
     <answer>
      <para>
       L'extension COM envoie des exceptions
-      <literal>com_exception</literal>, que vous pouvez intercepter en
+      <literal>com_exception</literal>, qu'il est possible d'intercepter en
       inspectant le membre <literal>code</literal> pour déterminer que faire.
      </para>
     </answer>
@@ -151,13 +151,13 @@
     </question>
     <answer>
      <para>
-      Exactement de la même manière qu'avec des objets locaux. Vous devez
-      juste passer l'adresse IP de la machine distante en deuxième paramètre
+      Exactement de la même manière qu'avec des objets locaux. Il suffit de
+      passer l'adresse IP de la machine distante en deuxième paramètre
       du constructeur COM.
      </para>
      <para>
-      Assurez-vous que vous avez spécifié 
-      <link linkend="ini.com.allow-dcom">com.allow_dcom</link><literal>=</literal>&true; dans votre
+      Il faut s'assurer que
+      <link linkend="ini.com.allow-dcom">com.allow_dcom</link><literal>=</literal>&true; dans le
       &php.ini;.
      </para>
     </answer>
@@ -172,7 +172,7 @@
     </question>
     <answer>
      <para>
-      Éditez votre &php.ini; et mettez 
+      Il faut éditer le &php.ini; et définir
       <link linkend="ini.com.allow-dcom">com.allow_dcom</link><literal>=</literal>&true;.
      </para>
     </answer>
@@ -203,8 +203,8 @@
     </question>
     <answer>
      <para>
-      C'est possible avec l'aide de monikers. Si vous voulez des références
-      multiples au même mot d'instance, vous pouvez créer une instance de la
+      C'est possible avec l'aide de monikers. Pour obtenir des références
+      multiples vers la même instance de Word, il est possible de créer une instance de la
       façon suivante :
      </para>
      <programlisting role="php">
@@ -230,8 +230,8 @@ $word = new COM("C:\docs\word.doc");
     </question>
     <answer>
      <para>
-      Vous pouvez définir un moniteur d'événement (sink) et le lier en
-      utilisant <function>com_event_sink</function>. Vous pouvez utiliser
+      Il est possible de définir un moniteur d'événement (sink) et le lier en
+      utilisant <function>com_event_sink</function>. Il est également possible d'utiliser
       <function>com_print_typeinfo</function> pour que PHP génère un
       squelette pour la classe du moniteur d'événement.
      </para>
@@ -248,7 +248,7 @@ $word = new COM("C:\docs\word.doc");
     <answer>
      <para>
       La réponse est aussi simple que non satisfaisante. Nous ne savons pas
-      exactement, mais nous pensons que vous ne pouvez rien faire.
+      exactement, mais nous pensons qu'il n'est pas possible de faire quoi que ce soit.
      </para>
     </answer>
    </qandaentry>
@@ -271,16 +271,16 @@ $word = new COM("C:\docs\word.doc");
    <qandaentry xml:id="faq.com.q15">
     <question>
      <para>
-      Si PHP peut manipuler des objets COM, peut-on imaginer d'utiliser des
-      ressources de composants, en conjonction avec PHP ?
+      Si PHP peut manipuler des objets COM, peut-on imaginer d'utiliser MTS
+      pour gérer les ressources de composants, en conjonction avec PHP ?
      </para>
     </question>
     <answer>
      <para>
       PHP ne supporte pas encore les transactions. Ainsi, si une erreur se
-      produit, aucun rollback n'est initié. Si vous utilisez des composants
-      qui supportent les transactions, vous devrez implémenter le
-      gestionnaire de transactions par vous-même.
+      produit, aucun rollback n'est initié. Si des composants supportant
+      les transactions sont utilisés, il faudra implémenter le
+      gestionnaire de transactions soi-même.
      </para>
     </answer>
    </qandaentry>

--- a/faq/databases.xml
+++ b/faq/databases.xml
@@ -23,15 +23,15 @@
     </question>
     <answer>
      <para>
-      Sur les machines UNIX, vous pouvez utiliser <link linkend="ref.pdo-odbc">PDO_ODBC</link>
+      Sur les machines UNIX, il est possible d'utiliser <link linkend="ref.pdo-odbc">PDO_ODBC</link>
       ou <link linkend="book.uodbc">Unified ODBC API</link>.
      </para>
      <para>
-      Sur les machines Windows, vous pouvez également utiliser <link linkend="ref.pdo-sqlsrv">PDO_SQLSRV</link>
+      Sur les machines Windows, il est également possible d'utiliser <link linkend="ref.pdo-sqlsrv">PDO_SQLSRV</link>
       ou <link linkend="book.sqlsrv">SQLSRV</link>.
       </para>
      <para>
-      Jetez aussi un oeil à la réponse à la question suivante.
+      Voir aussi la réponse à la question suivante.
      </para>
     </answer>
    </qandaentry>
@@ -42,85 +42,84 @@
     </question>
     <answer>
      <para>
-      Si vous utilisez PHP sur une machine Unix et que vous voulez vous
-      connecter à une base Access sur une machine Windows, vous aurez besoin
-      des pilotes ODBC Unix.
+      Pour se connecter à une base Access sur une machine Windows depuis
+      PHP sur une machine Unix, les pilotes ODBC Unix sont nécessaires.
       <link xlink:href="&url.openlink;">OpenLink Software</link> fournit des
       pilotes ODBC pour Unix qui peuvent le faire.
      </para>
      <para>
       Une autre solution consiste à utiliser un serveur SQL qui a des pilotes
-      ODBC Windows et l'utiliser pour stocker les données, que vous pouvez
-      utiliser à partir de Microsoft Access (en utilisant ODBC) et PHP (en
+      ODBC Windows et l'utiliser pour stocker les données, accessibles
+      à partir de Microsoft Access (en utilisant ODBC) et PHP (en
       utilisant les pilotes inclus), ou bien utiliser un format de fichier
       intermédiaire que Access et PHP peuvent traiter tous les deux, comme
-      des fichiers bruts ou des bases de données dBase. À ce sujet, Tim Hayes
+      des fichiers plats ou des bases de données dBase. À ce sujet, Tim Hayes
       de Openlink software écrit :
       <blockquote>
        <para>
         Utiliser une autre base de données comme intermédiaire n'est pas une
-        bonne idée lorsque vous pouvez utiliser ODBC de PHP directement vers
-        vos bases de données - par exemple avec les pilotes Openlink. Si vous
-        avez besoin d'un format de fichier intermédiaire, Openlink a publié
+        bonne idée lorsqu'il est possible d'utiliser ODBC de PHP directement vers
+        les bases de données - par exemple avec les pilotes Openlink. S'il
+        est nécessaire d'avoir un format de fichier intermédiaire, Openlink a publié
         Virtuoso (un moteur de base de données virtuel) pour NT, Linux et
-        d'autres plates-formes Unix. Visitez notre <link
-        xlink:href="&url.openlink;">site</link> pour un téléchargement gratuit.
+        d'autres plates-formes Unix. Consulter le <link
+        xlink:href="&url.openlink;">site officiel</link> pour un téléchargement gratuit.
        </para>
       </blockquote>
      </para>
      <para>
       Une solution qui a fait ses preuves est d'utiliser MySQL et ses pilotes
-      ODBC sous Windows et de synchroniser les bases de données. Steve
+      MyODBC sous Windows et de synchroniser les bases de données. Steve
       Lawrence écrit :
      </para>
      <para>
       <itemizedlist>
        <listitem>
         <simpara>
-         Installez MySQL sur votre plate-forme conformément aux instructions
-         de MySQL. Vous pouvez l'obtenir sur <link
+         Installer MySQL sur la plate-forme conformément aux instructions
+         de MySQL. Il est possible de l'obtenir sur <link
          xlink:href="&url.mysql;">&url.mysql;</link>. Aucune
          configuration particulière n'est nécessaire, mis à part que lorsque
-         vous configurez une base de données et un compte utilisateur, il
-         faille spécifier % dans le champ host, ou bien le nom de la machine
-         Windows avec laquelle vous voulez accéder à MySQL. Notez bien votre
-         nom de serveur, d'utilisateur et votre mot de passe.
+         l'on configure une base de données et un compte utilisateur, il
+         faut spécifier % dans le champ host, ou bien le nom de la machine
+         Windows avec laquelle on souhaite accéder à MySQL. Il convient de noter le nom
+         de serveur, d'utilisateur et le mot de passe.
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         Téléchargez les pilotes MyODBC pour Windows à partir du site de
-         MySQL. Installez les sur votre machine Windows. Vous pouvez tester
-         votre installation avec les utilitaires fournis avec les pilotes.
+         Télécharger les pilotes MyODBC pour Windows à partir du site de
+         MySQL. Installez-les sur la machine Windows. Il est possible de tester
+         l'installation avec les utilitaires fournis avec les pilotes.
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         Créez un utilisateur ou une source de données système dans votre
-         administration ODBC, dans le panneau de configuration. Donnez un nom
-         de source de données dsn, entrez votre nom d'hôte, identifiant, mot
+         Créer un utilisateur ou une source de données système dans
+         l'administration ODBC, dans le panneau de configuration. Donner un nom
+         à la source de données dsn, entrer le nom d'hôte, identifiant, mot
          de passe, port, etc. pour la base de données configurée à l'étape 1.
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         Installez Access avec une installation complète pour être sûr d'avoir
-         tous les composants nécessaires... Vous aurez besoin d'au moins le
+         Installer Access avec une installation complète pour être sûr d'avoir
+         tous les composants nécessaires... Il faut au moins le
          support ODBC et le gestionnaire de tables liées.
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         Maintenant, la partie amusante ! Créez un accès à une base de données.
-         Dans la fenêtre de la table, cliquez droit et sélectionner Lier les
+         Maintenant, la partie amusante ! Créer un accès à une base de données.
+         Dans la fenêtre de la table, faire un clic droit et sélectionnez Lier les
          Tables, ou, dans le menu Fichier, sélectionnez Obtenir des données
          externes et alors Lier les Tables.
-         Quand la fenêtre de gestion de fichiers apparaît, sélectionnez les
-         fichiers de type : ODBC. Sélectionnez dsn Système et le nom de votre
-         dsn créée à l'étape 3. Sélectionnez la table à lier, cliquez sur OK,
-         et voilà ! Vous pouvez maintenant ouvrir la table et
-         ajouter/supprimer/éditer des données sur votre serveur MySQL ! Vous
-         pouvez ainsi exécuter des requêtes, importer/exporter des tables vers
+         Quand la fenêtre de gestion de fichiers apparaît, sélectionner les
+         fichiers de type : ODBC. Sélectionner dsn Système et le nom de la
+         dsn créée à l'étape 3. Sélectionner la table à lier, cliquer sur OK,
+         et voilà ! Il est maintenant possible d'ouvrir la table et
+         ajouter/supprimer/éditer des données sur le serveur MySQL ! Il
+         est aussi possible d'exécuter des requêtes, importer/exporter des tables vers
          MySQL, construire des formulaires et des rapports, etc.
         </simpara>
        </listitem>
@@ -131,25 +130,25 @@
       <itemizedlist>
        <listitem>
         <simpara>
-         Vous pouvez construire vos tables dans Access et les exporter dans
+         Il est possible de construire les tables dans Access et les exporter dans
          MySQL, puis les lier de nouveau. Cela rend la création de table très
          rapide.
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         Lorsque vous créez des tables dans Access, vous devez avoir une clé
-         primaire définie pour avoir accès en écriture à la table. Assurez-vous
-         que vous avez bien créé une clé primaire dans MySQL avant de
+         Lors de la création de tables dans Access, il est nécessaire d'avoir une clé
+         primaire définie pour avoir accès en écriture à la table. Il faut
+         s'assurer qu'une clé primaire a bien été créée dans MySQL avant de
          lier le tout à Access.
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         Si vous changez une table dans MySQL, vous devez la lier de nouveau à
-         Access. Allez dans Outils&gt;suppléments&gt;gestionnaire de tables
-         liées, cherchez votre DSN ODBC, et sélectionnez la table à lier de
-         nouveau. Vous pouvez aussi changer votre source dsn à partir de là,
+         En cas de modification d'une table dans MySQL, il faut la lier de nouveau à
+         Access. Aller dans Outils&gt;suppléments&gt;gestionnaire de tables
+         liées, chercher le DSN ODBC, et sélectionner la table à lier de
+         nouveau. Il est aussi possible de changer la source dsn à partir de là,
          en cliquant sur l'option toujours demander pour un nouvel emplacement
          avant de presser OK.
         </simpara>

--- a/faq/general.xml
+++ b/faq/general.xml
@@ -18,14 +18,14 @@
     </question>
     <answer>
      <para>
-      Depuis la <link linkend="preface">préface de ce manuel</link> :
+      Extrait de la <link linkend="preface">préface de ce manuel</link> :
      </para>
      <para>
-      PHP est un langage de script HTML, exécuté côté serveur. Sa syntaxe
-      est empruntée aux langages C, Java et Perl, et est facile à apprendre.
-      Le but de ce langage est de permettre aux développeurs web
-      d'écrire des pages dynamiques rapidement, mais vous pouvez
-      faire beaucoup plus avec PHP.
+      PHP est un langage de script intégré au HTML. Sa syntaxe est
+      largement empruntée au C, à Java et à Perl, avec quelques
+      fonctionnalités spécifiques à PHP. L'objectif de ce langage est
+      de permettre aux développeurs web de créer rapidement des pages
+      générées dynamiquement.
      </para>
     </answer>
    </qandaentry>
@@ -39,7 +39,7 @@
       PHP signifie <emphasis>PHP: Hypertext Preprocessor</emphasis>.
       La confusion vient du fait que la première lettre de l'acronyme représente l'acronyme
       lui-même. Ce type d'acronyme est appelé un acronyme récursif.
-      Pour plus d'informations, les plus curieux peuvent visiter
+      Pour plus d'informations, il est possible de consulter
       "<link xlink:href="&url.foldoc;">Free On-Line Dictionary of Computing</link>"
       ou l'<link xlink:href="&url.wiki.recursive-acronym;">entrée Wikipedia sur les
        acronymes récursifs</link>.
@@ -55,10 +55,10 @@
      <para>
       PHP/FI 2.0 est une des premières versions de PHP et elle n'est plus
       supportée.
-      PHP 3 en est le successeur et est beaucoup plus convivial.
+      PHP 3 est le successeur de PHP/FI 2.0 et est beaucoup plus abouti.
       PHP 8 est la génération actuelle de PHP, qui utilise le
       moteur Zend 4 qui apporte, entre autres,
-      beaucoup de nouveautés dans le <link linkend="language.oop5">modèle objet</link>.
+      de nombreuses fonctionnalités POO supplémentaires dans le <link linkend="language.oop5">modèle objet</link>.
      </para>
     </answer>
    </qandaentry>
@@ -83,12 +83,12 @@
     </question>
     <answer>
      <para>
-      Vous devriez aller sur la base de données de bogues PHP afin de vous assurer
-      qu'il n'est pas déjà connu. Si vous ne le trouvez pas, utilisez le formulaire
+      Il est recommandé de consulter la base de données de bogues PHP afin de s'assurer
+      qu'il n'est pas déjà connu. S'il ne s'y trouve pas, il convient d'utiliser le formulaire
       de rapport de bogues pour le faire connaître. Il est important d'utiliser
       la base de données de bogues au lieu d'envoyer simplement un courriel à une des listes
-      de diffusion car le bogue se verra assigner un numéro qui vous sera utile
-      pour suivre son évolution. La base de données de bogues peut être trouvée à
+      de diffusion car le bogue se verra assigner un numéro
+      utile pour suivre son évolution. La base de données de bogues peut être trouvée à
       <link xlink:href="&url.php.bugs;">&url.php.bugs;</link>.
      </para>
     </answer>

--- a/faq/html.xml
+++ b/faq/html.xml
@@ -10,7 +10,7 @@
   <para>
    PHP et HTML sont très interactifs : PHP peut générer du HTML et HTML
    peut passer des informations à PHP. Avant de lire cette <literal>faq</literal> (foire aux
-   questions), il est important que vous appreniez comment <link 
+   questions), il est important d'apprendre comment <link
    linkend="language.variables.external">récupérer des variables externes à PHP</link>.
    La page du manuel correspondante contient beaucoup d'exemples.
   </para>
@@ -25,22 +25,22 @@
     </question>
     <answer>
      <para>
-      Il y a plusieurs étapes pour lesquelles le codage est important. En supposant que vous avez
+      Il y a plusieurs étapes pour lesquelles le codage est important. En supposant qu'il y a
       une <type>string</type> <varname>$data</varname>, qui contient la chaîne
-      que vous voulez passer de manière non-encodée, voici les étapes appropriées :
+      à passer de manière non-encodée, voici les étapes appropriées :
       <itemizedlist>
        <listitem>
         <para>
-         Interprétation HTML. Afin d'indiquer une chaîne aléatoire, vous 
-         <emphasis>devez</emphasis> l'inclure entre doubles guillemets et
+         Interprétation HTML. Afin d'indiquer une chaîne aléatoire, il
+         <emphasis>faut</emphasis> l'inclure entre doubles guillemets et
          utiliser la fonction <function>htmlspecialchars</function> pour encoder
          la chaîne.
         </para>
        </listitem>
        <listitem>
         <para>
-         URL : une URL est constituée de plusieurs parties. Si vous voulez que vos données
-         soient interprétées comme un seul élément, vous <emphasis>devez</emphasis>
+         URL : une URL est constituée de plusieurs parties. Pour que les données
+         soient interprétées comme un seul élément, il <emphasis>faut</emphasis>
          les encoder avec la fonction <function>urlencode</function>.
         </para>
        </listitem>
@@ -60,12 +60,12 @@
       <note>
        <simpara>
         Il n'est pas correct d'utiliser la fonction <function>urlencode</function>
-        pour vos données <varname>$data</varname>, car il en est de la responsabilité du 
+        pour les données <varname>$data</varname>, car il en est de la responsabilité du
         navigateur de les encoder. Tous les navigateurs populaires le font correctement.
-        Notez que cela s'effectue sans considération de la méthode utilisée
+        Il est à noter que cela s'effectue sans considération de la méthode utilisée
         (c'est-à-dire 
         <literal>GET</literal> ou <literal>POST</literal>).
-        Vous devez uniquement noter ce cas pour les requêtes <literal>GET</literal>, 
+        Ce cas ne concerne que les requêtes <literal>GET</literal>,
         car les requêtes <literal>POST</literal> sont généralement cachées.
        </simpara>
       </note>
@@ -90,7 +90,7 @@ echo '</textarea>';
         Au moment de la validation, via la méthode <literal>GET</literal> ou 
         <literal>POST</literal>, les données devraient être
         url-encodées par le navigateur avant le transfert et directement url-décodées par PHP.
-        Donc, finalement, vous n'avez pas à effectuer d'url-encodage/url-decodage vous-même,
+        Donc, finalement, il n'est pas nécessaire d'effectuer d'url-encodage/url-décodage manuellement,
         tout est effectué automatiquement.
        </simpara>
       </note>
@@ -107,22 +107,22 @@ echo '</textarea>';
       </example>
       <note>
        <simpara>
-        En fait, vous simulez une requête <literal>GET</literal> HTML, il est nécessaire 
-        d'utiliser manuellement la fonction <function>urlencode</function> sur vos données.
+        En fait, cela simule une requête <literal>GET</literal> HTML, il est nécessaire
+        d'utiliser manuellement la fonction <function>urlencode</function> sur les données.
        </simpara>
       </note>
       <note>
        <simpara>
-        Vous devez utiliser <function>htmlspecialchars</function> sur l'URL complète,
+        Il faut utiliser <function>htmlspecialchars</function> sur l'URL complète,
         car l'URL se comporte comme la valeur d'un attribut HTML. Dans ce cas, le navigateur
         fera un <function>htmlspecialchars</function> sur la valeur et passera le résultat à
-        l'URL. PHP devrait comprendre l'URL correctement, car vous avez url-encodé les données.
+        l'URL. PHP devrait comprendre l'URL correctement, car les données ont été url-encodées.
        </simpara>
        <simpara>
-        Vous devez noter que <literal>&amp;</literal> dans l'URL est remplacé par
+        Il est à noter que <literal>&amp;</literal> dans l'URL est remplacé par
         <literal>&amp;amp;</literal>. Bien que la plupart des navigateurs devraient
-        corriger cela si vous l'oubliez, ce n'est pas toujours le cas. Donc, même si votre URL
-        n'est pas dynamique, vous <emphasis>devez</emphasis> utiliser
+        corriger cela en cas d'oubli, ce n'est pas toujours le cas. Donc, même si l'URL
+        n'est pas dynamique, il <emphasis>faut</emphasis> utiliser
         la fonction <function>htmlspecialchars</function> sur l'URL.
        </simpara>
       </note>
@@ -142,7 +142,7 @@ echo '</textarea>';
     </question>
     <answer>
      <para>
-      Lorsque vous validez un formulaire, il est possible d'utiliser une image au lieu du bouton
+      Lors de la validation d'un formulaire, il est possible d'utiliser une image au lieu du bouton
       standard de type "<literal>submit</literal>" avec une balise du type :
       <programlisting role="html">
 <![CDATA[
@@ -157,7 +157,7 @@ echo '</textarea>';
       Comme <varname>foo.x</varname> et <varname>foo.y</varname> sont
       des noms de variables invalides en PHP, elles sont automatiquement converties
       en <varname>foo_x</varname> et <varname>foo_y</varname>. Les points sont 
-      remplacés par des soulignés. Donc, vous devez accéder à ces variables
+      remplacés par des soulignés. Il faut donc accéder à ces variables
       comme n'importe quelle autre variable tel que décrit dans la section
       "<link linkend="language.variables.external">Variables provenant d'autres sources</link>".
       Par exemple, en utilisant <varname>$_GET['foo_x']</varname>.
@@ -177,7 +177,7 @@ echo '</textarea>';
     <answer>
      <para>
       Pour envoyer le résultat du &lt;form&gt; comme un <link linkend="language.types.array">tableau</link>
-      de variables à votre script PHP, vous devez nommer, via l'attribut <literal>name</literal>, les balises
+      de variables au script PHP, il faut nommer, via l'attribut <literal>name</literal>, les balises
       &lt;input&gt;, &lt;select&gt; ou &lt;textarea&gt; comme cela :
       <programlisting role="html">
 <![CDATA[
@@ -188,7 +188,7 @@ echo '</textarea>';
 ]]>
       </programlisting>
       Noter les crochets après le nom de la variable, c'est ce qui fait que celle-ci sera un tableau.
-      Vous pouvez grouper les éléments dans différents tableaux de variables en assignant le 
+      Il est possible de grouper les éléments dans différents tableaux de variables en assignant le
       même nom à différents éléments :
       <programlisting role="html">
 <![CDATA[
@@ -199,7 +199,7 @@ echo '</textarea>';
 ]]>
       </programlisting>
       Cela produira deux tableaux de variables, MonTableau et MonAutreTableau, qui seront
-      envoyés au script PHP. Il est également possible d'assigner des clés spécifiques à votre
+      envoyés au script PHP. Il est également possible d'assigner des clés spécifiques au
       tableau :
       <programlisting role="html">
 <![CDATA[
@@ -214,8 +214,8 @@ echo '</textarea>';
      <para>
       <note>
        <para>
-         Le fait de spécifier une clé à un tableau est optionnel en HTML. Si vous ne le faites pas,
-         les clés du tableau suiveront l'ordre d'apparition des éléments dans le formulaire.
+         Le fait de spécifier une clé à un tableau est optionnel en HTML. Sans cela,
+         les clés du tableau suivront l'ordre d'apparition des éléments dans le formulaire.
          Dans notre premier exemple, le tableau contient les clés 0, 1, 2 et 3.
         </para>
        </note>
@@ -271,9 +271,9 @@ var=option3
       peut être utilisée pour trier le tableau, si nécessaire.
      </para>
      <para>
-      Notez que si vous utilisez Javascript, <literal>[]</literal> dans le nom de l'élément peut
-      vous poser problème lorsque vous tenterez d'accéder à celui-ci par son nom.
-      Utilisez plutôt l'indice numérique de l'élément dans ce cas, ou bien utilisez les simples 
+      Il est à noter que lors de l'utilisation de Javascript, <literal>[]</literal> dans le nom de l'élément peut
+      poser problème lors de l'accès à celui-ci par son nom.
+      Il est préférable d'utiliser l'indice numérique de l'élément dans ce cas, ou bien d'utiliser les simples
       guillemets pour entourer cet élément, comme :
       <programlisting>
 variable = document.forms[0].elements['var[]']; 
@@ -299,8 +299,8 @@ variable = document.forms[0].elements['var[]'];
       Cependant, il est possible de faire passer des variables entre les deux.
       Une des solutions pour cela est de générer un code Javascript à l'aide de PHP
       et de faire rafraîchir le navigateur tout seul, passant ainsi des variables spécifiques
-      au script PHP. L'exemple suivant montre précisément comme réaliser cela --
-      il permet à PHP de récupérer les dimensions de l'écran du client, ce qui est normalement
+      au script PHP. L'exemple suivant montre précisément comment réaliser cela --
+      il permet à PHP de récupérer les dimensions de l'écran du client, ce qui n'est normalement
       possible qu'en technologie côté client.
      </para>
      <para>

--- a/faq/installation.xml
+++ b/faq/installation.xml
@@ -13,7 +13,7 @@
    quasiment n'importe quel serveur web.
   </para>
   <para>
-   Pour installer PHP, suivez les instructions présentes dans  <xref linkend="install"/>.
+   Pour installer PHP, suivre les instructions présentes dans <xref linkend="install"/>.
   </para>
 
   <qandaset>
@@ -39,7 +39,7 @@
       entrante, de nouvelles faiblesses sont introduites dans le système PHP.
      </para>
      <para>
-      Si vous voulez utiliser un MPM threadé, regardez du côté
+      Pour utiliser un MPM threadé, il est possible de regarder du côté
       d'une configuration FastCGI dans laquelle PHP s'exécute dans son propre espace
       mémoire.
      </para>
@@ -59,27 +59,27 @@
       La plupart des personnes voudront changer ceci lors de la compilation
       avec l'option <link
       linkend="configure.with-config-file-path">--with-config-file-path</link>.
-      Vous pouvez par exemple le régler de cette façon :
+      Il est par exemple possible de le régler de cette façon :
       <programlisting role="shell">
 --with-config-file-path=/etc
       </programlisting>
-      Et alors vous copierez le fichier <filename>php.ini-development</filename> livré
-      avec les sources vers <filename>/etc/php.ini</filename> et l'éditer pour
-      l'adapter à vos besoins.
+      Il suffit ensuite de copier le fichier <filename>php.ini-development</filename> livré
+      avec les sources vers <filename>/etc/php.ini</filename> et de l'éditer pour
+      l'adapter aux besoins locaux.
      </para>
       <programlisting role="shell">
 --with-config-file-scan-dir=PATH
       </programlisting>
      <para>
       Sous Windows, le chemin par défaut de &php.ini; est le répertoire de
-      Windows. Si vous utilisez le serveur web Apache, &php.ini; est tout
-      d'abord cherché dans le répertoire d'installation de Apache, c'est-à-dire
+      Windows. Lors de l'utilisation du serveur web Apache, &php.ini; est tout
+      d'abord cherché dans le répertoire d'installation d'Apache, par exemple
       <filename>c:\program files\apache group\apache</filename>. De cette
-      façon, vous pouvez avoir un &php.ini; différent pour chaque version de
-      Apache installée.
+      façon, il est possible d'avoir un &php.ini; différent pour chaque version
+      d'Apache installée.
      </para>
      <para>
-     Consultez aussi le chapitre sur le
+     Consulter aussi le chapitre sur le
      <link linkend="configuration.file">fichier de configuration</link>.
      </para>
     </answer>
@@ -96,16 +96,16 @@
     <answer>
      <para>
       Cela signifie probablement que PHP rencontre un problème et génère un
-      fichier core. Consultez vos fichiers de logs de votre serveur pour voir
-      si c'est le cas, et tentez de reproduire le problème avec un test
-      simple. Si vous savez utiliser 'gdb', il serait très utile de fournir un
-      backtrace avec votre rapport de bogue, afin d'aider les développeurs à
-      cerner le problème. Si vous utilisez PHP en module Apache, essayez
+      fichier core. Il convient de consulter les fichiers de logs du serveur pour voir
+      si c'est le cas, et de tenter de reproduire le problème avec un test
+      simple. En cas de maîtrise de 'gdb', il serait très utile de fournir un
+      backtrace avec le rapport de bogue, afin d'aider les développeurs à
+      cerner le problème. Lors de l'utilisation de PHP en module Apache, il est possible d'essayer
       ceci :
       <itemizedlist>
        <listitem>
         <para>
-         Stoppez vos processus httpd
+         Stopper les processus httpd
         </para>
        </listitem>
        <listitem>
@@ -115,7 +115,7 @@
        </listitem>
        <listitem>
         <para>
-         Stoppez vos processus httpd
+         Stopper les processus httpd
         </para>
        </listitem>
        <listitem>
@@ -125,7 +125,7 @@
        </listitem>
        <listitem>
         <para>
-         Pointez alors avec votre navigateur vers l'URL posant problème.
+         Pointer alors avec le navigateur vers l'URL posant problème.
         </para>
        </listitem>
        <listitem>
@@ -135,17 +135,17 @@
        </listitem>
        <listitem>
         <para>
-         Si vous obtenez un fichier core, gdb doit alors vous en informer.
+         En cas de fichier core, gdb doit alors en informer.
         </para>
        </listitem>
        <listitem>
         <para>
-         tapez : bt
+         taper : bt
         </para>
        </listitem>
        <listitem>
         <para>
-         Vous devriez inclure votre backtrace dans votre rapport de bogue.
+         Il convient d'inclure le backtrace dans le rapport de bogue.
          Celui-ci doit être posté sur
          <link xlink:href="&url.php.bugs;">&url.php.bugs;</link>.
         </para>
@@ -153,9 +153,9 @@
       </itemizedlist>
      </para>
      <para>
-      Si votre script utilise les expressions régulières
-      (<function>preg_match</function> et consorts), assurez-vous que PHP et
-      Apache ont été compilés avec les même outils d'expression régulières.
+      Si le script utilise les expressions régulières
+      (<function>preg_match</function> et consorts), il faut s'assurer que PHP et
+      Apache ont été compilés avec les mêmes outils d'expressions régulières.
       Cela doit être automatiquement le cas avec PHP et Apache 1.3.x.
      </para>
     </answer>
@@ -170,9 +170,9 @@
     </question>
     <answer>
      <para>
-      En supposant que vous avez installé à la fois Apache et PHP à partir
-      de fichiers RPM, vous devrez commenter ou ajouter au moins quelques-unes
-      des lignes suivantes dans votre fichier &httpd.conf; :
+      En supposant qu'Apache et PHP ont été installés à partir
+      de fichiers RPM, il faut commenter ou ajouter au moins quelques-unes
+      des lignes suivantes dans le fichier &httpd.conf; :
       <programlisting role="apache-conf">
 <![CDATA[
 # Extra Modules
@@ -191,8 +191,8 @@ LoadModule perl_module        modules/libperl.so
 AddType application/x-httpd-php .php
 ]]>
       </programlisting>
-      ... aux propriétés globales ou aux propriétés du VirtualDomain ou vous
-      voulez que PHP officie.
+      ... aux propriétés globales ou aux propriétés du VirtualDomain où
+      PHP doit officier.
      </para>
     </answer>
    </qandaentry>
@@ -225,12 +225,12 @@ AddType application/x-httpd-php .php
     </question>
     <answer>
      <para>
-      Affichez le code source du document dans votre navigateur et vous
-      devriez probablement trouver le code source de votre script PHP.
+      En affichant le code source du document dans le navigateur, il est
+      probable d'y trouver le code source du script PHP.
       Cela signifie que le serveur web n'a pas envoyé le script à PHP pour
-      interprétation. Quelque chose est donc incorrecte dans le fichier de configuration
-      de votre serveur web - re-vérifiez la configuration du serveur web en vous
-      référant aux instructions d'installations
+      interprétation. Quelque chose est donc incorrect dans le fichier de configuration
+      du serveur web - il convient de re-vérifier la configuration du serveur web en se
+      référant aux instructions d'installation
       de PHP.
      </para>
     </answer>
@@ -247,15 +247,15 @@ AddType application/x-httpd-php .php
      <para>
       Quelque chose se passe mal lorsque le serveur tente d'utiliser PHP.
       Pour tenter de récupérer un message d'erreur, depuis la ligne de commande,
-      placez-vous dans le répertoire contenant l'exécutable PHP
-      (<filename>php.exe</filename> sous Windows) et exécutez la commande
+      se placer dans le répertoire contenant l'exécutable PHP
+      (<filename>php.exe</filename> sous Windows) et exécuter la commande
       <command>php -i</command>.
       Si PHP a un problème quelconque l'empêchant de fonctionner, un message
       d'erreur devrait s'afficher qui devrait expliquer comment résoudre ce souci. Si un
       écran de code HTML apparaît (la sortie de la fonction
       <function>phpinfo</function>),
       cela signifie que PHP fonctionne correctement et que le problème doit
-      certainement venir de la configuration de votre serveur web que vous devriez
+      certainement venir de la configuration du serveur web qu'il convient de
       re-vérifier.
      </para>
     </answer>
@@ -279,7 +279,7 @@ AddType application/x-httpd-php .php
      <para>
       Cela n'a actuellement rien à voir avec PHP mais avec la bibliothèque cliente
       MySQL. Suivant les versions, elle a besoin que PHP soit compilé avec l'option
-      <option role="configure">--with-zlib</option>, d'autre non.
+      <option role="configure">--with-zlib</option>, d'autres non.
       Ce problème est également traité dans la FAQ de MySQL.
      </para>
     </answer>
@@ -304,37 +304,37 @@ cgi error:
      <para>
       Ce message d'erreur signifie que PHP a échoué lors de l'affichage.
       Pour tenter de récupérer un message d'erreur, depuis la ligne de commande,
-      placez-vous dans le répertoire contenant l'exécutable PHP
-      (<filename>php.exe</filename> sous Windows) et exécutez la commande
+      se placer dans le répertoire contenant l'exécutable PHP
+      (<filename>php.exe</filename> sous Windows) et exécuter la commande
       <command>php -i</command>. Si PHP a un quelconque souci de
-      fonctionnement, alors un message d'erreur le décrivant s'affichera. Si vous
-      obtenez un écran de code HTML (le contenu du résultat de la fonction
+      fonctionnement, alors un message d'erreur le décrivant s'affichera. Si un
+      écran de code HTML apparaît (le contenu du résultat de la fonction
       <function>phpinfo</function>), alors PHP fonctionne
       correctement.
      </para>
      <para>
-      Si PHP fonctionne depuis la ligne de commande, tentez d'accéder à votre script
-      encore une fois via votre navigateur. S'il échoue toujours, alors, il se peut que ce
+      Si PHP fonctionne depuis la ligne de commande, tenter d'accéder au script
+      encore une fois via le navigateur. Si cela échoue toujours, alors, il se peut que ce
       soit l'un des soucis suivants :
      </para>
      <itemizedlist>
       <listitem>
        <simpara>
-        Les permissions de votre script PHP des fichiers <filename>php.exe</filename>,
+        Les permissions du script PHP, des fichiers <filename>php.exe</filename>,
         <filename>php5ts.dll</filename>, &php.ini; ou de toute extension nécessaire à PHP
-        que vous tentez de charger, sont telles que l'utilisateur internet anonyme de votre système
+        à charger, sont telles que l'utilisateur internet anonyme du système
         <literal>ISUR_&lt;machinename&gt;</literal> ne peut pas y accéder.
        </simpara>
       </listitem>
       <listitem>
        <simpara>
-        Le script PHP n'existe pas (ou n'est pas à l'endroit que vous pensez, relativement au
-        répertoire racine de votre serveur web). Notez que pour le serveur web IIS, vous pouvez
+        Le script PHP n'existe pas (ou n'est pas à l'endroit supposé, relativement au
+        répertoire racine du serveur web). Il est à noter que pour le serveur web IIS, il est possible de
         vérifier cela en cochant la case 'vérifier si le fichier existe' lors de la configuration
         de l'exécution des scripts dans le gestionnaire de services Internet. Si un fichier de script
         n'existe pas, le serveur web retournera une erreur 404. IIS a également
-        l'avantage d'effectuer toutes les identifications requises à votre place,
-        basés sur les permissions NTLanMan, sur votre fichier de script.
+        l'avantage d'effectuer toutes les identifications requises automatiquement,
+        basés sur les permissions NTLanMan, sur le fichier de script.
        </simpara>
       </listitem>
      </itemizedlist>
@@ -350,16 +350,16 @@ cgi error:
     </question>
     <answer>
      <para>
-      Assurez-vous que chaque utilisateur qui a besoin d'exécuter un script PHP
+      Il faut s'assurer que chaque utilisateur qui a besoin d'exécuter un script PHP
       possède les droits requis pour exécuter le fichier
       <filename>php.exe</filename> !
       IIS utilise un utilisateur anonyme qui est ajouté lors de l'installation de IIS.
-      Cet utilisateur doit avoir les droits suffisant sur le fichier
+      Cet utilisateur doit avoir les droits suffisants sur le fichier
       <filename>php.exe</filename>. De même, tous les utilisateurs enregistrés
       doivent posséder les droits requis pour exécuter le fichier
       <filename>php.exe</filename>.
-      Pour IIS4, vous devez lui dire que PHP est un moteur de script.
-      De plus, vous devriez lire cette <link
+      Pour IIS4, il faut lui indiquer que PHP est un moteur de script.
+      De plus, il est recommandé de lire cette <link
       linkend="faq.installation.forceredirect">FAQ</link>.
      </para>
     </answer>
@@ -368,22 +368,22 @@ cgi error:
    <qandaentry xml:id="faq.installation.forceredirect">
     <question>
      <para>
-      Lorsque vous exécutez PHP comme CGI avec IIS, PWS, OmniHTTPD ou Xitami,
-      j'obtiens l'erreur suivante : <literal>Security Alert! PHP CGI
+      Lors de l'exécution de PHP comme CGI avec IIS, PWS, OmniHTTPD ou Xitami,
+      l'erreur suivante apparaît : <literal>Security Alert! PHP CGI
        cannot be accessed directly.</literal>.
      </para>
     </question>
     <answer>
      <para>
-      Vous devez définir la directive <link linkend="ini.cgi.force-redirect">
+      Il faut définir la directive <link linkend="ini.cgi.force-redirect">
       cgi.force_redirect</link> à &zero;. Par défaut, elle vaut &one;, donc,
-      soyez sûrs que cette directive n'est pas commentée (précédée d'un point virgule).
+      il faut s'assurer que cette directive n'est pas commentée (précédée d'un point virgule).
       Comme toutes les directives, elles sont définies dans le &php.ini;.
      </para>
      <para>
-      Comme la valeur par défaut vaut &one;, il est impératif que vous soyez sûrs
+      Comme la valeur par défaut vaut &one;, il est impératif de s'assurer
       à 100% que le bon fichier &php.ini; a été lu.
-      Lisez cette <link linkend="faq.installation.findphpini">FAQ</link> 
+      Il est recommandé de lire cette <link linkend="faq.installation.findphpini">FAQ</link>
       pour plus de détails.
      </para>
     </answer>
@@ -398,18 +398,18 @@ cgi error:
     </question>
     <answer>
      <para>
-      Pour être sûr que votre &php.ini; a été lu par PHP, effectuez un appel à la fonction
+      Pour s'assurer que le &php.ini; a été lu par PHP, effectuer un appel à la fonction
       <function>phpinfo</function>. Vers le haut du document résultant, il devrait figurer
       une liste appelée <literal>Configuration File (php.ini)</literal>.
-      Cela vous indiquera où PHP a cherché le &php.ini; et si oui ou non il l'a lu.
-      Si seul un dossier <envar>PATH</envar> existe et qu'il est accessible en lecture,
-      vous devez copier votre &php.ini; dans ce dossier. Si le &php.ini; est présent dans le
+      Cela indiquera où PHP a cherché le &php.ini; et si oui ou non il l'a lu.
+      Si seul un dossier <envar>PATH</envar> existe et que le fichier n'est pas lu,
+      il faut copier le &php.ini; dans ce dossier. Si le &php.ini; est présent dans le
       chemin, cela signifie qu'il a bien été lu.
      </para>
      <para>
-      Si le &php.ini; a bien été lu et que vous exécutez PHP comme module,
-      alors assurez-vous de redémarrer le serveur web après avoir effectué les modifications
-      à votre &php.ini;.
+      Si le &php.ini; a bien été lu et que PHP s'exécute comme module,
+      alors il faut s'assurer de redémarrer le serveur web après avoir effectué les modifications
+      au &php.ini;.
      </para>
      <para>
       Voir aussi la fonction <function>php_ini_loaded_file</function>.
@@ -429,38 +429,38 @@ cgi error:
       Sous Windows :
       <itemizedlist>
        <listitem><para>
-        Allez dans le centre de contrôle et ouvrez l'icône système (Démarrer → Paramètres
+        Aller dans le centre de contrôle et ouvrir l'icône système (Démarrer → Paramètres
         → Panneau de configuration → Système ou juste Démarrer → centre de contrôle
         → Système pour Windows XP/2003+)
        </para></listitem>
        <listitem><para>
-        Allez à l'onglet "Avancé"
+        Aller à l'onglet "Avancé"
        </para></listitem>
        <listitem><para>
-        Cliquez sur le bouton "Variables d'environnements"
+        Cliquer sur le bouton "Variables d'environnements"
        </para></listitem>
        <listitem><para>
-        Regardez dans le panneau "Variables systèmes"
+        Regarder dans le panneau "Variables systèmes"
        </para></listitem>
        <listitem><para>
-        Trouvez l'entrée <literal>Path</literal> (vous devriez avoir à faire descendre
-        l'ascenseur pour le trouver)
+        Trouver l'entrée <literal>Path</literal> (il peut être nécessaire de faire descendre
+        l'ascenseur pour la trouver)
        </para></listitem>
        <listitem><para>
-        Double cliquez sur l'entrée <literal>Path</literal>
+        Double cliquer sur l'entrée <literal>Path</literal>
        </para></listitem>
        <listitem><para>
-        Entrez votre répertoire PHP à la fin, sans oublier le point virgule (<literal>;</literal>)
+        Entrer le répertoire PHP à la fin, sans oublier le point virgule (<literal>;</literal>)
         avant (par exemple <literal>;C:\php</literal>)
        </para></listitem>
        <listitem><para>
-        Confirmez en cliquant sur <literal>OK</literal>
+        Confirmer en cliquant sur <literal>OK</literal>
        </para></listitem>
       </itemizedlist>
      </para>
      <note>
       <simpara>
-       Assurez-vous de redémarrer l'ordinateur après avoir suivi cette procédure
+       Il faut redémarrer l'ordinateur après avoir suivi cette procédure
        afin que les modifications sur la variable <envar>PATH</envar>
        soient bien prises en compte.
       </simpara>
@@ -476,8 +476,8 @@ cgi error:
     </question>
     <answer>
      <para>
-      Il y a plusieurs façons de faire cela. Si vous utilisez Apache,
-      référez vous à la documentation d'Apache, sinon vous devez définir
+      Il y a plusieurs façons de faire cela. En cas d'utilisation d'Apache,
+      se référer à la documentation d'Apache, sinon il faut définir
       la variable d'environnement <varname>PHPRC</varname>.
      </para>
     </answer>
@@ -494,7 +494,7 @@ cgi error:
      <procedure>
       <step>
        <simpara>
-        Faites un clic droit sur le répertoire temporaire (<varname>%TEMP%</varname>)
+        Faire un clic droit sur le répertoire temporaire (<varname>%TEMP%</varname>)
         dans l'Explorateur de fichiers pour obtenir les autorisations.
         Le répertoire temporaire est disponible depuis la configuration ou
         <function>phpinfo</function>.
@@ -502,7 +502,7 @@ cgi error:
       </step>
       <step>
        <simpara>
-        Pour IIS, vérifiez que l'utilisateur <literal>IIS_User</literal> dispose de
+        Pour IIS, vérifier que l'utilisateur <literal>IIS_User</literal> dispose de
         l'autorisation <literal>MODIFIER</literal>.
        </simpara>
       </step>
@@ -521,10 +521,10 @@ cgi error:
      <para>
       Si les liens vers les fichiers PHP incluent l'extension, tout fonctionne
       parfaitement. Cette entrée de la FAQ traite uniquement du cas où les liens
-      vers les fichiers PHP n'incluent pas l'extension et que vous voulez
+      vers les fichiers PHP n'incluent pas l'extension et qu'il est souhaité
       utiliser la négociation sur le contenu fourni par Apache pour choisir les
       fichiers PHP depuis une URL qui ne contient pas d'extension. Dans ce
-      cas, remplacez la ligne
+      cas, remplacer la ligne
       <literal>AddType application/x-httpd-php .php</literal> par :
       <programlisting role="apache-conf">
 <![CDATA[
@@ -546,10 +546,10 @@ AddType text/html php
     </question>
     <answer>
      <para>
-      Non, il est possible de gérer tout type de méthode, comme CONNECT. Les
-      bons en-têtes de réponse peuvent être envoyés avec la fonction
+      Non, il est possible de gérer tout type de méthode, comme CONNECT. Le
+      bon statut de réponse peut être envoyé avec la fonction
       <function>header</function>. Si seules les méthodes POST et GET doivent
-      être gérées, vous pouvez configurer Apache comme ce qui suit :
+      être gérées, il est possible de configurer Apache comme ce qui suit :
       <programlisting role="apache-conf">
 <![CDATA[
 <LimitExcept GET POST>

--- a/faq/mailinglist.xml
+++ b/faq/mailinglist.xml
@@ -31,7 +31,7 @@
       <link xlink:href="mailto:&url.ml.general.unsubscribe;">&url.ml.general.unsubscribe;</link>.
      </para>
      <para>
-      Vous pouvez également vous inscrire et vous désinscrire en utilisant
+      Il est également possible de s'inscrire et de se désinscrire en utilisant
       l'interface web sur cette <link xlink:href="&url.php.mailing-lists;">page</link>;
       les instructions pour se désinscrire sont également présentes en bas
       de chaque courriel de la liste.
@@ -77,10 +77,10 @@
      <para>
       La raison la plus courante pour laquelle les gens ont du mal à se désabonner de nos
       listes de diffusion c'est à cause des courriels redirigés. Par exemple, si
-      votre adresse e-mail est <literal>elephpant@example.com</literal>, mais que vous vous
-      êtes abonné à la liste de diffusion en utilisant la redirection <literal>php-lists@example.com</literal> et que vous redirigez cela vers
-      <literal>elephpant@example.com</literal>, tenter de vous désabonner de <literal>elephpant@example.com</literal> ne fonctionnera pas,
-      car cette adresse n'est même pas connue de nos systèmes. Au lieu de cela, vous devrez vous désabonner
+      l'adresse e-mail est <literal>elephpant@example.com</literal>, mais que l'inscription
+      a été faite à la liste de diffusion en utilisant la redirection <literal>php-lists@example.com</literal> et que celle-ci redirige vers
+      <literal>elephpant@example.com</literal>, tenter de se désabonner de <literal>elephpant@example.com</literal> ne fonctionnera pas,
+      car cette adresse n'est même pas connue de nos systèmes. Au lieu de cela, il faudra se désabonner
       de l'adresse vers laquelle le courrier est envoyé, en envoyant un e-mail depuis
       cette adresse — dans cet exemple, <literal>php-lists@example.com</literal>.
      </para>
@@ -93,18 +93,18 @@
     </question>
     <answer>
      <para>
-      Oui, vous pouvez trouver la liste des sites proposant des archives
+      Oui, il est possible de trouver la liste des sites proposant des archives
       sur la page des
       <link xlink:href="&url.php.mailing-lists;">listes de diffusion</link>.
-      Vous pouvez également trouver plusieurs sites qui archivent ou publient
+      Il est également possible de trouver plusieurs sites qui archivent ou publient
       le contenu de nos listes de diffusion en utilisant votre moteur de
       recherche Internet préféré, en cherchant, par exemple, la chaîne
       "php mailing list archives".
      </para>
      <para>
       Tous les messages de nos listes de diffusion sont également archivés
-      dans des newsgroup. Vous pouvez accéder à ces serveurs sur <link
-      xlink:href="&url.php.news;">&url.php.news;</link> avec un client adapté.
+      sous forme de messages dans les newsgroups. Il est possible d'accéder à ces serveurs sur <link
+      xlink:href="&url.php.news;">&url.php.news;</link> avec un client de news.
       Il y a également une interface web expérimentale pour ces serveurs à l'adresse
       <link
       xlink:href="&url.php.newsweb;">&url.php.newsweb;</link>
@@ -125,13 +125,12 @@
       autres voies.
      </para>
      <para>
-      Avant de poster sur cette liste, merci de lire la FAQ (Foire Aux Questions) afin
+      Avant de poster sur cette liste, il est recommandé de lire la FAQ (Foire Aux Questions) afin
       de voir si vous n'y trouvez pas de l'aide. S'il n'y a rien concernant votre problème,
       essayez dans les archives de la liste de diffusion (voir précédemment).
       Si vous avez des problèmes pour l'installation ou la configuration de PHP,
       lisez toute la documentation s'y rapportant, ainsi que les fichiers <literal>README</literal>.
-      Si vous ne trouvez toujours pas de réponse à votre problème, vous
-      êtes le bienvenu sur la liste de diffusion.
+      S'il n'est toujours pas possible de trouver une réponse, la liste de diffusion est un recours bienvenu.
      </para>
      <para>
       Afin d'avoir la meilleure réponse à votre question (et pour éviter d'agacer
@@ -144,7 +143,7 @@
       vers la liste interne Windows.
      </para>
      <para>
-      Avant de poser une question, vous devriez lire l'article intitulé 
+      Avant de poser une question, il est recommandé de lire l'article intitulé 
       "<link xlink:href="&url.smart.questions;">Comment poser une
       question de la meilleure façon</link>" ; c'est une bonne idée, pour tout le monde.
      </para>
@@ -160,7 +159,7 @@
      <para>
       Les messages comme "Je n'arrive pas à faire fonctionner PHP !! Aidez-moi !!
       Qu'est-ce qu'il ne va pas ??" sont totalement inutiles, pour tous.
-      Si vous avez des problèmes pour faire fonctionner PHP, vous devez inclure
+      Si vous avez des problèmes pour faire fonctionner PHP, il faut inclure
       le système sur lequel le problème survient, quelle version de PHP vous tentez
       de faire fonctionner, sous quelle forme vous l'avez installée (précompilé,
       Git, RPMs, etc.), qu'est-ce que vous avez fait pour le moment, l'endroit où vous
@@ -168,7 +167,7 @@
      </para>
      <para>
       Cela est valable pour n'importe quel type de problème. Vous devez inclure les informations
-      sur ce que vous avez fait, où vous êtes coincé, ce que vous cherché à faire et, si possible,
+      sur ce que vous avez fait, où vous êtes coincé, ce que l'on cherche à faire et, si possible,
       le message d'erreur obtenu. Si vous avez un problème avec votre code source, vous
       devez également inclure la portion de code qui ne fonctionne pas. N'incluez que le code
       nécessaire à la compréhension du problème ! Si vous incluez tout le code, votre message
@@ -183,7 +182,7 @@
       ignoré par la majorité des lecteurs.
      </para>
      <para>
-      Et pour finir, vous êtes encouragé à lire l'article sur 
+      Et pour finir, il est recommandé de lire l'article sur 
       "<link xlink:href="&url.smart.questions;">Comment poser une question de la meilleure
       façon</link>", ce qui sera une aide énorme pour tous, et tout spécialement pour vous.
      </para>

--- a/faq/misc.xml
+++ b/faq/misc.xml
@@ -8,7 +8,7 @@
   <titleabbrev>Questions diverses</titleabbrev>
 
    <para>
-    Il y a quelques questions inclassables. Vous les trouverez ici.
+    Il y a quelques questions inclassables. Elles se trouvent ici.
    </para>
 
   <qandaset>
@@ -26,14 +26,13 @@
       plus bas).
      </para>
      <para>
-      Si vous préférez ne pas utiliser d'outil en ligne de commande, vous
-      pouvez essayer des outils gratuits comme <link xlink:href="&url.stuffit;">Stuffit Expander</link>,
+      S'il est préférable de ne pas utiliser d'outil en ligne de commande, il est possible d'essayer des outils gratuits comme <link xlink:href="&url.stuffit;">Stuffit Expander</link>,
       <link xlink:href="&url.ultimatezip;">UltimateZip</link>,
       <link xlink:href="&url.7zip;">7-Zip</link>, ou
-      <link xlink:href="&url.quickzip;">Quick Zip</link>. Si vous avez
+      <link xlink:href="&url.quickzip;">Quick Zip</link>. Avec
       des outils comme <link xlink:href="&url.winrar;">WinRAR</link> ou
-      <link xlink:href="&url.powerarchiver;">Power Archiver</link>, vous pouvez
-      facilement décompresser les fichiers bz2 avec. Si vous utilisez Total Commander
+      <link xlink:href="&url.powerarchiver;">Power Archiver</link>, il est facile de
+      décompresser les fichiers bz2. Pour les utilisateurs de Total Commander
       (autrefois Windows Commander), un plugin bz2 est disponible gratuitement sur le site de
       <link xlink:href="&url.wincmd;">Total Commander</link>.
      </para>
@@ -41,10 +40,10 @@
       L'outil en ligne de commande bzip2 de Redhat :
      </para>
      <para>
-      Les utilisateurs du service pack 2 de Win2K doivent prendre la version
-      1.0.2, tous les autres utilisateurs de Windows doivent prendre la
+      Les utilisateurs du service pack 2 de Win2K devraient prendre la version
+      1.0.2, tous les autres utilisateurs de Windows devraient prendre la
       version 1.00. Après avoir téléchargé, renommez l'exécutable en bzip2.exe.
-      Pour votre convenance, mettez-le dans un dossier dans votre path, c'est-à-dire
+      Par commodité, il est recommandé de le placer dans un dossier dans votre path, c'est-à-dire
       C:\Windows où C représente votre disque où Windows est installé.
      </para>
      <para>
@@ -54,25 +53,25 @@
       suivantes :
       <itemizedlist>
        <listitem>
-        <simpara>ouvrez un invite de commande</simpara>
+        <simpara>ouvrir une invite de commande</simpara>
        </listitem>
        <listitem>
         <simpara>
-         déplacez-vous dans le dossier où se trouvent les fichiers php_manual_lang.x.bz2
+         se déplacer dans le dossier où se trouvent les fichiers php_manual_lang.x.bz2
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         lancez la commande bzip2 -d php_manual_lang.x.bz2, pour extraire
+         lancer la commande bzip2 -d php_manual_lang.x.bz2, pour extraire
          php_manual_lang.x dans ce même dossier
         </simpara>
        </listitem>
       </itemizedlist>
      </para>
      <para>
-      Dans le cas où vous avez téléchargé le fichier php_manual_lang.tar.bz2
+      Dans le cas où le fichier php_manual_lang.tar.bz2 a été téléchargé
       avec beaucoup de fichiers HTML à l'intérieur, la procédure est la même.
-      La seule différence est que vous obtiendrez un fichier php_manual_lang.tar.
+      La seule différence est que le résultat sera un fichier php_manual_lang.tar.
       Le format tar est connu pour être pris en compte par la plupart des
       archiveurs de Windows, comme <link xlink:href="&url.winzip;">WinZip</link>.
      </para>

--- a/faq/obtaining.xml
+++ b/faq/obtaining.xml
@@ -19,11 +19,11 @@
     </question>
     <answer>
      <para>
-      Vous pouvez télécharger PHP à partir d'un des membres du réseau de
-      sites PHP. Vous pouvez les trouver sur
+      Il est possible de télécharger PHP à partir d'un des membres du réseau de
+      sites PHP. Ils se trouvent sur
       <link xlink:href="&url.php;">&url.php;</link>.
-      Vous pouvez aussi utiliser Git pour obtenir la toute dernière version
-      des sources. Pour plus d'informations, allez sur
+      Il est aussi possible d'utiliser Git pour obtenir la toute dernière version
+      des sources. Pour plus d'informations, consulter
       <link xlink:href="&url.php.anongit;">&url.php.anongit;</link>.
      </para>
     </answer>
@@ -37,11 +37,11 @@
      <para>
       Nous ne les distribuons que pour le système Windows, car nous ne pouvons
       compiler PHP pour chaque plate-forme Linux/Unix avec toutes les
-      combinaisons d'extensions. Notez aussi que plusieurs distributions Linux
+      combinaisons d'extensions. Il est à noter aussi que plusieurs distributions Linux
       fournissent PHP d'office de nos jours. Les binaires Windows peuvent être
       téléchargés à partir de notre page de <link
       xlink:href="&url.php.downloads;">Téléchargement</link>, pour les binaires
-      Linux, visitez le site de votre distribution.
+      Linux, il convient de consulter le site de la distribution correspondante.
      </para>
     </answer>
    </qandaentry>
@@ -57,8 +57,8 @@
      <para>
       <note>
        <simpara>
-        Celles marquées d'une étoile (*) ne sont pas thread safe ; nous vous
-        recommandons de ne pas les utiliser en environnement multithreadé.
+        Celles marquées d'une étoile (*) ne sont pas thread safe ; il est
+        recommandé de ne pas les utiliser en environnement multithreadé.
        </simpara>
       </note>
      </para>
@@ -178,12 +178,12 @@
     </question>
     <answer>
      <para>
-      Vous devrez suivre les instructions fournies avec les bibliothèques.
-      Quelques-unes d'entre elles sont détectées automatiquement lorsque vous
-      exécutez le script 'configure' de PHP (comme la bibliothèque GD), pour les
-      autres, vous devrez les activer en utilisant l'option 
+      Il est nécessaire de suivre les instructions fournies avec les bibliothèques.
+      Quelques-unes d'entre elles sont détectées automatiquement lorsque le
+      script 'configure' de PHP est exécuté (comme la bibliothèque GD), pour les
+      autres, il faut les activer en utilisant l'option
       '<literal>--with-EXTENSION</literal>' de '<literal>configure</literal>'.
-      Exécutez '<literal>configure --help</literal>' pour en avoir la liste
+      Exécuter '<literal>configure --help</literal>' pour en avoir la liste
       complète.     
      </para>
     </answer>
@@ -209,14 +209,14 @@
     </question>
     <answer>
      <para>
-      Vous pouvez trouver un fichier <filename>browscap.ini</filename> sur 
+      Il est possible de trouver un fichier <filename>browscap.ini</filename> sur
       <link xlink:href="&url.browscap.download;">&url.browscap.download;</link>.
      </para>
     </answer>
    </qandaentry>
    <qandaentry xml:id="faq.obtaining.threadsafety">
     <question>
-     <para>Que signifie thread safety lors du téléchargement de PHP?</para>
+     <para>Que signifie thread safety lors du téléchargement de PHP ?</para>
     </question>
     <answer>
      <para>
@@ -227,10 +227,10 @@
       threads.
      </para>
      <para>
-      Donc, que choisir? Si vous utilisez PHP comme CGI, alors vous n'avez pas besoin
-      de la sécurité des threads car le binaire est invoqué à chaque requête.
-      Concernant les serveurs multithreads, comme IIS5 et IIS6, vous devriez utiliser
-      la version threadée de PHP.
+      Donc, que choisir ? Si PHP est utilisé comme CGI, la sécurité des threads
+      n'est pas nécessaire car le binaire est invoqué à chaque requête.
+      Concernant les serveurs multithreads, comme IIS5 et IIS6, il est recommandé
+      d'utiliser la version threadée de PHP.
      </para>
     </answer>
    </qandaentry>

--- a/faq/passwords.xml
+++ b/faq/passwords.xml
@@ -30,16 +30,16 @@
      s'ils n'utilisent pas des mots de passe uniques.
     </simpara>
     <simpara>
-     En appliquant un hachage sur le mot de passe, vous rendez
-     la tâche d'un attaquant très difficile pour connaître le mot de passe original,
-     et vous avez toujours la possibilité de comparer le mot de passe haché à une chaîne
-     reçue.
+     En appliquant un hachage sur le mot de passe, il devient
+     improbable qu'un attaquant puisse déterminer le mot de passe original,
+     tout en conservant la possibilité de comparer le hachage résultant au mot de passe
+     original.
     </simpara>
     <simpara>
-     Il est important de noter que le hachage ne fait que protéger les mots de passe
-     dans la base, pas leur éventuelle interception alors qu'ils sont envoyés à
-     l'application par l'utilisateur, via du code malicieux injecté dans l'application,
-     par exemple.
+     Il est à noter, cependant, que le hachage de mots de passe ne fait que les
+     protéger dans l'espace de stockage, mais ne les protège pas nécessairement de
+     l'interception par du code malicieux injecté dans l'application ou le service
+     lui-même.
     </simpara>
    </answer>
   </qandaentry>
@@ -107,8 +107,8 @@
    <answer>
     <simpara>
      Un grain de sel, ou "salt", en cryptographie, est appliqué durant le processus de hachage pour
-     éliminer la possibilité d'attaques par dictionnaires (hachages enregistrés dans
-     une grande liste et comparés).
+     éliminer la possibilité que le résultat soit recherché dans une liste de paires
+     précalculées de hachages et de leur entrée, connue sous le nom de rainbow table.
     </simpara>
     <simpara>
      En termes plus simples, un sel est une donnée supplémentaire qui rend
@@ -118,29 +118,29 @@
      improbable ou impossible de trouver le hachage correspondant dans l'une de ces listes.
     </simpara>
     <simpara>
-     <function>password_hash</function> va créer un salt aléatoire si vous n'en fournissez
-     pas, et c'est généralement la façon la plus sécurisée et la plus simple.
+     <function>password_hash</function> va créer un grain de sel aléatoire si aucun n'est fourni,
+     et c'est généralement la façon la plus sécurisée et la plus simple.
     </simpara>
    </answer>
   </qandaentry>
    <qandaentry xml:id="faq.password.storing-salts">
     <question>
      <simpara>
-      Comment sont stockés les salts ?
+      Comment sont stockés les grains de sel ?
      </simpara>
     </question>
     <answer>
      <simpara>
       Lors de l'utilisation de la fonction <function>password_hash</function> ou
-      de la fonction <function>crypt</function>, la valeur retournée inclut le salt
-      comme partie du hash généré. Cette valeur devrait être stockée telle quelle
+      de la fonction <function>crypt</function>, la valeur retournée inclut le grain de sel
+      comme partie du hachage généré. Cette valeur devrait être stockée telle quelle
       dans la base de données, sachant qu'elle inclut les informations sur
       la fonction de hachage utilisée et peut donc être fournie directement à
       la fonction <function>password_verify</function> lors de la vérification des mots de passe.
      </simpara>
      <warning>
       <simpara>
-       <function>password_verify</function> doit toujours être utilisé au lieu de
+       <function>password_verify</function> devrait toujours être utilisé au lieu de
        rehacher et comparer le résultat à un hachage stocké afin d'éviter
        les attaques par chronométrage.
       </simpara>
@@ -149,14 +149,14 @@
       Le diagramme suivant montre le format d'une valeur retournée
       de la fonction <function>crypt</function> ou <function>password_hash</function>.
       Comme on peut le voir, tout est présent, comme toutes les informations
-      sur l'algorithme et le salt nécessaires pour une future vérification
+      sur l'algorithme et le grain de sel nécessaires pour une future vérification
       de mots de passe.
      </simpara>
      <para>
       <mediaobject>
        <alt>
         Les composants de la valeur retournée par la fonction password_hash et crypt :
-        dans l'ordre, l'algorithme choisi, les options de l'algorithme, le salt utilisé,
+        dans l'ordre, l'algorithme choisi, les options de l'algorithme, le grain de sel utilisé,
         et le mot de passe haché.
        </alt>
        <imageobject>

--- a/faq/using.xml
+++ b/faq/using.xml
@@ -7,8 +7,8 @@
   <titleabbrev>Utiliser PHP</titleabbrev>
 
   <para>
-   Cette section regroupe plusieurs erreurs que vous pouvez rencontrer
-   lors de l'écriture de vos scripts PHP.
+   Cette section regroupe plusieurs erreurs qu'il est possible de rencontrer
+   lors de l'écriture de scripts PHP.
   </para>
 
   <qandaset>
@@ -35,7 +35,7 @@
       "<emphasis>haystack, needle</emphasis>".
      </para>
      <para>
-      Depuis PHP 8.0, les <link linkend="functions.named-arguments">arguments nommés</link>
+      À partir de PHP 8.0, les <link linkend="functions.named-arguments">arguments nommés</link>
       permettent de passer les arguments par nom de paramètre, rendant l'ordre des paramètres moins important.
      </para>
     </answer>
@@ -53,7 +53,7 @@
      <para>
       PHP fournit plusieurs <link linkend="language.variables.predefined">
       variables pré-définies</link>, comme la superglobale <varname>
-      $_POST</varname>. Vous pouvez boucler sur <varname>$_POST</varname>
+      $_POST</varname>. Il est possible de boucler sur <varname>$_POST</varname>
       puisque c'est un tableau associatif de toutes les valeurs envoyées par 
       la méthode POST.
       Par exemple, bouclons dessus simplement avec &foreach;, vérifions
@@ -80,7 +80,6 @@ if (empty($empty)) {
     print "Vides :\n";  var_dump($empty);
     exit;
 }
-echo '</pre>';
 ?>
 ]]>
       </programlisting>
@@ -99,9 +98,8 @@ echo '</pre>';
     </question>
     <answer>
      <para>
-      Si l'on suppose que c'est pour une base de données, utilisez
-      le mécanisme d'échappement fourni avec la base de données. Par
-      exemple, utilisez la fonction
+      Si l'on suppose que c'est pour une base de données, il est recommandé d'utiliser le mécanisme d'échappement fourni avec la base de données. Par
+      exemple, il est possible d'utiliser la fonction
       <function>mysql_real_escape_string</function> avec MySQL et
       <function>pg_escape_string</function> avec PostgreSQL.
       Il y a également les fonctions génériques comme
@@ -138,9 +136,8 @@ echo "mafonction($variable) = " . mafonction($variable);
     </question>
     <answer>
      <para>
-      Pour pouvoir utiliser le résultat de votre fonction dans une expression
-      (comme le concaténer avec une chaîne comme dans cet exemple), vous devez
-      retourner la valeur avec <function>return</function>,
+      Pour pouvoir utiliser le résultat d'une fonction dans une expression
+      (comme le concaténer avec une chaîne comme dans cet exemple), il faut retourner la valeur avec <function>return</function>,
       et non pas l'afficher avec <function>echo</function>.
      </para>
     </answer>
@@ -165,14 +162,14 @@ echo "mafonction($variable) = " . mafonction($variable);
       En PHP, la fin d'un bloc de code est soit "?&gt;" ou
       "?&gt;\n" (où \n signifie une nouvelle ligne). Donc dans l'exemple plus
       haut, les phrases affichées le seront sur une seule ligne, car PHP
-      oublie les nouvelles lignes après la fin du bloc. Cela signifie que vous
-      devez insérer une nouvelle ligne de plus après chaque bloc de code PHP
+      oublie les nouvelles lignes après la fin du bloc. Cela signifie qu'il
+      faut insérer une nouvelle ligne de plus après chaque bloc de code PHP
       pour la lui faire afficher.
      </para>
      <para>
       Pourquoi PHP fait-il cela ? Car lors du formatage du HTML, cela
-      vous simplifie la vie car vous ne voulez pas de cette nouvelle ligne,
-      mais vous devez créer de très longues lignes ou rendre la source brute
+      simplifie la vie car cette nouvelle ligne n'est généralement pas souhaitée,
+      mais il faudrait créer de très longues lignes ou rendre la source brute
       de la page illisible pour arriver à cet effet.
      </para>
     </answer>
@@ -193,7 +190,7 @@ echo "mafonction($variable) = " . mafonction($variable);
       peuvent être envoyés qu'avant le reste du contenu. Il ne doit y avoir
       aucun affichage avant d'utiliser ces fonctions, comme le HTML par
       exemple. La fonction <function>headers_sent</function> vérifiera si
-      votre script a déjà envoyé des en-têtes. Voyez aussi 
+      le script a déjà envoyé des en-têtes. Voir aussi
       <link linkend="ref.outcontrol">les fonctions de bufferisation de sortie</link>.
      </para>
     </answer>
@@ -208,8 +205,8 @@ echo "mafonction($variable) = " . mafonction($variable);
     </question>
     <answer>
      <para>
-      La fonction <function>getallheaders</function> le fera si vous exécutez
-      PHP en tant que module Apache. Le code suivant vous montrera tous les
+      La fonction <function>getallheaders</function> le fera si PHP est exécuté
+      en tant que module Apache. Le code suivant affiche tous les
       en-têtes de requête :
       <programlisting role="php">
 <![CDATA[
@@ -243,11 +240,11 @@ foreach ($headers as $nom => $contenu) {
       Le modèle sécuritaire de IIS est en faute. C'est un problème commun à
       tous les programmes CGI fonctionnant avec IIS. Une alternative est de
       créer un fichier HTML (non exécuté par PHP) comme page d'entrée dans
-      le dossier où il faut s'identifier. Utilisez alors une balise META
-      pour rediriger vers la page PHP, ou encore proposez un lien vers
+      le dossier où il faut s'identifier. Il convient alors d'utiliser une balise META
+      pour rediriger vers la page PHP, ou encore de proposer un lien vers
       celle-ci. PHP reconnaîtra alors l'identification correctement.
       Cela ne devrait pas non
-      plus affecter d'autres serveurs NT. Pour plus d'informations, voyez : 
+      plus affecter d'autres serveurs NT. Pour plus d'informations, voir :
       <link xlink:href="&url.iis;">&url.iis;</link> et la section du manuel
       concernant l'<link linkend="features.http-auth">identification HTTP</link>.
      </para>
@@ -263,13 +260,13 @@ foreach ($headers as $nom => $contenu) {
     </question>
     <answer>
      <para>
-      Vous devez modifier le service <literal>Go to Internet Information
-      Services</literal>. Localisez votre fichier PHP et éditez ces propriétés.
-      Placez-vous sur l'onglet <literal>File Security</literal>, <literal>Edit -&lt; 
+      Il faut modifier le service <literal>Go to Internet Information
+      Services</literal>. Localisez le fichier PHP et éditez ses propriétés.
+      Se placer sur l'onglet <literal>File Security</literal>, <literal>Edit -&lt;
       Anonymous access and authentication control</literal>.
      </para>
      <para>
-      Vous pouvez résoudre ce souci soit en décochant la case <literal>Anonymous
+      Il est possible de résoudre ce souci soit en décochant la case <literal>Anonymous
       Access</literal> et en laissant la case <literal>Integrated Window
       Authentication</literal> cochée, soit en cochant la case <literal>Anonymous
       Access</literal> et en éditant l'utilisateur qui ne doit pas avoir les droits d'accès.
@@ -285,12 +282,12 @@ foreach ($headers as $nom => $contenu) {
     </question>
     <answer>
      <para>
-      Pour inclure &lt;?xml dans votre code PHP, vous devrez désactiver les
+      Pour inclure &lt;?xml dans le code PHP, il faut désactiver les
       short tags en configurant la directive PHP
       <link linkend="ini.short-open-tag">short_open_tags</link> à
-      <literal>0</literal>. Vous ne pouvez pas modifier cette directive avec
+      <literal>0</literal>. Il n'est pas possible de modifier cette directive avec
       <function>ini_set</function>.  Que <link linkend="ini.short-open-tag">
-      short_open_tags</link> soit à on ou off, vous pouvez toujours faire ceci :
+      short_open_tags</link> soit à on ou off, il est toujours possible de faire ceci :
       <literal>&lt;?php echo '&lt;?xml'; ?&gt;</literal>.  La valeur par
       défaut pour cette directive est <literal>On</literal>.
      </para>
@@ -301,17 +298,17 @@ foreach ($headers as $nom => $contenu) {
     <question>
      <para>
       Où puis-je trouver une liste complète des variables prédéfinies que je 
-      peux utiliser dans mes scripts PHP ?
+      peux utiliser dans des scripts PHP ?
      </para>
     </question>
     <answer>
      <para>
-      Lisez la page du manuel qui concerne les <link linkend="language.variables.predefined">
-      variables prédéfinies</link> vu qu'elle présente une liste
-      partielle des variables prédéfinies disponibles dans votre script. Une
+      La page du manuel qui concerne les <link linkend="language.variables.predefined">
+      variables prédéfinies</link> présente une liste
+      partielle des variables prédéfinies disponibles dans un script. Une
       liste complète des variables disponibles (et beaucoup d'informations)
       peut être vue en appelant la fonction <function>phpinfo</function>.
-      Lisez la section du manuel traitant des  
+      La page du manuel traitant des
       <link linkend="language.variables.external">variables non-issues de
       PHP</link>, elle décrit des scénarios communs pour les variables
       externes, comme celles issues d'un formulaire HTML, d'un cookie, et de
@@ -348,13 +345,13 @@ foreach ($headers as $nom => $contenu) {
     </question>
     <answer>
      <para>
-      Les options disponibles sont K (pour Kilo octets) et M (pour mégaoctet) et 
+      Les options disponibles sont K (pour kilooctet) et M (pour mégaoctet) et
       G (pour gigaoctet), ils sont
       insensibles à la casse. Toute autre syntaxe est supposée représenter des octets.
       <literal>1M</literal> équivaut à un mégaoctet ou <literal>1048576</literal>
       octets. <literal>1K</literal> équivaut à un kilooctet ou 
       <literal>1024</literal> octets. Ces notations abrégées peuvent être utilisées dans le fichier &php.ini; et dans la fonction <function>ini_set</function>.
-      Notez que la valeur numérique est transtypée en &integer; ;
+      Il est à noter que la valeur numérique est transtypée en &integer; ;
       par exemple, <literal>0.5M</literal> est interprété comme <literal>0</literal>.
      </para>
      <note>


### PR DESCRIPTION
Fixes across all 11 faq/ XML files: impersonal forms (TRADUCTIONS.txt), grammar, wrong content, terminology.