### PR TITLE
features/: fix terminology and translation errors

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -120,12 +120,12 @@
     </listitem>
     <listitem>
      <para>
-      Il y a plusieurs directives du &php.ini; qui sont ignorées par le
+      Il y a plusieurs directives du &php.ini; qui sont redéfinies par le
       &cli.sapi;, car elles n'ont pas de sens en environnement shell :
      </para>
      <para>
       <table>
-       <title>Directives &php.ini; ignorées</title>
+       <title>Directives &php.ini; redéfinies</title>
        <tgroup cols="3">
         <thead>
          <row>
@@ -589,7 +589,7 @@ string(15) "doesntmakesense"
         </para>
         <note>
          <para>
-          Avant PHP 8.3.0, il n'était possible de spécifier qu'un seul nom de fichier
+          Antérieur à PHP 8.3.0, il n'était possible de spécifier qu'un seul nom de fichier
           à vérifier.
          </para>
         </note>
@@ -1461,7 +1461,7 @@ php -r 'fwrite(STDERR, "stderr\n");'
    Le &cli.sapi; fournit un shell interactif lors de l'utilisation
    de l'option <option>-a</option> si PHP a été compilé avec l'option <option
    role="configure">--with-readline</option>.
-   Depuis PHP 7.1.0 le shell interactif est également disponible sur Windows,
+   À partir de PHP 7.1.0, le shell interactif est également disponible sur Windows,
    si l'<link linkend="book.readline">extension readline</link> est activée.
   </para>
   
@@ -1494,7 +1494,7 @@ php >
    Le shell interactif fournit également une autocomplétion des fonctions,
    des constantes, des noms de classes, des variables, des appels aux méthodes
    statiques et des constantes de classes en utilisant la touche de tabulation.
-   Depuis PHP 8.4.0, le chemin vers le fichier d'historique peut être défini en utilisant la
+   À partir de PHP 8.4.0, le chemin vers le fichier d'historique peut être défini en utilisant la
    variable d'environnement <envar>PHP_HISTFILE</envar>.
   </simpara>
   
@@ -1836,7 +1836,7 @@ Press Ctrl-C to quit.
 ]]>
    </screen>
    <para>
-    Noter qu'avant PHP 7.4.0, les ressources statiques en lien symbolique
+    Noter qu'antérieur à PHP 7.4.0, les ressources statiques en lien symbolique
     ne sont pas accessibles sous Windows, tant que le script routeur
     ne le gère pas.
    </para>
@@ -1952,7 +1952,7 @@ $ php -S 0.0.0.0:8000
    </programlisting>
    <warning>
     <para>
-     Le serveur web intégré ne doit pas être utilisé sur un réseau public.
+     Le serveur web intégré ne devrait pas être utilisé sur un réseau public.
     </para>
    </warning>
   </example>

--- a/features/gc.xml
+++ b/features/gc.xml
@@ -28,7 +28,7 @@
    </para>
    <para>
     Un conteneur zval est créé lorsqu'une nouvelle variable est créée avec une valeur
-    constante, comme par exemple :
+    constante, par exemple :
     <example>
      <title>Création d'un nouveau conteneur zval</title>
      <programlisting role="php">
@@ -349,7 +349,7 @@ a: (refcount=2, is_ref=1)=array (
    <para>
     Traditionnellement, les mécanismes de comptage de références, comme utilisés auparavant
     dans PHP, ne savent pas gérer les fuites mémoires dues à des références circulaires ;
-    cependant depuis PHP 5.3.0, un algorithme synchrone issu de l'analyse
+    cependant à partir de PHP 5.3.0, un algorithme synchrone issu de l'analyse
     <link xlink:href="&url.gc-paper;">Concurrent Cycle Collection in Reference Counted Systems</link>
     est utilisé pour répondre à ce problème particulier.
    </para>

--- a/features/persistent-connections.xml
+++ b/features/persistent-connections.xml
@@ -185,8 +185,8 @@
  <simplesect xml:id="persistent-connections.final-words">
   <title>Derniers mots</title>
   <simpara>
-   Étant donné leur comportement et les inconvénients potentiels décrits ci-dessus, vous ne devez pas
-   utiliser les connexions persistantes sans une réflexion approfondie. Elles ne doivent pas être
+   Étant donné leur comportement et les inconvénients potentiels décrits ci-dessus, vous ne devriez pas
+   utiliser les connexions persistantes sans une réflexion approfondie. Elles ne devraient pas être
    utilisées sans mettre en œuvre des modifications supplémentaires dans votre application et une configuration
    soigneuse de votre serveur de base de données et de votre serveur web et/ou PHP-FPM.
   </simpara>


### PR DESCRIPTION
Fix overridden≠ignored, apply TRADUCTIONS.txt rules (depuis→à partir de, avant→antérieur à, doit→devrait).