### PR TITLE
review: reference/eio

### DIFF
--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -316,7 +316,7 @@
     </term>
     <listitem>
      <simpara>
-      Noued de type
+      Noeud de type
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/examples.xml
+++ b/reference/eio/examples.xml
@@ -223,7 +223,7 @@ event_add($event);
 // Démarre la boucle d'événements
 event_base_loop($base);
 
-/* La mêmme chose est disponible viia l'interface libevent bufferisé */
+/* La même chose est disponible via l'interface libevent bufferisée */
 ?>
 ]]></programlisting>
 


### PR DESCRIPTION
Fixes #0

Corrige les typos dans eio : mêmme→même, viia→via, Noued→Noeud.