### PR TITLE
review: reference/event

### DIFF
--- a/reference/event/event.flags.xml
+++ b/reference/event/event.flags.xml
@@ -14,7 +14,7 @@
   <constant>Event::WRITE</constant>
   Ce drapeau indique que l'événement devient actif lorsque le descripteur
   de fichier fourni (habituellement, une ressource de flux ou un socket)
-  est prêt à être lu.
+  est prêt à être écrit.
  </para>
  <para>
   <constant>Event::SIGNAL</constant>

--- a/reference/event/eventbase.xml
+++ b/reference/event/eventbase.xml
@@ -179,7 +179,7 @@
        <literal>EVENT_EPOLL_USE_CHANGELIST</literal>.
       </para>
       <para>
-       Ce drapeau n'a aucun effet si on l'utlise avec un autre backend que
+       Ce drapeau n'a aucun effet si on l'utilise avec un autre backend que
        <literal>epoll</literal>.
       </para>
      </listitem>

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -172,7 +172,7 @@ if (!$output->add(
     exit("Échec lors de l'ajout de la requête dans le buffer de sortie\n");
 }
 
-/* COnnexion à l'hôte de façon synchrone.
+/* Connexion à l'hôte de façon synchrone.
 Nous connaissons l'IP, nous n'avons donc pas besoin de résolution DNS. */
 if (!$bev->connect("127.0.0.1:80")) {
     exit("Impossible de se connecter à l'hôte\n");
@@ -504,9 +504,9 @@ ruslan    3976  0.2  0.0 139896 11256 pts/1    S+   10:25   0:00 php examples/si
 ruslan    3978  0.0  0.0   9572   864 pts/2    S+   10:26   0:00 grep --color=auto examp
 $ kill -TERM 3976
 
-Dans le premier terminal, vous devriez attrapper ce qui suit :
+Dans le premier terminal, vous devriez attraper ce qui suit :
 
-On attrappe le signal 15
+On attrape le signal 15
 */
 class MyEventSignal {
     private $base;


### PR DESCRIPTION
Corrige la description du drapeau WRITE (lu→écrit), typos utlise/COnnexion/attrapper.