### PR TITLE
reference/image: fix grammar, terminology, and content alignment

### DIFF
--- a/reference/image/configure.xml
+++ b/reference/image/configure.xml
@@ -66,9 +66,9 @@
        <option role="configure">--with-zlib-dir[=DIR]</option> dans votre ligne
        de compilation.
        À partir de PHP 7.4.0, <option role="configure">--with-png-dir</option>
-       et <option role="configure">--with-zlib-dir</option> ont été supprimée.
+       et <option role="configure">--with-zlib-dir</option> ont été supprimées.
        <productname>libpng</productname> et <productname>zlib</productname>
-       sont nécessaire.
+       sont nécessaires.
       </entry>
      </row>
      <row>
@@ -130,7 +130,7 @@
        Pour activer le support des chaînes de caractères TrueType, 
        ajoutez l'option 
        <option role="configure">--enable-gd-native-ttf</option>.
-       (Cette option n'a aucun effet et a été supprimée depuis PHP 7.2.0.)
+       (Cette option n'a aucun effet et a été supprimée à partir de PHP 7.2.0.)
       </entry>
      </row>
     </tbody>

--- a/reference/image/constants.xml
+++ b/reference/image/constants.xml
@@ -25,7 +25,7 @@
    </term>
    <listitem>
     <simpara>
-     La version majeur GD de PHP.
+     La version majeure GD de PHP.
     </simpara>
    </listitem>
   </varlistentry>
@@ -126,7 +126,7 @@
     &gd.constants.types;
     <note>
      <para>
-      Cette constante à la même valeur que <constant>IMG_JPG</constant>
+      Cette constante a la même valeur que <constant>IMG_JPG</constant>
      </para>
     </note>
    </listitem>
@@ -292,7 +292,7 @@
     &gd.constants.arc;
     <note>
      <para>
-      Cette constante à la même valeur que <constant>IMG_ARC_PIE</constant>
+      Cette constante a la même valeur que <constant>IMG_ARC_PIE</constant>
      </para>
     </note>
    </listitem>

--- a/reference/image/functions/gd-info.xml
+++ b/reference/image/functions/gd-info.xml
@@ -123,7 +123,7 @@ var_dump(gd_info());
     &example.outputs.similar;
     <screen>
 <![CDATA[
-array(9) {
+array(10) {
   ["GD Version"]=>
   string(24) "bundled (2.1.0 compatible)"
   ["FreeType Support"]=>

--- a/reference/image/functions/image2wbmp.xml
+++ b/reference/image/functions/image2wbmp.xml
@@ -50,8 +50,8 @@
      <term><parameter>foreground</parameter></term>
      <listitem>
       <para>
-       La couleur du premier plan peut être définit avec ce paramètre en
-       fournissant un idantifiant obtenu avec <function>imagecolorallocate</function>.
+       La couleur du premier plan peut être définie avec ce paramètre en
+       fournissant un identifiant obtenu avec <function>imagecolorallocate</function>.
        La couleur du premier plan par défaut est noir.
       </para>
      </listitem>

--- a/reference/image/functions/imagearc.xml
+++ b/reference/image/functions/imagearc.xml
@@ -75,7 +75,7 @@
       <para>
        L'angle de fin de l'ellipse, en degrés.
        0° correspond à la position "trois heures" et l'ellipse est
-       dessiné dans le sens des aiguilles d'une montre.
+       dessinée dans le sens des aiguilles d'une montre.
       </para>
      </listitem>
     </varlistentry>
@@ -118,7 +118,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Dessine d'un cercle avec <function>imagearc</function></title>
+    <title>Dessin d'un cercle avec <function>imagearc</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -149,7 +149,7 @@ imagepng($img);
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Affichage de l'exemple : Desinne un cercle avec imagearc()</alt>
+     <alt>Affichage de l'exemple : Dessin d'un cercle avec imagearc()</alt>
      <imageobject>
       <imagedata fileref="en/reference/image/figures/imagearc.png"/>
      </imageobject>

--- a/reference/image/functions/imagebmp.xml
+++ b/reference/image/functions/imagebmp.xml
@@ -42,7 +42,7 @@
      <term><parameter>compressed</parameter></term>
      <listitem>
       <para>
-       Si le BMP doit être compréssé avec <literal>run-length encoding</literal> (RLE), ou pas.
+       Si le BMP doit être compressé avec <literal>run-length encoding</literal> (RLE), ou pas.
       </para>
      </listitem>
     </varlistentry>
@@ -97,7 +97,7 @@ $text_color = imagecolorallocate($im, 233, 14, 91);
 
 imagestring($im, 1, 5, 5,  'BMP with PHP', $text_color);
 
-// Save the image
+// Enregistre l'image
 imagebmp($im, 'php.bmp');
 ?>
 ]]>

--- a/reference/image/functions/imagecolorallocatealpha.xml
+++ b/reference/image/functions/imagecolorallocatealpha.xml
@@ -123,7 +123,7 @@ imagefilledellipse($image, $blue_x, $blue_y, $radius, $radius, $blue);
 // Ne pas oublier d'envoyer un header correct
 header('Content-Type: image/png');
 
-// et finallement, afficher le résultat
+// et finalement, afficher le résultat
 imagepng($image);
 ?>
 ]]>
@@ -144,9 +144,9 @@ imagepng($image);
    </title>
    <para>
     Généralement les valeurs alpha <literal>0</literal> désignent les pixels
-    complètement transparant, et le canal alpha a 8 bits. Pour convertir de
-    telle valeurs alpha pour être compatible avec
-    <function>imagecolorallocatealpha</function>, un peu d'arithmetique simple
+    complètement transparent, et le canal alpha a 8 bits. Pour convertir de
+    telles valeurs alpha pour être compatible avec
+    <function>imagecolorallocatealpha</function>, un peu d'arithmétique simple
     est suffisante :
    </para>
    <programlisting role="php">

--- a/reference/image/functions/imagecolorclosestalpha.xml
+++ b/reference/image/functions/imagecolorclosestalpha.xml
@@ -79,7 +79,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// On commence avec une image et on la convertie en palette
+// On commence avec une image et on la convertit en palette
 $im = imagecreatefrompng('figures/imagecolorclosest.png');
 imagetruecolortopalette($im, false, 255);
 

--- a/reference/image/functions/imagecreatefrombmp.xml
+++ b/reference/image/functions/imagecreatefrombmp.xml
@@ -74,10 +74,10 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Load the BMP file
+// Charge le fichier BMP
 $im = imagecreatefrombmp('./example.bmp');
 
-// Le convertit en fichier PNG avec les paramètres par défault
+// Le convertit en fichier PNG avec les paramètres par défaut
 imagepng($im, './example.png');
 ?>
 ]]>

--- a/reference/image/functions/imagecreatefromstring.xml
+++ b/reference/image/functions/imagecreatefromstring.xml
@@ -73,7 +73,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       WEBP est désormais supporté (si supporté par la libgd utilisé).
+       WEBP est désormais supporté (si supporté par la libgd utilisée).
       </entry>
      </row>
     </tbody>

--- a/reference/image/functions/imagecrop.xml
+++ b/reference/image/functions/imagecrop.xml
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne l'objet' de l'image recadrée en cas de
+   Retourne l'objet de l'image recadrée en cas de
    succès&return.falseforfailure;.
   </para>
  </refsect1>

--- a/reference/image/functions/imagecropauto.xml
+++ b/reference/image/functions/imagecropauto.xml
@@ -37,9 +37,9 @@
        <listitem>
         <simpara>
          Identique à <constant>IMG_CROP_TRANSPARENT</constant>.
-         Antérieur à PHP 7.4.0, la bibliothèque libgd intégré utilisait
-         <constant>IMG_CROP_SIDES</constant> en tant que solution de replis,
-         si l'image n'avait pas de couleur de transparance.
+         Antérieur à PHP 7.4.0, la bibliothèque libgd intégrée utilisait
+         <constant>IMG_CROP_SIDES</constant> en tant que solution de repli,
+         si l'image n'avait pas de couleur de transparence.
         </simpara>
        </listitem>
       </varlistentry>
@@ -103,7 +103,7 @@
      </para>
      <note>
       <simpara>
-       Antérieur à PHP 7.4.0, la bibliothèque libgd intégré utilisait un algorithme
+       Antérieur à PHP 7.4.0, la bibliothèque libgd intégrée utilisait un algorithme
        quelque peu différent, donc le même <parameter>threshold</parameter> produisait
        des résultats différents pour libgd système et intégré.
       </simpara>
@@ -155,16 +155,16 @@
      <row>
       <entry>7.4.0</entry>
       <entry>
-       Le comportement de imagecropauto de la bibliothèque libgd intégré a été
+       Le comportement de imagecropauto de la bibliothèque libgd intégrée a été
        synchronisé avec celle de libgd système : <constant>IMG_CROP_DEFAULT</constant>
-       n'utilise plus <constant>IMG_CROP_SIDES</constant> comme solution de replis et
+       n'utilise plus <constant>IMG_CROP_SIDES</constant> comme solution de repli et
        la tolérance de rognage utilise désormais le même algorithme que libgd système.     
       </entry>
      </row>
      <row>
       <entry>7.4.0</entry>
       <entry>
-       La valeur par défaut de <parameter>mode</parameter> a été modifié en
+       La valeur par défaut de <parameter>mode</parameter> a été modifiée en
        <constant>IMG_CROP_AUTO</constant>. Auparavant, la valeur par défaut était
        <literal>-1</literal> qui correspond à <constant>IMG_CROP_DEFAULT</constant>,
        mais passer <literal>-1</literal> est désormais obsolète.
@@ -179,7 +179,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Rognage automatique correcte</title>
+    <title>Rognage automatique correct</title>
     <para>
      Comme indiqué dans la section valeur de retour, <function>imagecropauto</function>
      retourne &false; si l'image entière a été rognée. Dans cet exemple, nous 
@@ -191,7 +191,7 @@
 <![CDATA[
 <?php
 $cropped = imagecropauto($im, IMG_CROP_DEFAULT);
-if ($cropped !== false) { // Si un nouveau objet d'image a été retournée
+if ($cropped !== false) { // Si un nouvel objet d'image a été retourné
     $im = $cropped;       // et assigne l'image rognée à $im
 }
 ?>

--- a/reference/image/functions/imagegd.xml
+++ b/reference/image/functions/imagegd.xml
@@ -120,7 +120,7 @@ imagegd($im, 'simple.gd');
   <note>
    <para>
     Le format GD est communément utilisé pour autoriser le chargement
-    rapide des parties d'un image. Notez que le format GD est uniquement
+    rapide des parties d'une image. Notez que le format GD est uniquement
     utilisable dans les applications compatibles GD.
    </para>
   </note>

--- a/reference/image/functions/imagegif.xml
+++ b/reference/image/functions/imagegif.xml
@@ -174,7 +174,7 @@ else
     Vous pouvez utiliser la 
     fonction <function>imagetypes</function> au lieu de
     <function>function_exists</function> pour vérifier la
-    présence des différents formats d'images supportés.:
+    présence des différents formats d'images supportés :
     <informalexample>
      <programlisting role="php">
 <![CDATA[

--- a/reference/image/functions/imagelayereffect.xml
+++ b/reference/image/functions/imagelayereffect.xml
@@ -128,7 +128,7 @@ imagefilledrectangle($im, 0, 0, 100, 100, imagecolorallocate($im, 220, 220, 220)
 // Applique l'overlay
 imagelayereffect($im, IMG_EFFECT_OVERLAY);
 
-// Dessine 2 élipses grises
+// Dessine 2 ellipses grises
 imagefilledellipse($im, 50, 50, 40, 40, imagecolorallocate($im, 100, 255, 100));
 imagefilledellipse($im, 50, 50, 50, 80, imagecolorallocate($im, 100, 100, 255));
 imagefilledellipse($im, 50, 50, 80, 50, imagecolorallocate($im, 255, 100, 100));

--- a/reference/image/functions/imagepng.xml
+++ b/reference/image/functions/imagepng.xml
@@ -43,7 +43,7 @@
      <term><parameter>quality</parameter></term>
      <listitem>
       <para>
-       Degré de compression : depuis 0 (aucune compression) à 9.
+       Degré de compression : de 0 (aucune compression) à 9.
        La valeur par défaut (<literal>-1</literal>) utilise la compression par défaut de zlib.
        Pour plus d'informations voir le <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.zlib.manual;">manuel zlib</link>.
       </para>

--- a/reference/image/functions/imagesetinterpolation.xml
+++ b/reference/image/functions/imagesetinterpolation.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Définit la méthode d'interpolation ; le fait de définir une méthode d'interpolation
-   affecte le rendu de plusieurs fonctions en GD, comme par exemple la fonction
+   affecte le rendu de plusieurs fonctions en GD, par exemple la fonction
    <function>imagerotate</function>.
   </para>
  </refsect1>

--- a/reference/image/functions/imagettftext.xml
+++ b/reference/image/functions/imagettftext.xml
@@ -198,7 +198,7 @@ imagettftext($im, 20, 0, 11, 21, $grey, $font, $text);
 // Ajout du texte
 imagettftext($im, 20, 0, 10, 20, $black, $font, $text);
 
-// Utiliser imagepng() donnera un texte plus claire,
+// Utiliser imagepng() donnera un texte plus clair,
 // comparé à l'utilisation de la fonction imagejpeg()
 imagepng($im);
 

--- a/reference/image/setup.xml
+++ b/reference/image/setup.xml
@@ -123,12 +123,12 @@
      <tbody>
       <row>
        <entry><literal>gd</literal></entry>
-       <entry>Ressource Image, utilisé par des fonctions comme <function>imagecreatefrompng</function></entry>
+       <entry>Ressource Image, utilisée par des fonctions comme <function>imagecreatefrompng</function></entry>
        <entry>Antérieur à PHP 8.0.0</entry>
       </row>
       <row>
        <entry><literal>gd font</literal></entry>
-       <entry>Ressource Police créé en interne par <function>imageloadfont</function></entry>
+       <entry>Ressource Police créée en interne par <function>imageloadfont</function></entry>
        <entry>Antérieur à PHP 8.1.0</entry>
       </row>
      </tbody>


### PR DESCRIPTION
Fix grammar, terminology across 19 image/ files.