### PR TITLE
appendices/: fix translation errors, grammar, and terminology

### DIFF
--- a/appendices/about.xml
+++ b/appendices/about.xml
@@ -262,7 +262,7 @@ Retourne la taille de la chaîne $string.
   </para>
   <para>
    Cela signifie que cette fonction n'est disponible
-   que depuis PHP 4.3.0.
+   qu'à partir de PHP 4.3.0.
   </para>
  </sect1>
  

--- a/appendices/migration56/constants.xml
+++ b/appendices/migration56/constants.xml
@@ -12,7 +12,7 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     <constant>IMG_WEBP</constant> (depuis PHP 5.6.25)
+     <constant>IMG_WEBP</constant> (à partir de PHP 5.6.25)
     </simpara>
    </listitem>
   </itemizedlist>

--- a/appendices/migration70/incompatible/foreach.xml
+++ b/appendices/migration70/incompatible/foreach.xml
@@ -16,7 +16,7 @@
   <title>&foreach; ne modifie plus le pointeur interne de tableau</title>
 
   <para>
-   Antérieur à PHP 7, le pointeur interne de tableau était modifié pendant
+   Antérieurement à PHP 7, le pointeur interne de tableau était modifié pendant
    qu'un tableau était parcouru avec &foreach;. Cela n'est plus le cas,
    comme le montre l'exemple suivant :
   </para>

--- a/appendices/migration70/incompatible/removed-functions.xml
+++ b/appendices/migration70/incompatible/removed-functions.xml
@@ -33,7 +33,7 @@
  </sect3>
 
  <sect3 xml:id="migration70.incompatible.removed-functions.mcrypt">
-  <title>Alias<link linkend="book.mcrypt">mcrypt</link></title>
+  <title>Alias <link linkend="book.mcrypt">mcrypt</link></title>
 
   <para>
    La fonction obsolète <function>mcrypt_generic_end</function> a été

--- a/appendices/migration71/incompatible.xml
+++ b/appendices/migration71/incompatible.xml
@@ -110,7 +110,7 @@ Warning: Cannot call func_num_args() dynamically in %s on line %d
  </sect2>
 
  <sect2 xml:id="migration71.incompatible.invalid-class-names">
-  <title>Nom de classe, interface, et trait invalide</title>
+  <title>Nom de classe, interface, et trait invalides</title>
 
   <para>
    Les noms suivants ne peuvent pas être utilisés pour nommer des classes, 
@@ -308,8 +308,8 @@ string(11) "          f"
   </title>
 
   <para>
-   L'ordre des éléments dans un tableau a changé lorsque ces éléments ont été 
-   créés automatiquement en les référençant dans une assignation par référence. 
+   L'ordre des éléments dans un tableau a changé lorsqu'ils ont été
+   créés automatiquement en les référençant dans une assignation par référence.
    Par exemple:
   </para>
 
@@ -407,10 +407,10 @@ new DateTime() == new DateTime();
   <title>Conversions des erreurs fatales en exceptions <classname>Error</classname></title>
   <para>
    Dans l'extension date, les données de sérialisation invalides pour les classes 
-   <classname>DateTime</classname> ou <classname>DatePeriod</classname> , ou 
+   <classname>DateTime</classname> ou <classname>DatePeriod</classname>, ou 
    l'échec de l'initialisation du fuseau horaire à partir de données sérialisées, 
    lèveront désormais une exception <classname>Error</classname> à partir de la 
-   méthode <methodname>__wakeup</methodname> ou  <methodname>__set_state</methodname>, 
+   méthode <methodname>__wakeup</methodname> ou <methodname>__set_state</methodname>, 
    au lieu de se traduire par une erreur fatale.
   </para>
 
@@ -427,7 +427,7 @@ new DateTime() == new DateTime();
    résulter en une erreur fatale. De même, la tentative d'inscription d'une 
    classe de nœud qui n'étend pas la classe de base appropriée, ou tente de lire 
    une propriété non valide ou d'écrire dans une propriété en lecture seule, lèvera 
-   également une exception <classname>Error</classname> .
+   également une exception <classname>Error</classname>.
   </para>
 
   <para>
@@ -506,12 +506,12 @@ new DateTime() == new DateTime();
    une exception <classname>ParseError</classname> au lieu d'une erreur fatale 
    capturable si le code PHP n'est pas valide. De même, l'appel à 
    <function>forward_static_call</function> en dehors d'une étendue de classe lève 
-   maintenant une exception <classname>Error</classname> .
+   maintenant une exception <classname>Error</classname>.
   </para>
 
   <para>
    Dans l'extension Tidy, la création manuelle d'un <classname>tidyNode</classname> 
-   lèvera une exception  <classname>Error</classname> au lieu d'une erreur fatale.
+   lèvera une exception <classname>Error</classname> au lieu d'une erreur fatale.
   </para>
 
   <para>

--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -12,9 +12,9 @@
   <para>
    Auparavant, il était possible pour la fonction 
    <function>number_format</function> retourne <literal>-0</literal>. 
-   Bien que cela soit parfaitement valide conformément à la norme "IEEE 754 
-   floating point spécification", cette bizarrerie n'était pas souhaitable 
-   pour l’affichage des nombres mis en forme sous une forme lisible par l'homme.
+   Bien que cela soit parfaitement valide conformément à la spécification
+   IEEE 754 pour les nombres à virgule flottante, cette bizarrerie n’était pas souhaitable
+   pour l’affichage des nombres mis en forme sous une forme lisible par l’homme.
   </para>
 
   <informalexample>
@@ -351,7 +351,7 @@ int(2)
   <title>Cookies entrants</title>
 
   <para>
-   Depuis PHP 7.2.34, les <emphasis>noms</emphasis> des cookies entrants ne sont plus
+   À partir de PHP 7.2.34, les <emphasis>noms</emphasis> des cookies entrants ne sont plus
    url-décodés pour des raisons de sécurité.
   </para>
  </sect2>

--- a/appendices/migration72/new-features.xml
+++ b/appendices/migration72/new-features.xml
@@ -115,9 +115,9 @@ abstract class B extends A
   <title>Extension des types de chaîne <link linkend="book.pdo">PDO</link></title>
 
   <para>
-   Le type de chaîne de PDO a été étendu pour prendre en charge le type de 
-   caractère national lors de l’utilisation des requêtes préparées. Cela a été 
-   fait avec l’une des constantes suivantes :
+   Le type de chaîne de PDO a été étendu pour prendre en charge le type de
+   caractère national lors de l’émulation des requêtes préparées. Cela a été
+   fait avec les constantes suivantes :
   </para>
 
   <itemizedlist>

--- a/appendices/migration72/other-changes.xml
+++ b/appendices/migration72/other-changes.xml
@@ -99,7 +99,7 @@
   <title><function>session_module_name</function></title>
 
   <para>
-   Le passage de <literal> "user"</literal> à 
+   Le passage de <literal>"user"</literal> à 
    <function>session_module_name</function> déclenche maintenant une erreur de 
    niveau <constant>E_RECOVERABLE_ERROR</constant>. Auparavant, cela a été 
    ignoré silencieusement.

--- a/appendices/migration73/deprecated.xml
+++ b/appendices/migration73/deprecated.xml
@@ -37,11 +37,11 @@
    <title>Recherche de chaînes avec Needle non-chaîne</title>
 
    <para>
-    Passer une valeur recherchée qui n'est pas du texte dans les fonctions de 
-    recherche est déconseillé. Dans le futur la valeur recherchée sera interprétée 
-    comme une chaîne en ASCII. Selon le comportement prévu, vous devez soit 
-    explicitement caster la recherche en chaîne soit effectuer un appel explicite à 
-    <function>chr</function>. Les fonctions suivantes sont affectées :
+    Passer une valeur recherchée qui n'est pas du texte dans les fonctions de
+    recherche est déconseillé. Dans le futur la valeur recherchée sera interprétée
+    comme une chaîne au lieu d'un point de code ASCII. Selon le comportement prévu,
+    vous devez soit explicitement caster la recherche en chaîne soit effectuer un
+    appel explicite à <function>chr</function>. Les fonctions suivantes sont affectées :
     <itemizedlist>
      <listitem>
       <simpara><function>strpos</function></simpara>

--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -329,7 +329,7 @@ foo(...gen());
   <title>Cookies entrants</title>
 
   <para>
-   Depuis PHP 7.3.23, les <emphasis>noms</emphasis> des cookies entrants
+   À partir de PHP 7.3.23, les <emphasis>noms</emphasis> des cookies entrants
    ne sont plus url-décodés pour des raisons de sécurité.
   </para>
  </sect2>

--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -50,7 +50,7 @@
   </sect3>
 
   <sect3 xml:id="migration74.incompatible.core.stream-wrappers">
-   <title>Filtres de flux</title>
+   <title>Enveloppes de flux</title>
 
    <para>
     Lors de l'utilisation de include/require sur un flux, 
@@ -324,7 +324,7 @@
   <title>Cookies entrants</title>
 
   <para>
-   Depuis PHP 7.4.11, les <emphasis>noms</emphasis> des cookies entrants ne sont plus
+   À partir de PHP 7.4.11, les <emphasis>noms</emphasis> des cookies entrants ne sont plus
    url-décodés pour des raisons de sécurité.
   </para>
  </sect2>

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -79,7 +79,7 @@ function test(?A $a, $b) {}       // Recommandé
    <listitem>
     <para>
      <function>enchant_broker_free</function> et <function>enchant_broker_free_dict</function> sont
-     obsolètes ; détruissez l'objet à la place.
+     obsolètes ; détruisez l'objet à la place.
     </para>
    </listitem>
    <listitem>

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -794,8 +794,8 @@ $array["key"];
 
   <para>
    Les classes non implémentées de l'extension DOM qui n'avaient pas de comportement et contenaient des données de test
-   ont été supprimées. Ces classes ont également été supprimées dans la dernière version de la norme
-   du standard DOM :
+   ont été supprimées. Ces classes ont également été supprimées dans la dernière version du
+   standard DOM :
   </para>
   <para>
    <simplelist>
@@ -974,7 +974,7 @@ $array["key"];
    </listitem>
    <listitem>
     <para>
-     L'interface de <function>ldap_set_rebind_proc</function> a changée ; le paramètre
+     L'interface de <function>ldap_set_rebind_proc</function> a changé ; le paramètre
      <parameter>callback</parameter> n'accepte plus les chaînes vides ; &null; doit être utilisé
      à la place.
     </para>
@@ -1064,7 +1064,7 @@ $array["key"];
     <para>
      Les alias de codage de caractères <literal>ISO_8859-*</literal> ont été remplacés par
      <literal>ISO8859-*</literal> pour une meilleure interopérabilité avec l'extension iconv. Les alias
-     mbregex ISO 8859 avec des traits de soulignement<literal>(ISO_8859_*</literal> et
+     mbregex ISO 8859 avec des traits de soulignement (<literal>ISO_8859_*</literal> et
      <literal>ISO8859_*</literal>) ont également été supprimés.
     </para>
    </listitem>
@@ -1130,7 +1130,7 @@ $array["key"];
     <para>
      <function>openssl_seal</function> et <function>openssl_open</function> requièrent désormais le paramètre
      <parameter>method</parameter> car l'ancienne valeur par défaut <literal>"RC4"</literal>
-     est considéré comme peu sûr.
+     est considérée comme peu sûre.
     </para>
    </listitem>
   </itemizedlist>
@@ -1268,7 +1268,7 @@ $array["key"];
     <para>
      La méthode <methodname>ReflectionType::__toString</methodname> retourne maintenant une représentation complète de débogage
      du type, et n'est plus dépréciée. En particulier, le résultat inclura un
-     indicateur de nullité pour les types nullables. Le format de la valeur retournée n'est pas stable et peut changer
+     indicateur de nullité pour les types nullables. Le format de la valeur retournée n'est pas stable et peut
      changer d'une version de PHP à l'autre.
     </para>
    </listitem>
@@ -1569,7 +1569,7 @@ echo file_get_contents('http://example.org', false, $ctx);
    </listitem>
    <listitem>
     <para>
-     Sous Windows, les fonctions d'exécution de programmes<function>(proc_open</function>, <function>exec</function>,
+     Sous Windows, les fonctions d'exécution de programmes (<function>proc_open</function>, <function>exec</function>,
      <function>popen</function> etc.) utilisant l'interpréteur de commandes, exécutent désormais systématiquement <command>%comspec% /s
      /c "$commandline"</command>, ce qui a le même effet que l'exécution de
      <command>$commandline</command> (sans les guillemets supplémentaires).
@@ -1625,8 +1625,8 @@ echo file_get_contents('http://example.org', false, $ctx);
    <listitem>
     <para>
      Les noms à espace de nommage sont désormais représentés à l'aide des attributs <constant>T_NAME_QUALIFIED</constant>
-     <code>(Foo\Bar</code>), <constant>T_NAME_FULLY_QUALIFIED</constant><code>(\Foo\Bar</code>) et
-     <constant>T_NAME_RELATIVE</constant><code>(namespace\Foo\Bar</code>).
+     (<code>Foo\Bar</code>), <constant>T_NAME_FULLY_QUALIFIED</constant> (<code>\Foo\Bar</code>) et
+     <constant>T_NAME_RELATIVE</constant> (<code>namespace\Foo\Bar</code>).
      <constant>T_NS_SEPARATOR</constant> n'est utilisé que pour les séparateurs d'espace de noms autonomes, et n'est syntaxiquement 
      valide qu'en conjonction avec les déclarations d'utilisation de groupe.
     <!-- RFC: https://wiki.php.net/rfc/namespaced_names_as_token -->
@@ -1650,7 +1650,6 @@ echo file_get_contents('http://example.org', false, $ctx);
 
   <para>
    L'extension XML-RPC a été déplacée vers PECL et ne fait plus partie de la distribution de PHP.
-   et ne fait plus partie de la distribution de PHP.
   </para>
  </sect2>
 

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -170,7 +170,7 @@ $user = $session->user ?? throw new Exception('Un utilisateur est requis');
     </listitem>
     <listitem>
      <para>
-      Une virguile finale optionnelle est maintenant autorisée dans les listes de paramètres.
+      Une virgule finale optionnelle est maintenant autorisée dans les listes de paramètres.
       <programlisting role="php">
 <![CDATA[
 <?php
@@ -486,7 +486,7 @@ $proc = proc_open($command, [['pty'], ['pty'], ['pty']], $pipes);
    </listitem>
    <listitem>
     <para>
-     <function>proc_open</function> supportent maintenant les descripteurs de paire de socket. Le code suivant attache
+     <function>proc_open</function> supporte maintenant les descripteurs de paire de socket. Le code suivant attache
      une paire de socket distincte à <literal>stdin</literal>, <literal>stdout</literal> et
      <literal>stderr</literal> :
     </para>

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -171,7 +171,7 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
     <para>
      Les fonctions <link linkend="book.ldap">LDAP</link> acceptent et retournent désormais
      des objets <classname>LDAP\Connection</classname> au lieu
-     de &resource;s <literal>ldap</literal>.
+     de &resource;s <literal>ldap link</literal>.
     </para>
    </listitem>
    <listitem>
@@ -273,7 +273,7 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
   <title>MySQLnd</title>
 
   <para>
-   La directive INIT <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.fetch_data_copy</link>
+   La directive INI <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.fetch_data_copy</link>
    a été enlevée.
    Cela ne devrait pas entraîner de changements de comportement visibles pour l'utilisateur.
   </para>
@@ -304,9 +304,9 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
   </para>
   <para>
    Appeler <methodname>PDOStatement::bindColumn</methodname> avec
-   <constant>PDO::PARAM_LOB</constant> liera désormais constamment un stream
+   <constant>PDO::PARAM_LOB</constant> liera désormais constamment un flux
    de résultat lorsqu'<constant>PDO::ATTR_STRINGIFY_FETCHES</constant> n'est pas activé.
-   Précédemment, le résultat était soit un stream, soit une chaîne en fonction du
+   Précédemment, le résultat était soit un flux, soit une chaîne en fonction du
    pilote de base de données utilisé et du moment où la liaison est effectuée.
   </para>
 

--- a/appendices/migration81/new-functions.xml
+++ b/appendices/migration81/new-functions.xml
@@ -119,7 +119,7 @@
    <title>Ristretto255</title>
 
    <para>
-    Les fonctions Ristretto255 sont disponibles depuis libsodium 1.0.18.
+    Les fonctions Ristretto255 sont disponibles à partir de libsodium 1.0.18.
    </para>
 
    <itemizedlist>

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration81.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Autre changements</title>
+ <title>Autres changements</title>
 
  <sect2 xml:id="migration81.other-changes.sapi">
   <title>Changement dans les modules SAPI</title>
@@ -23,7 +23,7 @@
    <title>PHPDBG</title>
 
    <para>
-    Les fonctionnalités distantes de <link linkend="book.phpdbg">phpdbg</link> ont été enlèvées.
+    Les fonctionnalités distantes de <link linkend="book.phpdbg">phpdbg</link> ont été enlevées.
    </para>
   </sect3>
  </sect2>
@@ -156,7 +156,7 @@
     </listitem>
     <listitem>
      <para>
-      Ajout du support pour les signatures OpenSSL_SHA256 and OpenSSL_SHA512.
+      Ajout du support pour les signatures OpenSSL_SHA256 et OpenSSL_SHA512.
      </para>
     </listitem>
    </itemizedlist>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -147,7 +147,7 @@
     <classname>Spoofchecker</classname>,
     <classname>IntlTimeZone</classname>,
     et <classname>Transliterator</classname>
-    ne sont plus sérialisables. Auparavant, elles pouvaient être sérialisés, mais
+    ne sont plus sérialisables. Auparavant, elles pouvaient être sérialisées, mais
     la désérialisation produisait des objets inutilisables ou échouait.
    </para>
   </sect3>

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -8,7 +8,7 @@
   <title>PHP Core</title>
 
   <sect3 xml:id="migration83.deprecated.core.saner-inc-dec-operators">
-   <title>Opérateurs incrémentation/décrémentation plus sain</title>
+   <title>Opérateurs incrémentation/décrémentation plus sains</title>
 
    <para>
     L'utilisation de l'opérateur d'<link linkend="language.operators.increment">incrémentation</link>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -5,7 +5,7 @@
  <title>Autres changements</title>
 
  <sect2 xml:id="migration83.other-changes.core">
-  <title>Core changes</title>
+  <title>Changements du cœur</title>
 
   <sect3 xml:id="migration83.other-changes.core.ffi">
    <title>FFI</title>
@@ -150,7 +150,7 @@
     <function>curl_getinfo</function> supporte désormais deux nouvelles constantes :
     <constant>CURLINFO_CAPATH</constant> et
     <constant>CURLINFO_CAINFO</constant>. Si option est &null;, les deux clés
-    suivant sont présentes :
+    suivantes sont présentes :
     <literal>"capath"</literal> et <literal>"cainfo"</literal>.
    </para>
   </sect3>
@@ -233,7 +233,7 @@
    </para>
 
    <para>
-    Dans de rare cas, <function>mb_encode_mimeheader</function> va encoder
+    Dans de rares cas, <function>mb_encode_mimeheader</function> va encoder
     sa chaîne de caractères d'entrée là où elle la passerait en ASCII brut en PHP 8.2.
    </para>
 
@@ -374,7 +374,7 @@
    </para>
 
    <para>
-    <function>password_hash</function> chaîne désormais l'exception sous-jacente
+    <function>password_hash</function> enchaîne désormais l'exception sous-jacente
     <classname>Random\RandomException</classname>
     dans la <parameter>$previous</parameter> <classname>Exception</classname>
     de <classname>ValueError</classname> lorsque la génération de sel échoue.

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -236,7 +236,7 @@
      <member><function>textdomain</function></member>
      <member><function>d<replaceable>*</replaceable>gettext</function></member>
     </simplelist>
-    lance désormais une <exceptionname>ValueError</exceptionname> si un
+    lancent désormais une <exceptionname>ValueError</exceptionname> si le
     <parameter>domain</parameter> est la chaîne vide.
    </para>
   </sect3>
@@ -494,7 +494,7 @@
 
   <simpara>
    Auparavant, les objets <classname>DOMXPath</classname> pouvaient être clonés,
-   mais en résultaient en un objet inutilisable.
+   mais cela résultait en un objet inutilisable.
    Cela n'est plus possible, et cloner un objet <classname>DOMXPath</classname>
    lance désormais une <exceptionname>Error</exceptionname>.
   </simpara>
@@ -810,7 +810,7 @@ nodeData: 3
   <title>Tidy</title>
 
   <simpara>
-   Les echecs dans le constructeur lancent désormais des exceptions plutôt que
+   Les échecs dans le constructeur lancent désormais des exceptions plutôt que
    d'émettre des alertes et d'avoir un objet cassé.
   </simpara>
  </sect2>

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -237,7 +237,7 @@ $object = $reflector->newLazyGhost($initializer);
    avec l'objet <classname>CurlHandle</classname>,
    un entier contenant le type de message de débogage,
    et une chaîne contenant le message de débogage.
-   Le type de message de débogage est l'un des constantes suivantes:
+   Le type de message de débogage est l'une des constantes suivantes :
    <simplelist>
     <member><constant>CURLINFO_TEXT</constant></member>
     <member><constant>CURLINFO_HEADER_IN</constant></member>
@@ -322,7 +322,7 @@ $object = $reflector->newLazyGhost($initializer);
   </simpara>
 
   <simpara>
-   Implementation de PASSWORD_ARGON2 hashage de mot de passe.
+   Implémentation du hachage de mot de passe PASSWORD_ARGON2.
    Requiert OpenSSL 3.2 et une construction NTS.
   </simpara>
  </sect2>

--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -636,7 +636,7 @@
     Augmentation de la performance de l'analyse et de la génération de nombres à virgule flottante
     dans les constructions ZTS sous des charges très concurrentes.
     Cela affecte les fonctions <function>printf</function> ainsi
-    que les fonctions de sérialisation tel que <function>json_encode</function>
+    que les fonctions de sérialisation telles que <function>json_encode</function>
     ou <function>serialize</function>.
    </simpara>
 
@@ -716,7 +716,7 @@
    <title>MySQLnd</title>
 
    <simpara>
-    Augmentation de la performance de la cotation MySQLnd.
+    Augmentation de la performance de l'échappement MySQLnd.
    </simpara>
   </sect3>
 

--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -372,7 +372,7 @@
    </term>
    <listitem>
     <simpara>
-     Le répertoire par défaut où chercher pour des extensions chargeable
+     Le répertoire par défaut où chercher pour des extensions chargeables
      dynamiquement (sauf outrepassé par
      <link linkend="ini.extension-dir">extension_dir</link>).
      Par défaut <constant>PHP_PREFIX</constant> (ou <code>PHP_PREFIX . "\\ext"</code> sur Windows).

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -425,7 +425,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-global">
      <entry><constant>T_GLOBAL</constant></entry>
      <entry>global</entry>
-     <entry><link linkend="language.variables.scope">scope de variable</link></entry>
+     <entry><link linkend="language.variables.scope">portée de variable</link></entry>
     </row>
     <row xml:id="constant.t-goto">
      <entry><constant>T_GOTO</constant></entry>
@@ -796,7 +796,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-static">
      <entry><constant>T_STATIC</constant></entry>
      <entry>static</entry>
-     <entry><link linkend="language.variables.scope">scope de variable</link></entry>
+     <entry><link linkend="language.variables.scope">portée de variable</link></entry>
     </row>
     <row xml:id="constant.t-string">
      <entry><constant>T_STRING</constant></entry>
@@ -857,7 +857,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-use">
      <entry><constant>T_USE</constant></entry>
      <entry>use</entry>
-     <entry><link linkend="language.namespaces">namespaces</link></entry>
+     <entry><link linkend="language.namespaces">espaces de noms</link></entry>
     </row>
     <row xml:id="constant.t-var">
      <entry><constant>T_VAR</constant></entry>


### PR DESCRIPTION
Fix translation errors across 25 appendices/ XML files (migration guides, tokens, constants, about).

- Fix terminology: depuis→à partir de, scope→portée, stream→flux, wrapper→enveloppe
- Fix grammar: accords genre/nombre, conjugaisons, espaces en trop, doublons
- Fix residual English (untranslated titles, operators)
- Fix incorrect translations (cotation→échappement, filtres→enveloppes de flux)
- Remove duplicate content