### PR TITLE
install/: fix translation errors, grammar, terminology, and missing content

### DIFF
--- a/install/cloud/azure.xml
+++ b/install/cloud/azure.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes Maintainer: mikaelkael -->
 
 <sect1 xml:id="install.cloud.azure" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Azure App services</title>
+ <title>Azure App Services</title>
  <para>
   PHP est fréquemment utilisé sur Azure App Services (alias Microsoft Azure, 
   Windows Azure, Azure Web Apps).
@@ -25,7 +25,7 @@
    En tant que tel, PHP et les extensions s'exécutent sur Azure App Services 
    tout comme ils le feraient sur d'autres serveurs Windows.
 
-   Toutefois, l'interface de gestion pour Azure app services est différente :
+   Toutefois, l'interface de gestion pour Azure App Services est différente :
   </para>
 
   <itemizedlist spacing="compact">

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -55,7 +55,7 @@
     </term>
     <listitem>
      <para>
-      Limite d'historique pour les lignes enregistrées qui permet des messages d'événements plus longs que 1024 caractères sans s'emballer.
+      Limite de journalisation pour les lignes enregistrées qui permet de journaliser des messages de plus de 1024 caractères sans découpage.
       Valeur par défaut : 1024
       Disponible à partir de PHP 7.3.0.
      </para>
@@ -68,7 +68,7 @@
     </term>
     <listitem>
      <para>
-      Historique expérimental sans tampon.
+      Journalisation expérimentale sans tampon supplémentaire.
       Valeur par défaut : yes.
       Disponible à partir de PHP 7.3.0.
      </para>
@@ -355,7 +355,7 @@
       <listitem>
        <para>
         Définit la table de routage associée (FIB). FreeBSD uniquement.
-        Valeur par défaut : <literal>-1</literal>. Depuis PHP 8.2.0.
+        Valeur par défaut : <literal>-1</literal>. À partir de PHP 8.2.0.
        </para>
       </listitem>
      </varlistentry>
@@ -389,7 +389,7 @@
     </term>
     <listitem>
      <para>
-      Choisi comment le gestionnaire de processus va contrôler le nombre de processus fils.
+      Choisit comment le gestionnaire de processus va contrôler le nombre de processus fils.
       Valeurs possibles : <literal>static</literal>, <literal>ondemand</literal>,
       <literal>dynamic</literal>. Option obligatoire.
      </para>
@@ -420,7 +420,7 @@
       <literal>pm</literal> est réglé sur <literal>dynamic</literal>. Option obligatoire.
      </para>
      <para>
-      Cette option affecte la limite du nombre de requêtes simultanées qui seront servies. Equivalent à
+      Cette option affecte la limite du nombre de requêtes simultanées qui seront servies. Équivalent à
       ApacheMaxClients avec mpm_prefork et à <varname>PHP_FCGI_CHILDREN</varname> dans l'implémentation originale
       de FastCGI de PHP.
      </para>
@@ -472,8 +472,9 @@
       </term>
       <listitem>
        <para>
-        Nombre maximum de taux de génération de processus enfants simultanés. Utilisé seulement si 
+        Nombre maximum de taux de génération de processus enfants simultanés. Utilisé seulement si
         <literal>pm</literal> est défini à <literal>dynamic</literal>.
+        Valeur par défaut : 32
        </para>
       </listitem>
      </varlistentry>
@@ -487,7 +488,7 @@
         Nombre de secondes après lesquelles un processus inactif sera tué.
         Utilisé uniquement quand <literal>pm</literal> est défini à 
         <literal>ondemand</literal>.
-        Unités disponibles : s (secondes)(par défaut), m (minutes), h (heure), ou d (jour).
+        Unités disponibles : s (secondes)(par défaut), m (minutes), h (heures), ou d (jours).
         Valeur par défaut : 10s.
        </para>
       </listitem>
@@ -499,9 +500,9 @@
       </term>
       <listitem>
        <para>
-        Nombre de requêtes que chaque processus fils devrait exécuter avant de renaitre.
+        Nombre de requêtes que chaque processus fils devrait exécuter avant de renaître.
         Ceci peut être utile pour contourner des fuites mémoires dans des bibliothèques tierces.
-        Pour un traitement sans fin des requêtes, précisez '0'. Equivalent à
+        Pour un traitement sans fin des requêtes, précisez '0'. Équivalent à
         <varname>PHP_FCGI_MAX_REQUESTS</varname>. Par défaut : 0.
        </para> 
       </listitem>
@@ -515,8 +516,8 @@
        <para>
         L'adresse sur laquelle accepter la demande de statut FastCGI. Cela crée un nouveau pool invisible
         qui peut traiter les requêtes indépendamment. Ceci est utile si le pool principal est occupé par des 
-        requêtes de longue durée car il est toujours possible d'obtenir le statut
-        <link linkend="fpm.status">FPM status page</link> tant qu'elles ne sont pas terminées. 
+        requêtes de longue durée car il est toujours possible d'obtenir la
+        <link linkend="fpm.status">page de statut de FPM</link> avant qu'elles ne soient terminées. 
         La syntaxe est la même que pour la directive <link linkend="listen">listen</link>. 
         Valeur par défaut : none.
        </para>
@@ -531,7 +532,7 @@
        <para>
         L'URI vers la <link linkend="fpm.status">page de statut de FPM</link>.
         Cette valeur doit commencer par une barre oblique (/). Si cette valeur n'est pas définie,
-        aucun URI ne sera reconnu en tant qu'une page d'état. Valeur par défaut : none.
+        aucun URI ne sera reconnu en tant que page de statut. Valeur par défaut : none.
        </para> 
       </listitem>
      </varlistentry>
@@ -587,7 +588,7 @@
         si l'utilisateur ou le groupe de processus est différent de 
         l'utilisateur du processus maître. Il permet de créer un core dump du 
         processus et ptrace le processus pour l'utilisateur de pool. Valeur par 
-        défaut : no. Depuis PHP 7.0.29, 7.1.17 et 7.2.5.
+        défaut : no. À partir de PHP 7.0.29, 7.1.17 et 7.2.5.
        </para>
       </listitem>
      </varlistentry>
@@ -755,11 +756,12 @@
       </term>
       <listitem>
        <para>
-        Nettoie l'environnement des agents FPM.
-        Prévient que des variables d’environnement arbitraire puissent
-        atteindre les processus FPM par le nettoyage de l'environnement
-        de ces agents avant que les variables d'environnement spécifiées
+        Nettoie l’environnement des agents FPM.
+        Prévient que des variables d’environnement arbitraires puissent
+        atteindre les processus FPM par le nettoyage de l’environnement
+        de ces agents avant que les variables d’environnement spécifiées
         dans la configuration du pool ne soient ajoutées.
+        Valeur par défaut : Yes.
        </para> 
       </listitem>
      </varlistentry>
@@ -772,7 +774,7 @@
        <para>
         Limite les extensions que le script principal FPM va être autorisé à analyser.
         Ceci peut prévenir les erreurs de configuration côté serveur.
-        Vous pouvez limiter FPM à exécuter seulement les extensions .php pour prévenir que des utilisateurs malicieux utilisent d'autres extensions pour exécuter du code.
+        Vous devriez limiter FPM aux extensions .php uniquement pour empêcher des utilisateurs malveillants d'utiliser d'autres extensions pour exécuter du code PHP.
         Valeur par défaut : .php .phar
        </para> 
       </listitem>
@@ -1001,7 +1003,7 @@
       <listitem>
        <para>
         Une liste de valeurs request_uri qui devraient être filtrées du journal d'accès.
-        Valeur par défaut : non définie. Depuis PHP 8.2.0.
+        Valeur par défaut : non définie. À partir de PHP 8.2.0.
        </para>
       </listitem>
      </varlistentry>
@@ -1066,8 +1068,8 @@ fastcgi_param  PHP_ADMIN_VALUE "open_basedir=/var/www/htdocs";
    </caution>
    <note>
     <simpara>
-     Les pools ne sont pas un mécanisme de sécurité, car elles ne
-     fournissent pas une séparation totale ; par exemple toutes les pools
+     Les pools ne sont pas un mécanisme de sécurité, car ils ne
+     fournissent pas une séparation totale ; par exemple tous les pools
      utiliseraient une seule instance OPcache.
     </simpara>
    </note>

--- a/install/fpm/index.xml
+++ b/install/fpm/index.xml
@@ -37,7 +37,7 @@
    <listitem>
     <para>
      "slowlog" - journalisation des scripts (pas juste leurs noms, mais leur backtrace PHP également, 
-     utilisant ptrace ou équivalent pour lire le processus distant) qui s'exécutent de manière anormalement lente ;
+     utilisant ptrace ou équivalent pour lire le execute_data du processus distant) qui s'exécutent de manière anormalement lente ;
     </para>
    </listitem>
    <listitem>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -183,24 +183,24 @@ include_path = ".;c:\php\lib"
    <informalexample>
     <screen>
 <![CDATA[
-Assuming PHP is configured with --with-config-file-scan-dir=/etc/php.d,
-and that the path separator is :...
+En supposant que PHP est configuré avec --with-config-file-scan-dir=/etc/php.d,
+et que le séparateur de chemin est :...
 
 $ php
-  PHP va charger tous les fichiers présent dans /etc/php.d/*.ini comme fichier 
+  PHP va charger tous les fichiers présents dans /etc/php.d/*.ini comme fichiers
   de configuration.
 
 $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d php
-  PHP va charger tous les fichiers présent dans /usr/local/etc/php.d/*.ini 
-  comme fichier de configuration.
+  PHP va charger tous les fichiers présents dans /usr/local/etc/php.d/*.ini 
+  comme fichiers de configuration.
 
 $ PHP_INI_SCAN_DIR=:/usr/local/etc/php.d php
-  PHP va charger tous les fichiers présent dans /etc/php.d/*.ini, puis
-  /usr/local/etc/php.d/*.ini comme fichier de configuration.
+  PHP va charger tous les fichiers présents dans /etc/php.d/*.ini, puis
+  /usr/local/etc/php.d/*.ini comme fichiers de configuration.
 
 $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
-  PHP va charger tous les fichiers présent dans /usr/local/etc/php.d/*.ini, puis dans
-  /etc/php.d/*.ini comme fichier de configuration.
+  PHP va charger tous les fichiers présents dans /usr/local/etc/php.d/*.ini, puis dans
+  /etc/php.d/*.ini comme fichiers de configuration.
 ]]>
     </screen>
    </informalexample>

--- a/install/intro.xml
+++ b/install/intro.xml
@@ -55,8 +55,8 @@
   module ou d'exécutables CGI.
  </para>
  <para>
-  Les codes source et les exécutables compilés pour certains OS
-  (y compris Windows), sont disponibles à
+  Les codes source et les distributions binaires de PHP pour Windows
+  sont disponibles à
   <link xlink:href="&url.php.downloads;">&url.php.downloads;</link>.
  </para>
 </chapter>

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -152,7 +152,7 @@
      par défaut est <filename>/Library/WebServer/Documents</filename> mais peut
      être défini à n'importe quelle valeur dans le fichier
      <filename>httpd.conf</filename>. De plus, le dossier <filename>DocumentRoot</filename> pour
-     les différentes utilisateurs est
+     les différents utilisateurs est
      <filename>/Users/yourusername/Sites</filename>
     </simpara>
    </listitem>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -145,7 +145,7 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
    </para>
    <para>
     PHP est livré avec les extensions qui sont les plus utiles à la majorité des utilisateurs.
-    Elles sont appelées des extensions <emphasis>intégrées</emphasis>, ou <emphasis>bundled</emphasis>.
+    Elles sont appelées des extensions <emphasis>bundled</emphasis> (intégrées).
    </para>
    <para>
     Cependant, si les extensions intégrées ne fournissent pas la fonctionnalité nécessaire,
@@ -233,7 +233,7 @@ drive:\path\to\php\executable\php.exe -i
    </para>
    <para>
     À partir de PHP 7.2.0, le nom de l'extension peut être utilisé à la place
-    du nom de l'extension. Comme il est indépendant de l'OS et plus facile, en 
+    du nom de fichier de l'extension. Comme il est indépendant de l'OS et plus facile, en
     particulier pour les nouveaux arrivants, il devient la manière recommandée 
     de spécifier des extensions à charger. Les noms de fichiers restent pris en 
     charge pour la compatibilité avec les versions antérieures.
@@ -387,7 +387,7 @@ $ make
    Si le système ne possède pas la commande <command>phpize</command> et que
    des paquets précompilés (comme des RPM) sont utilisés, il faut s'assurer d'installer
    également la version de développement appropriée des paquets PHP car
-   elle inclut également la commande <literal>phpize</literal> ainsi que les en-têtes
+   elle inclut également la commande <command>phpize</command> ainsi que les en-têtes
    appropriés pour construire PHP et ses extensions.
   </simpara>
   <simpara>

--- a/install/pie.xml
+++ b/install/pie.xml
@@ -19,7 +19,7 @@
    Après <link xlink:href="&url.pie;?tab=readme-ov-file#what-do-i-need-to-get-started">l'installation
    des prérequis et de PIE lui-même</link>, vous pouvez ensuite installer
    l'<link linkend="mongodb.mongodb">extension MongoDB</link> en exécutant
-   la commande suivante.
+   la commande suivante en ligne de commande.
   </simpara>
   <example>
    <title>Installer l'extension MongoDB avec PIE</title>

--- a/install/problems.xml
+++ b/install/problems.xml
@@ -45,7 +45,7 @@
     <simpara>
      Si vous pensez avoir trouvé un bogue dans PHP, n'oubliez
      pas de le signaler. L'équipe de développement
-     PHP ne le connaît peut être pas et, si vous ne le signalez pas,
+     PHP ne le connaît peut-être pas et, si vous ne le signalez pas,
      vos chances de voir le bogue corrigé sont nulles. Vous pouvez
      rapporter des bogues grâce au système de suivi, accessible
      à <link xlink:href="&url.php.bugs;">&url.php.bugs;</link>.

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -35,7 +35,7 @@
   Il y a plusieurs raisons de choisir l'une plutôt que l'autre ; néanmoins, la version
   2.4 est actuellement la dernière version disponible et c'est aussi celle
   que nous vous recommandons. Cependant, les instructions contenues
-  dans ce guide devraient fonctionner pour la version 2.4 comme pour la version 2.2. Note: Apache httpd 2.2 est officiellement en Fin de Vie, il n'y aura plus de développement ni de patch pour cette version.
+  dans ce guide devraient fonctionner pour la version 2.4 comme pour la version 2.2. Note : Apache httpd 2.2 est officiellement en fin de vie, il n'y aura plus de développement ni de correctif pour cette version.
  </para>
  
  <orderedlist>
@@ -116,7 +116,8 @@ make install
    <para>
     Maintenant, configurez et compilez PHP. Ce sera à ce moment-là
     où vous pourrez personnaliser PHP avec les diverses options disponibles,
-    comme la liste des extensions à activer. Dans notre exemple, nous effectuerons
+    comme la liste des extensions à activer. Exécutez
+    <command>./configure --help</command> pour la liste des options disponibles. Dans notre exemple, nous effectuerons
     une configuration simple, avec Apache 2 et le support MySQL.
    </para>
    
@@ -358,8 +359,8 @@ service httpd restart
    Pour compiler une version multithreadée d'Apache, le système cible
    doit supporter les threads. Dans ce cas, PHP doit également être construit
    avec Zend Thread Safety (ZTS). Sous cette configuration, toutes les extensions
-   ne seront pas disponibles. Nous vous recommandons de compiler Apache avec le
-   <filename>prefork</filename> MPM-Module.
+   ne seront pas disponibles. La configuration recommandée est de compiler Apache avec le
+   module MPM <filename>prefork</filename> par défaut.
   </para>
  </note>
 </sect1>

--- a/install/unix/commandline.xml
+++ b/install/unix/commandline.xml
@@ -11,7 +11,7 @@
    processeur CGI. Si vous utilisez un serveur qui supporte le module PHP,
    vous devriez en général utiliser cette solution pour des raisons de
    performances. Cependant, la version CGI permet aux utilisateurs de lancer
-   des pages PHP sous différent id utilisateurs (Unix).
+   des pages PHP sous différents identifiants utilisateurs (Unix).
  </para>
  &warn.install.cgi;
 

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -108,7 +108,7 @@
    <listitem>
     <simpara>
      Si une extension a apparemment été installée mais que ses fonctions ne sont pas définies,
-     assurez vous que les lignes adéquates ont été insérées dans les fichiers .ini et/ou que
+     assurez-vous que les lignes adéquates ont été insérées dans les fichiers .ini et/ou que
      le serveur web a été redémarré après l'installation.
     </simpara>
    </listitem>

--- a/install/unix/lighttpd-14.xml
+++ b/install/unix/lighttpd-14.xml
@@ -59,7 +59,7 @@ fastcgi.server = ( ".php" =>
    <envar>PHP_FCGI_CHILDREN</envar>. La directive <literal>bin-environment</literal> définit l'environnement
    pour les processus appelés. PHP terminera un processus fils lorsque le
    nombre de requêtes spécifié par <envar>PHP_FCGI_MAX_REQUESTS</envar> a été atteint.
-   Les directives <literal>min-procs</literal> et <literal>max-procs</literal> peuvent généralement être ignorées
+   Les directives <literal>min-procs</literal> et <literal>max-procs</literal> devraient généralement être évitées
    avec PHP. PHP gère ses propres fils et caches opcode comme APC qui partage
    uniquement les fils gérés par PHP. Si <literal>min-procs</literal> est défini à quelque chose
    de supérieur à 1, le nombre total de réponses PHP sera multiplié par
@@ -80,9 +80,9 @@ fastcgi.server = ( ".php" =>
   <title>Appel de php-cgi</title>
 
   <para>
-   Il est possible d'appeler des processus sans spawn-fcgi, avec un
-   minimum de configuration. La variable d'environnement <envar>PHP_FCGI_CHILDREN</envar>
-   contrôle le nombre de fils que PHP appelle pour gérer les demandes.
+   Il est possible d'appeler des processus sans spawn-fcgi, bien que
+   cela demande un peu de travail. La variable d'environnement <envar>PHP_FCGI_CHILDREN</envar>
+   contrôle le nombre de fils que PHP appelle pour gérer les requêtes entrantes.
    La variable d'environnement <envar>PHP_FCGI_MAX_REQUESTS</envar> détermine la durée de
    vie, en nombre de requêtes, de chaque fils. Voici un script bash simple
    qui permet d'aider les appels aux répondeurs PHP.

--- a/install/unix/litespeed.xml
+++ b/install/unix/litespeed.xml
@@ -138,7 +138,7 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
  <para>
   Le mode de ligne de commande LSPHP (LSAPI + PHP) est utilisé pour traiter les scripts PHP en cours d'exécution
   sur un serveur distant qui n'a pas nécessairement un serveur web en cours d'exécution. Il est utilisé pour traiter
-  les scripts PHP résidant sur un serveur web local (séparé). Cette configuration est adaptée à la scalabilité du service
+  les scripts PHP résidant sur un serveur web local (séparé). Cette configuration est adaptée à la mise à l'échelle du service
   car le traitement PHP est déchargé vers un serveur distant.
  </para>
 
@@ -189,7 +189,7 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
  </informalexample>
 
  <para>
-  Faire en sorte que LSPHP accepte les demandes sur le socket de domaine Unix <literal>/tmp/lsphp_manual.sock</literal> :
+  Faire en sorte que LSPHP accepte les requêtes sur le socket de domaine Unix <literal>/tmp/lsphp_manual.sock</literal> :
  </para>
 
  <informalexample>
@@ -213,7 +213,7 @@ PHP_LSAPI_MAX_REQUESTS=500 PHP_LSAPI_CHILDREN=35 /path/to/lsphp -b IP_address:po
  </informalexample>
 
  <para>
-  Aujourd'hui, LiteSpeed PHP peut être utilisé avec LiteSpeed Web Server,
+  Actuellement, LiteSpeed PHP peut être utilisé avec LiteSpeed Web Server,
   OpenLiteSpeed Web Server et Apache mod_lsapi. Pour les étapes de
   configuration côté serveur, visitez les pages de documentation pour
   <link xlink:href="&url.litespeed.web.server;">LiteSpeed Web Server</link>
@@ -238,7 +238,7 @@ PHP_LSAPI_MAX_REQUESTS=500 PHP_LSAPI_CHILDREN=35 /path/to/lsphp -b IP_address:po
 
  <para>
   cPanel:
-  Voir la <link xlink:href="&url.litespeed.cpanel;">page de documentation</link> respective
+  Visitez la <link xlink:href="&url.litespeed.cpanel;">page de documentation</link> respective
   sur la façon d'installer LSPHP avec cPanel et LSWS/OLS en utilisant EasyApache 4.
  </para>
 

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -213,7 +213,7 @@ location / {
 
    <para>
     La prochaine étape permet d'assurer que les fichiers .php soient passés
-    au backend PHP-FPM ; Sous le bloc commenté par défaut et entrez :
+    au backend PHP-FPM. Sous le bloc PHP commenté par défaut, entrez :
    </para>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx.php">
@@ -268,8 +268,8 @@ echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
  <para>
   En suivant ces différentes étapes, vous devriez exécuter un serveur
   web Nginx avec le support de PHP comme module <literal>FPM</literal> <literal>SAPI</literal>.
-  Bien entendu, il y a beaucoup plus d'options de configuration de
-  disponible pour Nginx et PHP. Pour plus d'informations, tapez
+  Bien entendu, il y a beaucoup plus d'options de configuration
+  disponibles pour Nginx et PHP. Pour plus d'informations, tapez
   <command>./configure --help</command> dans la source correspondante.
  </para>
 

--- a/install/unix/openbsd.xml
+++ b/install/unix/openbsd.xml
@@ -48,7 +48,7 @@ Follow the instructions shown with each package!
   </example>
   <simpara>
    Lisez la page de manuel Unix <link xlink:href="&url.openbsd.packages;">packages(7)</link>
-    pour plus de détails sur les packages binaires d'OpenBSD.
+    pour plus de détails sur les paquets binaires d'OpenBSD.
   </simpara>
  </sect2>
  <sect2 xml:id="install.unix.openbsd.ports">
@@ -57,11 +57,11 @@ Follow the instructions shown with each package!
    Vous pouvez aussi compiler PHP en utilisant <link
    xlink:href="&url.openbsd.ports;">l'arbre des ports</link>.
    Cette méthode est recommandée aux utilisateurs expérimentés de OpenBSD. Le port PHP
-   est divisé en core et extensions. Le dossier
-   extensions génère les sous paquets de tous les modules PHP. Si vous souhaitez
-   ne pas créer ces modules, vous pouvez utiliser la commande en ligne
-   <command>no_*</command> FLAVOR. Par exemple, pour ne pas compiler le module
-   imap, utilisez FLAVOR avec la valeur <command>no_imap</command>.
+   est divisé en core et extensions. Les
+   extensions génèrent les sous-paquets de tous les modules PHP supportés. Si vous souhaitez
+   ne pas créer certains de ces modules, utilisez le FLAVOR
+   <command>no_*</command>. Par exemple, pour ne pas compiler le module
+   imap, définissez le FLAVOR à <command>no_imap</command>.
   </simpara>
  </sect2>
  <sect2 xml:id="install.unix.openbsd.faq">
@@ -95,8 +95,8 @@ Follow the instructions shown with each package!
    <listitem>
     <simpara>
      Le paquet OpenBSD pour l'extension <link xlink:href="&url.gd;">gd</link> 
-     requiert Xorg. A moins d'être déjà incluse après l'installation en ajoutant
-     le jeu de fichiers <filename>xbase.tgz</filename>, cela peut être ajouté a posteriori
+     requiert l'installation de Xorg. À moins d'avoir été déjà installé lors de l'installation de base en ajoutant
+     le jeu de fichiers <filename>xbase.tgz</filename>, cela peut être ajouté après l'installation
      (voir <link xlink:href="&url.openbsd.faq4;">OpenBSD FAQ#4</link>).
     </simpara>
    </listitem>

--- a/install/unix/solaris.xml
+++ b/install/unix/solaris.xml
@@ -11,7 +11,7 @@
  <sect2 xml:id="install.unix.solaris.required">
   <title>Logiciels nécessaires</title>
   <para>
-   L'installation <productname>Solaris</productname> oublie généralement les compilateurs C, et leurs
+   Les installations <productname>Solaris</productname> sont généralement dépourvues de compilateurs C et de leurs
    utilitaires. Lisez <link linkend="faq.installation.needgnu">cette FAQ</link>
    pour savoir pourquoi est-ce que les versions GNU de certains de ces outils
    sont nécessaires.
@@ -86,7 +86,7 @@
      </simpara>
     </listitem>
    </itemizedlist>
-   De plus, vous devrez aussi installer (et peut être aussi compiler)
+   De plus, vous devrez aussi installer (et peut-être aussi compiler)
    toutes les bibliothèques nécessaires aux extensions comme MySQL, Oracle, etc.
   </para>     
  </sect2>
@@ -95,9 +95,9 @@
   <simpara>
    Vous pouvez simplifier l'installation <productname>Solaris</productname> 
    en utilisant pkgadd pour installer la plupart des composants. Le
-   système de paquets des images (IPS) pour <productname>Solaris 11 Express</productname>
-   contient également les composants nécessaires pour l'installation
-   utilisant la commande pkg.
+   système Image Packaging System (IPS) pour <productname>Solaris 11 Express</productname>
+   contient également la plupart des composants nécessaires pour l'installation
+   en utilisant la commande pkg.
   </simpara>
  </sect2>
 </sect1>

--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -74,7 +74,7 @@
  <simpara>
   Pour plus de détails sur les étapes pour compiler PHP à partir des sources, voir le fichier
   <link xlink:href="&url.php.git.src.master.view;README.md">README.md</link>
-  dans la source tarball.
+  dans l'archive source.
  </simpara>
 
  <simpara>
@@ -89,11 +89,11 @@
  </simpara>
 
  <simpara>
-  Après que le script de configuration a été exécuté, PHP peut être construit en utilisant
+  Une fois le script de configuration exécuté, PHP peut être construit en utilisant
   la commande <command>make</command>.
-  Le <link linkend="faq.installation">
-  chapitre Installation des questions fréquemment posées
-  </link> contient plus d'informations sur la gestion des problèmes de compilation.
+  La <link linkend="faq.installation">section Installation des
+  questions fréquemment posées</link> contient plus d'informations
+  sur la gestion des problèmes de compilation.
  </simpara>
 
  <note>

--- a/install/windows/commandline.xml
+++ b/install/windows/commandline.xml
@@ -9,7 +9,7 @@
  </para>
  <note>
   <para>
-   Lire les <link linkend="install.windows.manual">étapes
+   Veuillez lire les <link linkend="install.windows.manual">étapes
    d'installation manuelle</link> en premier !
   </para>
  </note>
@@ -155,8 +155,8 @@ script -arg1 -arg2 -arg3
 
  <note>
   <para>
-   Il y a un petit problème si l'intention d'utiliser cette technique et
-   d'utiliser les scripts PHP comme filtre en ligne de commande, comme l'exemple ci-dessous :
+   Il y a un petit problème si l'on souhaite utiliser cette technique et
+   utiliser les scripts PHP comme filtre en ligne de commande, comme l'exemple ci-dessous :
    <screen>
 <![CDATA[
 dir | "C:\PHP Scripts\script" -arg1 -arg2 -arg3
@@ -181,7 +181,7 @@ Windows Registry Editor Version 5.00
    Plus d'informations sur ce problème peuvent être trouvées dans cet <link
    xlink:href="http://support.microsoft.com/default.aspx?scid=kb;en-us;321788">article de la base de connaissances Microsoft : 321788</link>.
    À partir de Windows 10, ce paramètre semble être inversé, rendant l'installation par défaut de
-   Windows 10 supportant automatiquement les poignées de console héritées. Ce <link
+   Windows 10 supportant automatiquement les gestionnaires de console hérités. Ce <link
    xlink:href="https://social.msdn.microsoft.com/Forums/en-US/f19d740d-21c8-4dc2-a9ab-d5c0527e932b/nasty-file-association-regression-bug-in-windows-10-console?forum=windowssdk">
    post du forum Microsoft</link> fournit l'explication.
   </para>

--- a/install/windows/iis.xml
+++ b/install/windows/iis.xml
@@ -9,8 +9,8 @@
   <simpara>
    Les Services d'informations Internet (Internet Information Services - IIS) sont intégrés à Windows.
    Sur Windows Server, le rôle IIS peut être ajouté via le Gestionnaire de serveur.
-   Le module CGI doit être inclus.
-   Sur les bureaux Windows, IIS doit être ajouté via le Panneau de configuration.
+   La fonctionnalité de rôle CGI doit être incluse.
+   Sur les bureaux Windows, IIS doit être ajouté via l'option Ajout/Suppression de programmes du Panneau de configuration.
    La documentation Microsoft fournit <link xlink:href="&url.iis.enable;">des instructions détaillées pour activer IIS</link>.
    Pour le développement,
    <link xlink:href="&url.iis.express;">IIS/Express</link> peut également être utilisé.
@@ -26,7 +26,7 @@
   <title>Configurer PHP avec IIS</title>
 
   <simpara>
-   Dans IIS Manager, installez le module FastCGI et ajoutez une correspondance de gestionnaire pour
+   Dans le gestionnaire IIS, installez le module FastCGI et ajoutez un mappage de gestionnaire pour
    <literal>.php</literal> au chemin de <filename>php-cgi.exe</filename>
    (pas <filename>php.exe</filename>)
   </simpara>
@@ -51,7 +51,7 @@ REM chemin du répertoire dans lequel le fichier .ZIP de PHP a été décompress
 set phppath=c:\php
 
 
-REM Enlève les gestionnaires PHP actuels
+REM Efface les gestionnaires PHP actuels
 %windir%\system32\inetsrv\appcmd clear config /section:system.webServer/fastCGI
 REM La commande suivante générera un message d'erreur si PHP n'est pas installé. Cela peut être ignoré.
 %windir%\system32\inetsrv\appcmd set config /section:system.webServer/handlers /-[name='PHP_via_FastCGI']

--- a/install/windows/manual.xml
+++ b/install/windows/manual.xml
@@ -10,8 +10,8 @@
    PHP n'est disponible que pour les systèmes 32 bits x86 ou 64 bits x64, et ne fonctionne
    actuellement pas sur Windows RT ou Windows sur ARM.
    À partir de la version 8.3.0, PHP nécessite Windows 8 ou Windows Server 2012.
-   Les versions après 7.2.0 nécessitaient Windows 2008 R2 ou Windows 7.
-   Les versions avant 7.2.0 supportaient Windows 2008 et Vista.
+   Les versions postérieures à 7.2.0 nécessitaient Windows 2008 R2 ou Windows 7.
+   Les versions antérieures à 7.2.0 supportaient Windows 2008 et Vista.
   </simpara>
 
   <simpara>

--- a/install/windows/recommended.xml
+++ b/install/windows/recommended.xml
@@ -24,7 +24,7 @@ opcache.enable_cli=On
   </example>
   Et redémarrer le serveur web.
   
-  Pour plus d'information, lire : 
+  Pour plus d'informations, voir : 
   <link linkend="opcache.configuration">Configuration d'OpCache</link>
  </para>
  
@@ -34,8 +34,8 @@ opcache.enable_cli=On
   
   <para>
    Il est recommandé d'utiliser WinCache lors de l'utilisation d'IIS,
-   surtout si dans un environnement d'hébergement Web partagé ou en utilisant
-   le stockage de fichiers en réseau (NAS).
+   surtout dans un environnement d'hébergement Web partagé ou lors de l'utilisation
+   du stockage de fichiers en réseau (NAS).
    
    Toutes les applications PHP bénéficient automatiquement de la fonctionnalité
    de cache de fichiers de WinCache. Les opérations du système de fichiers sont
@@ -68,7 +68,7 @@ wincache.ocenabled=1 ; removed as of wincache 2.0.0.0
    </screen>
   </example>
   
-  Pour plus d'information, lire : 
+  Pour plus d'informations, voir : 
   <link linkend="wincache.configuration">Configuration de WinCache</link>
  </para>
  


### PR DESCRIPTION
Fix translation errors, grammar, and terminology across 22 install/ XML files.

- Fix inverted meanings (lighttpd, solaris)
- Fix terminology: handle→gestionnaire, packages→paquets, depuis→à partir de
- Fix grammar: accords, traits d'union, conjugaisons
- Add missing content from EN source
- Fix anglicisms and align FPM configuration translations