### PR TITLE
reference/apcu: review traduction FR vs EN

### DIFF
--- a/reference/apcu/apcuiterator.xml
+++ b/reference/apcu/apcuiterator.xml
@@ -13,7 +13,7 @@
    &reftitle.intro;
    <simpara>
     La classe <classname>APCUIterator</classname> facilite le parcours des
-    caches APCu de grandes tailles. Cela est utile car il permet de les parcourir
+    caches APCu de grandes tailles. Cela est utile car elle permet de les parcourir
     par étapes, tout en récupérant un nombre défini d'entrées par instance de
     verrouillage. Ainsi cela libère les verrous de cache pour d'autres activités
     au lieu de bloquer tout le cache pour récupérer 100 entrées (par défaut).

--- a/reference/apcu/functions/apcu-cas.xml
+++ b/reference/apcu/functions/apcu-cas.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.apcu-cas">
  <refnamediv>
   <refname>apcu_cas</refname>
-  <refpurpose>Remplace une ancienne valeur par une nouvelle</refpurpose>
+  <refpurpose>Met à jour une ancienne valeur avec une nouvelle</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/apcu/functions/apcu-entry.xml
+++ b/reference/apcu/functions/apcu-entry.xml
@@ -37,7 +37,7 @@
   </note>
   <warning>
    <simpara>
-     La seule fonction qui peut être appelée en toute sécurité par <parameter>callback</parameter>
+     La seule fonction APCu qui peut être appelée en toute sécurité par <parameter>callback</parameter>
      est <function>apcu_entry</function>.
    </simpara>
   </warning>


### PR DESCRIPTION
Corrections traduction et synchronisation avec doc-en pour reference/apcu/.

- apcuiterator.xml: accord "il permet" → "elle permet" (la classe)
- apcu-cas.xml: refpurpose "Remplace" → "Met à jour" (EN: "Updates")
- apcu-entry.xml: ajout "APCu" manquant dans le warning callback