### PR TITLE
reference/array: review traduction FR vs EN

### DIFF
--- a/reference/array/constants.xml
+++ b/reference/array/constants.xml
@@ -78,7 +78,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>SORT_REGULAR</constant> compare normalement les valeurs d'un tri.
+     <constant>SORT_REGULAR</constant> est utilisée pour comparer les éléments normalement.
     </simpara>
    </listitem>
   </varlistentry>
@@ -89,7 +89,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>SORT_NUMERIC</constant> compare numériquement les valeurs d'un tri.
+     <constant>SORT_NUMERIC</constant> est utilisée pour comparer les éléments numériquement.
     </simpara>
    </listitem>
   </varlistentry>
@@ -100,7 +100,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>SORT_STRING</constant> compare alphabétiquement les valeurs d'un tri.
+     <constant>SORT_STRING</constant> est utilisée pour comparer les éléments comme des chaînes de caractères.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/array/functions/array-intersect-key.xml
+++ b/reference/array/functions/array-intersect-key.xml
@@ -111,7 +111,7 @@ array(2) {
    <literal>'bleu'</literal> et <literal>'vert'</literal> diffèrent
    entre les deux tableaux. Néanmoins, elles correspondent toujours car
    uniquement les clés sont vérifiées.
-   Les valeurs retournées sont celles du tableau <parameter>array1</parameter>.
+   Les valeurs retournées sont celles du tableau <parameter>array</parameter>.
   </para>
   <para>
    Les deux clés depuis les paires <literal>clé =&gt; valeur</literal>

--- a/reference/array/functions/array-intersect-ukey.xml
+++ b/reference/array/functions/array-intersect-ukey.xml
@@ -103,11 +103,11 @@ array(2) {
    </example>
   </para>
   <para>
-   Dans cet exemple, vous pouvez voir que seules les clés
-   <literal>'bleu'</literal> et <literal>'vert'</literal> sont présentes dans
+   Dans cet exemple, seules les clés
+   <literal>'blue'</literal> et <literal>'green'</literal> sont présentes dans
    les deux tableaux et, donc, elles
    sont retournées. Notez également que les valeurs pour les clés
-   <literal>'bleu'</literal> et <literal>'vert'</literal> diffèrent
+   <literal>'blue'</literal> et <literal>'green'</literal> diffèrent
    entre les deux tableaux. Néanmoins, elles correspondent toujours car
    uniquement les clés sont vérifiées. Les valeurs retournées sont celles du
    tableau <parameter>array</parameter>.

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -40,15 +40,15 @@
       <para>
        Si le paramètre optionnel <parameter>mode</parameter> vaut
        <constant>COUNT_RECURSIVE</constant> (ou 1), <function>count</function>
-       va compter récursivement les tableaux. C'est particulièrement pratique
-       pour compter le nombre d'éléments d'un tableau.
+       va compter récursivement les tableaux. C'est particulièrement utile
+       pour compter tous les éléments d'un tableau multidimensionnel.
       </para>
       <caution>
        <para>
         La fonction <function>count</function> peut détecter les récursions
         afin d'éviter les boucles infinies, mais émettra une alerte de type
         <constant>E_WARNING</constant> à chaque fois qu'une boucle infinie surviendra
-        (dans le cas où un tableau contient lui-même plus d'une boucle infinie)
+        (dans le cas où un tableau se contient lui-même plus d'une fois)
         et retournera un compteur plus grand que l'attendu.
        </para>
       </caution>


### PR DESCRIPTION
Corrections traduction et synchronisation avec doc-en pour reference/array/.

- constants.xml: SORT_REGULAR/NUMERIC/STRING descriptions alignées avec EN
- count.xml: "tableau multidimensionnel" manquant, "boucle infinie" → "plus d'une fois"
- array-intersect-key.xml: paramètre array1 → array
- array-intersect-ukey.xml: clés 'bleu'/'vert' → 'blue'/'green' (cohérence avec le code)