### PR TITLE
chapters/: fix missing content and path in examples

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -93,9 +93,7 @@ echo "Bonjour, je suis un script PHP !";
       traditionnelle, et aussi le principal objet de PHP.
       Trois composants sont nécessaires pour l'exploiter :
       un analyseur PHP (CGI ou module serveur), un serveur
-      web et un navigateur web. Vous devez exécuter le serveur
-      web en corrélation avec PHP. Vous pouvez accéder
-      au programme PHP avec l'aide du navigateur web. Tout ceci
+      web et un navigateur web. Tout ceci
       peut fonctionner sur une machine locale juste pour expérimenter
       la programmation PHP. Voyez la
       section <link linkend="install">d'installation</link>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -54,7 +54,7 @@ php -S localhost:8000
      </programlisting>
      <simpara>
       Utilisez votre navigateur pour accéder au fichier en utilisant l'URL de votre serveur web, se terminant
-      avec la référence au fichier <literal>hello.php</literal>.
+      avec la référence au fichier <literal>/hello.php</literal>.
       Selon la commande précédente exécutée, l'URL sera
       <literal>http://localhost:8000/hello.php</literal>.
       Si tout est configuré correctement, ce fichier sera analysé par PHP


### PR DESCRIPTION
Remove extra sentences not present in EN source, add missing leading slash in /hello.php literal.