### PR TITLE
security/: fix translation errors, wrong content, and terminology

### DIFF
--- a/security/database.xml
+++ b/security/database.xml
@@ -22,7 +22,7 @@
    requête SQL</link>.
  </simpara>
  <simpara>
-  Comme vous pouvez le réaliser, <acronym>PHP</acronym> ne peut pas protéger
+  Comme vous pouvez vous en douter, <acronym>PHP</acronym> ne peut pas protéger
   vos bases de données pour vous. La section suivante vous introduira aux
   notions de base pour protéger vos bases de données, lors de la programmation
   de vos scripts <acronym>PHP</acronym>.
@@ -39,7 +39,8 @@
   <simpara>
    La première étape est de créer une base de données, à moins que vous ne
    souhaitiez utiliser une base de données déjà créée. Lorsque la base
-   de données est créée, un utilisateur propriétaire en est responsable.
+   de données est créée, elle est assignée à un propriétaire, qui a
+   exécuté l'instruction de création.
    Généralement, seul le propriétaire et le super utilisateur peuvent
    intervenir avec les tables de cette base, et il faut que ce dernier
    donne des droits à tous les intervenants qui auront à travailler sur cette
@@ -166,7 +167,7 @@ if ($row && password_verify($password, $row['pwd'])) {
   <para>
    <example>
     <title>
-     Séparation des résultats en pages, et créer des administrateurs
+     Séparation des résultats en pages, et créer des superutilisateurs
      (PostgreSQL)
     </title>
     <simpara>
@@ -226,7 +227,7 @@ insert into pg_shadow(usename,usesysid,usesuper,usecatupd,passwd)
     recommandé.
     <example>
      <title>
-      Liste d'articles ... et ajout de mot de passe
+      Liste d'articles ... et quelques mots de passe (n'importe quel serveur de bases de données)
      </title>
      <programlisting role="php">
 <![CDATA[
@@ -254,11 +255,11 @@ union select '1', concat(uname||'-'||passwd) as name, '1971-01-01', '0' from use
     Les instructions <literal>UPDATE</literal> et <literal>INSERT</literal> sont également
     susceptibles à de telles attaques
     <example>
-     <title>Modifier un mot de passe ... et gain de droits!</title>
+     <title>Modifier un mot de passe ... et gain de droits ! (n'importe quel serveur de bases de données)</title>
      <programlisting role="php">
 <![CDATA[
 <?php
-$query= "UPDATE usertable SET pwd='$pwd' WHERE uid='$uid';";
+$query = "UPDATE usertable SET pwd='$pwd' WHERE uid='$uid';";
 ?>
 ]]>
     </programlisting>
@@ -334,8 +335,8 @@ $result = mssql_query($query);
    MSSQL Server exécute les requêtes SQL en lot, y compris la commande
    d'ajout d'un nouvel utilisateur à la base de données locale. Si cette
    application fonctionnait en tant que <literal>sa</literal> et que le
-   service MSSQLSERVER disposait de niveau de droits suffisant, le pirate
-   dispose désormais d'un compte avec accès au serveur.
+   service MSSQLSERVER disposait d'un niveau de droits suffisant, le pirate
+   disposerait désormais d'un compte avec accès au serveur.
    </para>
    <note>
     <para>
@@ -365,7 +366,7 @@ $result = mssql_query($query);
      La méthode recommandée pour éviter les injections SQL est de lier toutes les données
      via des requêtes préparées. L'utilisation de requêtes paramétrées n'est pas suffisante
      pour éviter complètement les injections SQL, mais c'est le moyen le plus facile et le plus sûr
-     de fournir une entrée aux instructions SQL. Toutes les littérales de données dynamiques dans les clauses
+     de fournir une entrée aux instructions SQL. Toutes les valeurs littérales dynamiques dans les clauses
      <literal>WHERE</literal>, <literal>SET</literal> et <literal>VALUES</literal> doivent être remplacées
      par des espaces réservés. Les données réelles seront liées pendant
      l'exécution et envoyées séparément de la commande SQL.
@@ -447,7 +448,7 @@ La liaison de paramètres ne peut être utilisée que pour les données. Les aut
     <simpara>
      Il est particulièrement important de ne pas divulguer d'informations spécifiques à la base de données,
      en particulier sur le schéma, que ce soit de manière légale ou illégale.
-     Consultez également <link linkend="security.errors">Signalement d'erreurs</link> et
+     Consultez également <link linkend="security.errors">Rapport d'erreurs</link> et
      <link linkend="ref.errorfunc">Fonctions de gestion et de journalisation des erreurs</link>.
      </simpara>
        </listitem>

--- a/security/errors.xml
+++ b/security/errors.xml
@@ -21,9 +21,9 @@
    <title>Attaque de variables avec une page HTML personnalisée</title>
    <programlisting role="html">
 <![CDATA[
-<form method="post" action="http://www.site.cible.com/?username=badfoo&amp;password=badfoo">
- <input type="hidden" name="username" value="badfoo" />
- <input type="hidden" name="password" value="badfoo" />
+<form method="post" action="attacktarget?username=badfoo&amp;password=badfoo">
+<input type="hidden" name="username" value="badfoo" />
+<input type="hidden" name="password" value="badfoo" />
 </form>
 ]]>
    </programlisting>
@@ -49,10 +49,10 @@
    <title>Exploiter des variables classiques de débogage</title>
    <programlisting role="html">
 <![CDATA[
-<form method="post" action="http://www.site.cible.com/?errors=Y&amp;showerrors=1&amp;debug=1">
- <input type="hidden" name="errors" value="Y" />
- <input type="hidden" name="showerrors" value="1" />
- <input type="hidden" name="debug" value="1" />
+<form method="post" action="attacktarget?errors=Y&amp;showerrors=1&amp;debug=1">
+<input type="hidden" name="errors" value="Y" />
+<input type="hidden" name="showerrors" value="1" />
+<input type="hidden" name="debug" value="1" />
 </form>
 ]]>
    </programlisting>
@@ -84,8 +84,8 @@
  <para>
   Une erreur de fichier, ou une erreur générale de PHP, peut indiquer
   quelles sont les permissions du serveur web, ainsi que la structure
-  et l'organisation des fichiers. Les gestionnaires d'erreurs utilisateurs
-  peuvent aussi aggraver ce problème, en permettant l'exploitation facile
+  et l'organisation des fichiers. Le code de gestion d'erreurs écrit par le
+  développeur peut aussi aggraver ce problème, en permettant l'exploitation facile
   d'informations préalablement "cachées".
  </para>
  <para>
@@ -121,7 +121,7 @@ if ($username) {
 }
 if ($good_login == 1) {
   // Si le test ci-dessus échoue, les valeurs n'ont pas été testées
-  fpassthru ("/données/très/très/sensibles/index.html");
+  readfile ("/données/très/très/sensibles/index.html");
 }
 ?>
 ]]>

--- a/security/filesystem.xml
+++ b/security/filesystem.xml
@@ -141,7 +141,7 @@ if (!ctype_alnum($username) || !preg_match('/^(?:[a-z0-9_-]|\.(?!\.))+$/iD', $us
    die("Mauvais utilisateur/nom de fichier");
 }
 
-// etc...
+// etc.
 
 ?>
 ]]>

--- a/security/intro.xml
+++ b/security/intro.xml
@@ -29,7 +29,7 @@
   La flexibilité de configuration de PHP est épaulée par la flexibilité
   du code. PHP peut être utilisé pour construire des applications serveur
   complètes, avec tous les pouvoirs d'un utilisateur shell, ou il peut
-  être utilisé pour de simples SSI (<literal>server side include</literal>)
+  être utilisé pour de simples SSI (<literal>server-side includes</literal>)
   avec peu de risque dans un environnement à sécurité renforcée. La
   création de cet environnement et sa sécurisation sont largement à la charge
   du développeur PHP.


### PR DESCRIPTION
Fix false friends, wrong function names, incorrect terms, missing EN content, and terminology alignment.