### PR TITLE
review: reference/gmp

### DIFF
--- a/reference/gmp/functions/gmp-div-qr.xml
+++ b/reference/gmp/functions/gmp-div-qr.xml
@@ -35,7 +35,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>num1</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       <para>
        Le diviseur.

--- a/reference/gmp/functions/gmp-powm.xml
+++ b/reference/gmp/functions/gmp-powm.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Calcule (<parameter>num</parameter> puissance <parameter>exponent</parameter>)
-   modulo <parameter>mod</parameter>. Si <parameter>exponent</parameter> est négatif,
+   modulo <parameter>modulus</parameter>. Si <parameter>exponent</parameter> est négatif,
    le résultat est indéfini.
   </para>
  </refsect1>

--- a/reference/gmp/functions/gmp-random-bits.xml
+++ b/reference/gmp/functions/gmp-random-bits.xml
@@ -16,7 +16,7 @@
   <para>
    Génère un nombre aléatoire. Le nombre sera dans l'intervalle
    <literal>0</literal> et
-   <literal>2<superscript>$bits</superscript> - 1</literal>..
+   <literal>2<superscript>$bits</superscript> - 1</literal>.
   </para>
   <para>
    Le paramètre <parameter>bits</parameter> doit être plus grand que 0,


### PR DESCRIPTION
Corrige les noms de paramètres (num1→num2, mod→modulus) et double point dans gmp-random-bits.