### PR TITLE
reference/mbstring: fix grammar, spelling, terminology, and residual English

### DIFF
--- a/reference/mbstring/constants.xml
+++ b/reference/mbstring/constants.xml
@@ -92,7 +92,7 @@
      dues à la casse dans la chaîne. Ceci est utilisé pour réaliser des
      correspondances insensibles à la casse. Ceci peut modifier
      la longueur de la chaîne.
-     Disponible depuis PHP 7.3.
+     Disponible à partir de PHP 7.3.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/mbstring/encoding-requirements.xml
+++ b/reference/mbstring/encoding-requirements.xml
@@ -82,7 +82,7 @@ JIS, SJIS, ISO-2022-JP, BIG-5
    mais aussi les performances.
   </para>
   <para>
-   Si vous utilisez PostGreSQL, le jeu de caractères utilisé dans la base
+   Si vous utilisez PostgreSQL, le jeu de caractères utilisé dans la base
    de données et celui de PHP peuvent différer car cette base supporte
    la traduction automatique de jeu de caractères.
   </para>

--- a/reference/mbstring/functions/mb-check-encoding.xml
+++ b/reference/mbstring/functions/mb-check-encoding.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.mb-check-encoding" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_check_encoding</refname>
-  <refpurpose>Vérifie si les chaînes sont valide pour l'encodage spécifié</refpurpose>
+  <refpurpose>Vérifie si les chaînes sont valides pour l'encodage spécifié</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -36,7 +36,7 @@
      <term><parameter>map</parameter></term>
      <listitem>
       <para>
-       <parameter>map</parameter>est un tableau qui spécifie les
+       <parameter>map</parameter> est un tableau qui spécifie les
        codes à convertir.
       </para>
      </listitem>

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -20,7 +20,7 @@
    <parameter>string</parameter> depuis une liste de candidats.
   </para>
   <para>
-   Depuis PHP 8.1, cette fonction utilise des heuristiques pour détecter lequel des encodages de texte valides dans la liste spécifiée
+   À partir de PHP 8.1, cette fonction utilise des heuristiques pour détecter lequel des encodages de texte valides dans la liste spécifiée
    est le plus susceptible d'être correct et peut ne pas être dans l'ordre des <parameter>encodings</parameter> fournis.
   </para>
   <para>

--- a/reference/mbstring/functions/mb-detect-order.xml
+++ b/reference/mbstring/functions/mb-detect-order.xml
@@ -125,7 +125,7 @@ echo implode(", ", mb_detect_order());
 ; Toujours détecté comme ISO-8859-1
 detect_order = ISO-8859-1, UTF-8
 
-; Toujours détecté comme UTF-8, depuis que les valeurs ASCII/UTF-7
+; Toujours détecté comme UTF-8, car les valeurs ASCII/UTF-7
 ; sont valides pour UTF-8
 detect_order = UTF-8, ASCII, UTF-7
 ]]>

--- a/reference/mbstring/functions/mb-encode-numericentity.xml
+++ b/reference/mbstring/functions/mb-encode-numericentity.xml
@@ -53,7 +53,7 @@
      <term><parameter>hex</parameter></term>
      <listitem>
       <para>
-       Si l'entité de référence retourné devrait être en notation hexadécimale
+       Si l'entité de référence retournée devrait être en notation hexadécimale
        (sinon il est en notation décimale).
       </para>
      </listitem>

--- a/reference/mbstring/functions/mb-ereg-match.xml
+++ b/reference/mbstring/functions/mb-ereg-match.xml
@@ -82,7 +82,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>options</parameter> is nullable now.
+       <parameter>options</parameter> est désormais nullable.
       </entry>
      </row>
     </tbody>

--- a/reference/mbstring/functions/mb-ereg-replace-callback.xml
+++ b/reference/mbstring/functions/mb-ereg-replace-callback.xml
@@ -42,7 +42,7 @@
        L'expression régulière.
       </para>
       <para>
-       Les caractères multi octets peuvent être utilisé dans le <parameter>pattern</parameter>.
+       Les caractères multi octets peuvent être utilisés dans le <parameter>pattern</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -51,7 +51,7 @@
      <listitem>
       <para>
         Un callback qui sera appelé et lui sera passé un tableau d'éléments correspondants 
-        dans la chaîne de caractères <parameter>string</parameter>. Le callback doit retourné
+        dans la chaîne de caractères <parameter>string</parameter>. Le callback doit retourner
         la chaîne remplacée.
       </para>
       <para>
@@ -60,10 +60,10 @@
         Dans ce cas vous pouvez utiliser les
         <link linkend="functions.anonymous">fonctions anonymes</link> pour 
         déclarer une fonction de rappel lors de l'appel de la fonction
-        <function>mb_ereg_replace_callback</function>. En faisait cela de cette manière
+        <function>mb_ereg_replace_callback</function>. En faisant cela de cette manière
         vous avez toutes les informations nécessaires à l'appel de la fonction
         en un seul endroit, ce qui permet d'éviter d'encombrer l'espace de noms
-        des fonctions avec un callback de fonction qui n'est pas utilisé ailleur.
+        des fonctions avec un callback de fonction qui n'est pas utilisé ailleurs.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-ereg.xml
+++ b/reference/mbstring/functions/mb-ereg.xml
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne si une correspondence de <parameter>pattern</parameter> a été trouvé
+   Retourne si une correspondance de <parameter>pattern</parameter> a été trouvée
    dans <parameter>string</parameter>.
   </para>
  </refsect1>
@@ -88,10 +88,10 @@
       <entry>8.0.0</entry>
       <entry>
        Cette fonction retourne désormais &true; en cas de succès.
-       Auparavant, elle retournait la longueur d'octet de la chaîne trouvé, si une correspondence
-       pour <parameter>pattern</parameter> était trouvé dans <parameter>string</parameter> et
-       que <parameter>matches</parameter> était fournis.
-       Si la paramètre optionnel <parameter>matches</parameter> n'était pas fournis ou que la
+       Auparavant, elle retournait la longueur d'octet de la chaîne trouvée, si une correspondance
+       pour <parameter>pattern</parameter> était trouvée dans <parameter>string</parameter> et
+       que <parameter>matches</parameter> était fourni.
+       Si le paramètre optionnel <parameter>matches</parameter> n'était pas fourni ou que la
        longueur de la chaîne correspondante était <literal>0</literal>, cette fonction retournait <literal>1</literal>.
       </entry>
      </row>

--- a/reference/mbstring/functions/mb-eregi.xml
+++ b/reference/mbstring/functions/mb-eregi.xml
@@ -70,7 +70,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne si une correspondence de <parameter>pattern</parameter> a été trouvé
+   Retourne si une correspondance de <parameter>pattern</parameter> a été trouvée
    dans <parameter>string</parameter>.
   </para>
  </refsect1>
@@ -90,10 +90,10 @@
       <entry>8.0.0</entry>
       <entry>
        Cette fonction retourne désormais &true; en cas de succès.
-       Auparavant, elle retournait la longueur d'octet de la chaîne trouvé, si une correspondence
-       pour <parameter>pattern</parameter> était trouvé dans <parameter>string</parameter> et
-       que <parameter>matches</parameter> était fournis.
-       Si la paramètre optionnel <parameter>matches</parameter> n'était pas fournis ou que la
+       Auparavant, elle retournait la longueur d'octet de la chaîne trouvée, si une correspondance
+       pour <parameter>pattern</parameter> était trouvée dans <parameter>string</parameter> et
+       que <parameter>matches</parameter> était fourni.
+       Si le paramètre optionnel <parameter>matches</parameter> n'était pas fourni ou que la
        longueur de la chaîne correspondante était <literal>0</literal>, cette fonction retournait <literal>1</literal>.
       </entry>
      </row>

--- a/reference/mbstring/functions/mb-get-info.xml
+++ b/reference/mbstring/functions/mb-get-info.xml
@@ -30,7 +30,6 @@
       <para>
        Si <parameter>type</parameter> n'est pas demandé explicitement, ou s'il vaut
        <literal>"all"</literal>,
-       <literal>"all"</literal>,
        <literal>"internal_encoding"</literal>, <literal>"http_input"</literal>,
        <literal>"http_output"</literal>, <literal>"http_output_conv_mimetypes"</literal>,
        <literal>"mail_charset"</literal>, <literal>"mail_header_encoding"</literal>,
@@ -81,7 +80,7 @@
       <entry>8.0.0</entry>
       <entry>
        Les <parameter>type</parameter>s <literal>"func_overload"</literal>
-       et <literal>"func_overload_list"</literal> ne sont désormais plus supporté.
+       et <literal>"func_overload_list"</literal> ne sont désormais plus supportés.
       </entry>
      </row>
     </tbody>

--- a/reference/mbstring/functions/mb-internal-encoding.xml
+++ b/reference/mbstring/functions/mb-internal-encoding.xml
@@ -56,7 +56,7 @@
   <para>
    À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si la valeur
    de <parameter>encoding</parameter> est un encodage invalide.
-   Antérieur à PHP 8.0.0, une <constant>E_WARNING</constant> était émise à la place.
+   Antérieurement à PHP 8.0.0, une <constant>E_WARNING</constant> était émise à la place.
   </para>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-language.xml
+++ b/reference/mbstring/functions/mb-language.xml
@@ -28,7 +28,7 @@
      <listitem>
       <para>
        Utilisé pour encoder les courriels électroniques.
-       Les langages valides sont énuméré dans le tableau suivant.
+       Les langages valides sont énumérés dans le tableau suivant.
        <function>mb_send_mail</function> utilise cette option pour encoder
        les e-mails.
       </para>

--- a/reference/mbstring/functions/mb-regex-set-options.xml
+++ b/reference/mbstring/functions/mb-regex-set-options.xml
@@ -154,7 +154,7 @@
   <para>
    Les options précédentes. Si le paramètre <parameter>options</parameter>
    est omis ou &null;, une chaîne de caractères décrivant les options courantes
-   sera retourné.
+   sera retournée.
   </para>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-scrub.xml
+++ b/reference/mbstring/functions/mb-scrub.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.mb-scrub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_scrub</refname>
-  <refpurpose>Remplacez les séquences d'octets mal formées par le caractère de substitution.</refpurpose>
+  <refpurpose>Remplace les séquences d'octets mal formées par le caractère de substitution.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Effectuez une conversion de jeu de caractères depuis l'encodage spécifié, ou depuis l'encodage par défaut si aucun
+   Effectue une conversion de jeu de caractères depuis l'encodage spécifié, ou depuis l'encodage par défaut si aucun
    encodage n'a été spécifié, vers le même encodage. Cela a pour effet de remplacer toute séquence d'octets invalide
    par le caractère de substitution.   
   </para>

--- a/reference/mbstring/functions/mb-send-mail.xml
+++ b/reference/mbstring/functions/mb-send-mail.xml
@@ -81,7 +81,7 @@
         par défaut dans le &php.ini;.
        </para>
        <para>
-        Si vous ne le faîtes pas, une erreur similaire à :
+        Si vous ne le faites pas, une erreur similaire à :
         <literal>Warning: mail(): "sendmail_from" not
         set in php.ini or custom "From:" header missing</literal> sera émise.
         L'en-tête <literal>From</literal> définie également
@@ -95,7 +95,7 @@
         <link xlink:href="&url.qmail;">qmail</link>) remplace un LF par
         un CRLF automatiquement (ce qui résulte en un doublement du CR si
         CRLF est utilisé). Vous devez tenter cette correction en dernier recourt,
-        sachant qu'elle ne respecte pas la
+        sachant que cela ne respecte pas la
         <link xlink:href="&url.rfc;2822">RFC 2822</link>.
        </para>
       </note>
@@ -117,7 +117,7 @@
        raisons de sécurité, ce paramètre doit être validé.
       </para>
       <para>
-       Depuis que la fonction <function>escapeshellcmd</function> est appliquée automatiquement en
+       Étant donné que la fonction <function>escapeshellcmd</function> est appliquée automatiquement en
        interne, quelques caractères autorisés dans les adresses mails par les RFCs d'internet
        ne peuvent plus être utilisés. Les programmes qui doivent utiliser ces caractères,
        la fonction <function>mail</function> ne peut plus être utilisée.

--- a/reference/mbstring/functions/mb-str-pad.xml
+++ b/reference/mbstring/functions/mb-str-pad.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    Cette fonction renvoie le <parameter>string</parameter>
-   remplit sur la gauche, la droite, ou les deux côtés à la longueur de
+   rempli sur la gauche, la droite, ou les deux côtés à la longueur de
    remplissage spécifiée, où la longueur est mesurée en points de code Unicode. Si l'argument optionnel
    <parameter>pad_string</parameter> n'est pas fourni, le
    <parameter>string</parameter> est rempli avec des espaces, sinon il
@@ -95,7 +95,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>mb_str_pad</function> example</title>
+    <title>Exemple avec <function>mb_str_pad</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -77,7 +77,7 @@
        Cependant, si le nombre négatif passé au paramètre
        <parameter>length</parameter> est plus grand que le nombre de caractères
        après la position <parameter>start</parameter>, une chaîne vide sera
-       retourné.
+       retournée.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-strripos.xml
+++ b/reference/mbstring/functions/mb-strripos.xml
@@ -20,7 +20,7 @@
    <function>strripos</function> basée sur le nombre de caractères.
    La position <parameter>needle</parameter> est comptée depuis le début de
    <parameter>haystack</parameter>. La position du premier caractère est 0.
-   Le second a comme position 1, etc..
+   Le second a comme position 1, etc.
    Contrairement à <function>mb_strrpos</function>,
    <function>mb_strripos</function> n'est pas sensible à la casse.
   </para>

--- a/reference/mbstring/functions/mb-trim.xml
+++ b/reference/mbstring/functions/mb-trim.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    Effectue une opération <function>trim</function> multi-octets sûre,
-   et renvoie une chaîne avec les espace supprimés du
+   et renvoie une chaîne avec les espaces supprimés du
    début et de la fin de <parameter>string</parameter>.
    Sans le deuxième paramètre,
    <function>mb_trim</function> supprimera les caractères suivants :

--- a/reference/mbstring/functions/mb-ucfirst.xml
+++ b/reference/mbstring/functions/mb-ucfirst.xml
@@ -17,7 +17,7 @@
   <simpara>
    Effectue une opération <function>ucfirst</function> multi-octets sûre,
    et renvoie une chaîne avec la première lettre de
-   <parameter>string</parameter> avec titre en majuscule.
+   <parameter>string</parameter> en majuscule.
   </simpara>
  </refsect1>
 

--- a/reference/mbstring/ja-basic.xml
+++ b/reference/mbstring/ja-basic.xml
@@ -18,7 +18,7 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     La taille nécessaire à un caractère peut aller jusqu'à 4 octets.
+     La taille nécessaire à un caractère peut aller jusqu'à six octets.
     </simpara>
    </listitem>
    <listitem>


### PR DESCRIPTION
Fix grammar, spelling, terminology across 23 mbstring/ files.