### PR TITLE
review: reference/ds

### DIFF
--- a/reference/ds/ds/map/ksorted.xml
+++ b/reference/ds/ds/map/ksorted.xml
@@ -80,7 +80,7 @@ Ds\Map Object
    </screen>
   </example>
   <example>
-   <title>Exemple de <function>Ds\Map::ksorted</function>utilisant un comparateur</title>
+   <title>Exemple de <function>Ds\Map::ksorted</function> utilisant un comparateur</title>
    <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
Fixes #0

Ajoute un espace manquant dans le titre d'exemple Ds\Map::ksorted.