### PR TITLE
fix(style): tournures impersonnelles dans 500 fichiers

### DIFF
--- a/appendices/about.xml
+++ b/appendices/about.xml
@@ -35,7 +35,7 @@
   <para>
    Il y a de nombreux formats du manuel pour la consultation hors ligne, et
    le format le plus approprié dépend du système d'exploitation et des goûts personnels.
-   Pour savoir comment le manuel est généré, lisez la section
+   Pour savoir comment le manuel est généré, se reporter à la section
    <link linkend="about.generate">'Comment le manuel est généré'</link> de cet
    appendice.
   </para>
@@ -53,7 +53,7 @@
    il intègre un moteur de recherche complet, un index et des signets. De
    nombreux IDE sous Windows fournissent des liens avec ce format pour une
    meilleure intégration. Il existe aussi des visualiseurs de CHM pour
-   Linux. Visitez <link xlink:href="&url.xchm;">xCHM</link> ou <link
+   Linux. Consulter <link xlink:href="&url.xchm;">xCHM</link> ou <link
    xlink:href="&url.gnochm;">GnoCHM</link>.
   </para>
   <para>
@@ -88,7 +88,7 @@
     Pour des questions de portée de licence, les notes utilisateurs sont
     considérées comme faisant partie du manuel PHP, et sont donc couvertes par
     la même licence qui couvre cette documentation (Creative Commons Attribution
-    à ce jour). Pour plus de détails, lisez la page <link
+    à ce jour). Pour plus de détails, se reporter à la page <link
     linkend="copyright">Manual's Copyright</link>.
    </para>
   </note>
@@ -348,8 +348,8 @@ Retourne la taille de la chaîne $string.
   <para>
    En contribuant aux notes, il est possible de fournir de nouveaux exemples,
    mettre en lumière des effets de bords et apporter des clarifications pour
-   les autres lecteurs. Mais ne prenez pas le système d'annotation pour
-   un système de soumission de bogues. Il est possible d'en savoir plus sur les
+   les autres lecteurs. Mais il ne faut pas utiliser le système d'annotation
+   comme un système de soumission de bogues. Il est possible d'en savoir plus sur les
    annotations dans la section
    <link linkend="about.notes">'À propos des notes utilisateurs'</link>
   </para>
@@ -362,7 +362,7 @@ Retourne la taille de la chaîne $string.
    de l'anglais ainsi que d'une autre langue permet d'aider
    la documentation de PHP en travaillant avec une équipe de traduction.
    Pour plus d'informations sur la manière de démarrer une nouvelle traduction
-   ou de contribuer à une version déjà traduite, commencez par lire
+   ou de contribuer à une version déjà traduite, il convient de lire
    <link xlink:href="&url.php.dochowto;">&url.php.dochowto;</link>.
   </para>
   <para>
@@ -391,7 +391,7 @@ Retourne la taille de la chaîne $string.
    bien sûr, PHP lui-même pour effectuer des conversions et du formatage.
   </para>
   <para>
-   Le manuel PHP est généré en de nombreux langages et formats, lisez
+   Le manuel PHP est généré en de nombreux langages et formats, consulter
    <link xlink:href="&url.php.docs;">&url.php.docs;</link> pour plus d'informations.
    Le code source <acronym>XML</acronym> peut être téléchargé depuis git et
    visualisé sur <link xlink:href="&url.php.git.mirror;doc-en">&url.php.git.mirror;doc-en</link>.

--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -16,7 +16,7 @@
   très mauvaise habitude d'utiliser ces alias, car ils risquent à tout moment de
   disparaître, rendus obsolètes sans préavis, ou bien par un simple changement de
   nom, ce qui rend le script inutilisable avec des versions plus récentes de
-  PHP. Préférez toujours les versions officielles. En fait, cette liste est
+  PHP. Il est préférable de toujours utiliser les versions officielles. En fait, cette liste est
   surtout destinée à ceux qui doivent mettre à jour leurs scripts avec les
   syntaxes plus récentes.
  </para>

--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -24,7 +24,7 @@
  <note>
   <para>
    Les formulaires HTML ne connaissent pas les entiers, nombres à virgule
-   flottante et autres booléens. Pour savoir si une chaîne est numérique, utilisez
+   flottante et autres booléens. Pour savoir si une chaîne est numérique, utiliser
    <function>is_numeric</function>.
   </para>
  </note>

--- a/appendices/configure/index.xml
+++ b/appendices/configure/index.xml
@@ -26,7 +26,7 @@
   <note>
    <para>
     Elles sont également utilisées lors de la compilation. Pour modifier la configuration
-    de l'exécution de PHP, lisez le chapitre sur la <link
+    de l'exécution de PHP, se reporter au chapitre sur la <link
     linkend="configuration">configuration de l'exécution</link>.
    </para>
   </note>

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -551,8 +551,8 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <para>
         Temps (en seconde) pour lequel persiste l'information du cache de
         realpath pour un fichier ou un répertoire donné. Pour des systèmes
-        avec des fichiers qui changent peu souvent, pensez à augmenter cette
-        valeur.
+        avec des fichiers qui changent peu souvent, il est recommandé d'augmenter
+        cette valeur.
        </para>
       </listitem>
      </varlistentry>
@@ -1484,7 +1484,7 @@ include_path = ".:${USER}/pear/php"
         Le comportement précédent de PHP était de définir
         <literal>PATH_TRANSLATED</literal> en <literal>SCRIPT_FILENAME</literal>
         et de ne pas remplir <literal>PATH_INFO</literal>. Pour plus d'informations
-        sur <literal>PATH_INFO</literal>, lisez les spécificités <acronym>CGI</acronym>.
+        sur <literal>PATH_INFO</literal>, consulter les spécificités <acronym>CGI</acronym>.
         Si définie à <literal>1</literal>, PHP <acronym>CGI</acronym> fixera ce
         chemin suivant les spécifications. Si définie à <literal>0</literal>, PHP
         appliquera l'ancien comportement. Par défaut, cette directive est activée. Il est

--- a/appendices/migration56/new-features.xml
+++ b/appendices/migration56/new-features.xml
@@ -151,7 +151,7 @@ echo add(1, ...$operators);
   <para>
    Un opérateur <literal>**</literal> associatif à droite a été ajouté
    pour supporter l'exponentiation, en conjonction de l'opérateur
-   d'affectation <literal>**=</literal>.
+   d'assignation <literal>**=</literal>.
   </para>
 
   <informalexample>
@@ -223,7 +223,7 @@ Name\Space\f
 
   <para>
    PHP inclut désormais un débogueur interactif appelé phpdbg, implémenté
-   comme module SAPI. Pour plus d'informations, visitez la
+   comme module SAPI. Pour plus d'informations, consulter la
    <link linkend="book.phpdbg">documentation phpdbg</link>.
   </para>
  </sect2>

--- a/appendices/migration70/incompatible/removed-functions.xml
+++ b/appendices/migration70/incompatible/removed-functions.xml
@@ -55,7 +55,7 @@
   </title>
   <para>
    Toutes les fonctions <link linkend="book.mysql">ext/mysql</link> ont été supprimées.
-   Pour plus d'informations sur le choix d'une autre API MySQL, consultez 
+   Pour plus d'informations sur le choix d'une autre API MySQL, consulter
    <link linkend="mysqlinfo.api.choosing">choisir une API MySQL</link>.
   </para>
  </sect3>

--- a/appendices/migration72/new-features.xml
+++ b/appendices/migration72/new-features.xml
@@ -60,7 +60,7 @@ abstract class A
 }
 abstract class B extends A
 {
-    // overridden - still maintaining contravariance for parameters and covariance for return
+    // surchargée - tout en maintenant la contravariance pour les paramètres et la covariance pour le retour
     abstract function test($s) : int;
 }
 ]]>
@@ -75,7 +75,7 @@ abstract class B extends A
    La bibliothèque moderne de cryptographie sodium est maintenant devenue une extension de base dans PHP.
   </para>
   <para>
-   Pour une référence de fonction complète, consultez le chapitre <link linkend="book.sodium">Sodium</link>.
+   Pour une référence de fonction complète, consulter le chapitre <link linkend="book.sodium">Sodium</link>.
   </para>
  </sect2>
  

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -7,7 +7,7 @@
  <title>Fonctionnalités obsolètes</title>
 
  <sect2 xml:id="migration80.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <itemizedlist>
    <listitem>
@@ -66,20 +66,20 @@ function test(?A $a, $b) {}       // Recommandé
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_add_to_personal</function> est obsolète ; utilisez plutôt
+     <function>enchant_dict_add_to_personal</function> est obsolète ; utiliser plutôt
      <function>enchant_dict_add</function> à la place.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_is_in_session</function> est obsolète ; utilisez plutôt
+     <function>enchant_dict_is_in_session</function> est obsolète ; utiliser plutôt
      <function>enchant_dict_is_added</function> à la place.
     </para>
    </listitem>
    <listitem>
     <para>
      <function>enchant_broker_free</function> et <function>enchant_broker_free_dict</function> sont
-     obsolètes ; détruisez l'objet à la place.
+     obsolètes ; détruire l'objet à la place.
     </para>
    </listitem>
    <listitem>

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -5,7 +5,7 @@
  <title>Fonctionnalités dépréciées</title>
 
  <sect2 xml:id="migration81.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration81.deprecated.core.serialize-interface">
    <title>
@@ -252,7 +252,7 @@ $arr[] = 2;
   <para>
    La propriété <property>mysqli_driver::$driver_version</property>
    a été dépréciée.
-   C'était dénué de sens et obsolète, utilisez <constant>PHP_VERSION_ID</constant>
+   C'était dénué de sens et obsolète, utiliser <constant>PHP_VERSION_ID</constant>
    à la place.
   </para>
 

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -5,7 +5,7 @@
  <title>Les changements de rétrocompatibilités</title>
 
  <sect2 xml:id="migration81.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration81.incompatible.core.globals-access">
    <title>Restrictions d'accès $GLOBALS</title>
@@ -64,7 +64,7 @@ var_dump(B::counter()); // int(4), précédemment int(2)
     spécifié avant les paramètres requis est maintenant toujours traité comme requis,
     même lorsqu'il est appelé en utilisant
     <link linkend="functions.named-arguments">les arguments nommés</link>.
-    À partir de PHP 8.0.0, mais avant PHP 8.1.0, le code ci-dessous émet une note de dépréciation
+    À partir de PHP 8.0.0, mais antérieur à PHP 8.1.0, le code ci-dessous émet une note de dépréciation
     sur la définition, mais s'exécute avec succès lorsqu'il est appelé. À partir de PHP 8.1.0, une erreur
     de la classe <classname>ArgumentCountError</classname> est lancée, comme ce serait le cas lorsqu'il
     est appelé avec des arguments positionnels.
@@ -259,7 +259,7 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
    Voir la page <link linkend="mysqli-driver.report-mode">Mode de rapport MySQLi</link>
    pour plus de détails sur ce que cela implique,
    et comment définir explicitement cet attribut.
-   Pour restaurer le comportement précédent, utilisez :
+   Pour restaurer le comportement précédent, utiliser :
    <code>mysqli_report(MYSQLI_REPORT_OFF);</code>
   </para>
 

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -13,7 +13,7 @@
  </simpara>
 
  <sect2 xml:id="migration84.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <!-- RFC: https://wiki.php.net/rfc/exit-as-function -->
   <sect3 xml:id="migration84.incompatible.core.exit">
@@ -638,7 +638,7 @@
    Par conséquent, cela signifie que <literal>{,3}</literal> est désormais reconnu
    comme un quantificateur au lieu d'un texte.
    De plus, la signification de certaines classes de caractères en mode UCP a changé.
-   Consultez le <link xlink:href="&url.pcre2.changelog;">Journal des modifications de PCRE2</link>
+   Consulter le <link xlink:href="&url.pcre2.changelog;">Journal des modifications de PCRE2</link>
    pour un journal des modifications complet.
   </simpara>
  </sect2>
@@ -778,7 +778,7 @@ nodeData: 3
    Si PHP est compilé sans l'extension session et avec le drapeau de configuration
    <option>--enable-rtld-now</option> activé, des erreurs de démarrage se produiront
    désormais si l'extension <link linkend="book.soap">SOAP</link> est également utilisée.
-   Pour résoudre ce problème, n'utilisez pas rtld-now ou chargez l'extension session.
+   Pour résoudre ce problème, ne pas utiliser rtld-now ou charger l'extension session.
   </simpara>
  </sect2>
 

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -5,7 +5,7 @@
  <title>Changements non rétrocompatibles</title>
 
  <sect2 xml:id="migration85.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration85.incompatible.core.array-callable-alias">
    <title>Les noms d'alias <literal>"array"</literal> et <literal>"callable"</literal></title>
@@ -328,7 +328,7 @@
    De plus, l'encapsulation automatique pour les arguments par valeur passés à un paramètre par référence
    a été supprimée, et l'habituel <constant>E_WARNING</constant>
    à ce sujet est désormais émis.
-   Pour passer une variable par référence à un argument de constructeur utilisez l'affectation
+   Pour passer une variable par référence à un argument de constructeur, utiliser l'affectation
    de référence de valeur de tableau générale : <code>$ctor_args = [&amp;$valByRef]</code>
   </simpara>
 

--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -63,14 +63,14 @@ echo "Bonjour, je suis un script PHP !";
   <para>
    Le grand avantage de PHP est qu'il est extrêmement simple pour les
    néophytes, mais offre des fonctionnalités avancées pour les
-   experts. Ne craignez pas de lire la longue liste de fonctionnalités
+   experts. Il ne faut pas se laisser effrayer par la longue liste de fonctionnalités
    PHP. Avec PHP, presque tout le monde peut commencer rapidement
    et écrire des scripts simples en un rien de temps.
   </para>
   <para>
    Bien que le développement de PHP soit orienté vers la programmation
    pour les sites web, on peut faire bien plus avec PHP.
-   Lisez donc la section <link linkend="intro-whatcando">Que peut faire PHP ?</link>
+   Consulter la section <link linkend="intro-whatcando">Que peut faire PHP ?</link>
    ou bien le <link linkend="tutorial">tutoriel d'introduction</link> pour passer directement
    à l'apprentissage de la programmation web.
   </para>
@@ -95,7 +95,7 @@ echo "Bonjour, je suis un script PHP !";
       un analyseur PHP (CGI ou module serveur), un serveur
       web et un navigateur web. Tout ceci
       peut fonctionner sur une machine locale juste pour expérimenter
-      la programmation PHP. Voyez la
+      la programmation PHP. Voir la
       section <link linkend="install">d'installation</link>
       pour plus d'informations.
      </simpara>
@@ -110,7 +110,7 @@ echo "Bonjour, je suis un script PHP !";
       avec un <command>cron</command> (sous Unix ou macOS) ou
       le Planificateur de tâches (sous Windows). Ces scripts
       peuvent aussi être utilisés pour réaliser des opérations sur des
-      fichiers texte. Voyez la section sur l'utilisation de PHP en
+      fichiers texte. Voir la section sur l'utilisation de PHP en
       <link linkend="features.commandline">ligne de commande</link>
       pour plus d'informations.
      </simpara>
@@ -182,9 +182,9 @@ echo "Bonjour, je suis un script PHP !";
   </para>
   <para>
    Cette page ne suffit pas pour lister toutes les fonctionnalités
-   et avantages que PHP peut offrir. Lisez la section
+   et avantages que PHP peut offrir. Consulter la section
    sur <link linkend="install">l'installation de PHP</link>
-   et consultez la <link linkend="funcref">référence des fonctions</link>
+   et la <link linkend="funcref">référence des fonctions</link>
    pour des explications sur les extensions mentionnées ici.
   </para>
  </section>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -27,7 +27,7 @@
     <link xlink:href="&url.php.downloads;">page de téléchargement</link>.
    </simpara>
    <para>
-    Créez un fichier appelé <filename>hello.php</filename>
+    Créer un fichier appelé <filename>hello.php</filename>
     avec le contenu suivant :
    </para>
    <para>
@@ -113,7 +113,7 @@ php -S localhost:8000
     Puis, nous avons introduit les commandes PHP et refermé les balises
     PHP avec <literal>?&gt;</literal>. Il est possible de passer du mode PHP
     au mode HTML et vice-versa, de cette manière, à volonté. Pour plus
-    d'informations, lisez la section du manuel sur la
+    d'informations, consulter la section du manuel sur la
     <link linkend="language.basic-syntax">syntaxe basique de PHP</link>.
    </para>
 
@@ -124,8 +124,8 @@ php -S localhost:8000
      c'est toujours une bonne idée de rendre le HTML aussi joli et proche
      que possible en y ajoutant des retours à la ligne. Un retour à la ligne
      suivant immédiatement une balise de fermeture PHP (<literal>?&gt;</literal>)
-     sera supprimé par PHP. Ceci peut être vraiment très utile lorsque vous
-     insérez plusieurs blocs PHP ou fichiers inclus contenant du PHP qui
+     sera supprimé par PHP. Ceci peut être vraiment très utile lors de
+     l'insertion de plusieurs blocs PHP ou fichiers inclus contenant du PHP qui
      n'est pas supposé afficher quoi que ce soit. En même temps, ce peut
      être confus. Il est possible d'ajouter un espace après la balise fermante
      PHP (<literal>?&gt;</literal>) pour forcer l'espace et un retour à
@@ -168,7 +168,7 @@ php -S localhost:8000
     <link
     linkend="language.variables.predefined">variables pré-définies disponibles</link>,
     les modules PHP chargés ainsi que la <link linkend="configuration">configuration</link>.
-    Prenez du temps pour revoir ces informations importantes.
+    Prendre le temps de revoir ces informations importantes.
    </para>
    <para>
     <example>
@@ -359,7 +359,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
     L'un des points forts de PHP est sa capacité à gérer les formulaires.
     Le concept de base qui est important à comprendre est que tous les
     champs d'un formulaire seront automatiquement disponibles dans le
-    script PHP d'action. Lisez le chapitre du manuel concernant les
+    script PHP d'action. Consulter le chapitre du manuel concernant les
     <link linkend="language.variables.external">variables depuis des sources externes à PHP</link>
     pour plus d'informations et d'exemples sur la façon d'utiliser les
     formulaires. Voici un exemple de formulaire HTML :

--- a/faq/build.xml
+++ b/faq/build.xml
@@ -106,7 +106,7 @@
      </screen>
     </para>
     <para>
-     Pour davantage d'informations, lisez le fichier
+     Pour davantage d'informations, consulter le fichier
      <filename>INSTALL</filename> à la racine du répertoire source
      Apache ou bien <link xlink:href="&url.apachedso;">le manuel des bibliothèques
      DSO</link>.
@@ -207,7 +207,7 @@
    <answer>
     <para>
      Cela signifie que le module PHP n'est pas chargé, pour une raison ou
-     pour une autre. Avant de chercher de l'aide ailleurs, veuillez vérifier
+     pour une autre. Avant de chercher de l'aide ailleurs, il convient de vérifier
      ces quelques points :
      <itemizedlist>
       <listitem>

--- a/faq/databases.xml
+++ b/faq/databases.xml
@@ -63,7 +63,7 @@
         les bases de données - par exemple avec les pilotes Openlink. En cas de
         besoin d'un format de fichier intermédiaire, Openlink a publié
         Virtuoso (un moteur de base de données virtuel) pour NT, Linux et
-        d'autres plates-formes Unix. Visitez notre <link
+        d'autres plates-formes Unix. Consulter le <link
         xlink:href="&url.openlink;">site</link> pour un téléchargement gratuit.
        </para>
       </blockquote>

--- a/faq/installation.xml
+++ b/faq/installation.xml
@@ -79,7 +79,7 @@
       Apache installée.
      </para>
      <para>
-     Consultez aussi le chapitre sur le
+     Consulter aussi le chapitre sur le
      <link linkend="configuration.file">fichier de configuration</link>.
      </para>
     </answer>
@@ -96,7 +96,7 @@
     <answer>
      <para>
       Cela signifie probablement que PHP rencontre un problème et génère un
-      fichier de vidage. Consultez les fichiers de logs du serveur pour voir
+      fichier de vidage. Consulter les fichiers de logs du serveur pour voir
       si c'est le cas, et tentez de reproduire le problème avec un test
       simple. En cas de maîtrise de 'gdb', il serait très utile de fournir un
       backtrace avec le rapport de bogue, afin d'aider les développeurs à
@@ -383,7 +383,7 @@ cgi error:
      <para>
       Comme la valeur par défaut vaut &one;, il est impératif d'être sûr
       à 100% que le bon fichier &php.ini; a été lu.
-      Lisez cette <link linkend="faq.installation.findphpini">FAQ</link> 
+      Consulter cette <link linkend="faq.installation.findphpini">FAQ</link>
       pour plus de détails.
      </para>
     </answer>
@@ -438,7 +438,7 @@ cgi error:
         Cliquez sur le bouton "Variables d'environnements"
        </para></listitem>
        <listitem><para>
-        Regardez dans le panneau "Variables systèmes"
+        Consulter le panneau "Variables systèmes"
        </para></listitem>
        <listitem><para>
         Trouvez l'entrée <literal>Path</literal> (il faudra peut-être faire descendre

--- a/faq/using.xml
+++ b/faq/using.xml
@@ -99,9 +99,9 @@ echo '</pre>';
     </question>
     <answer>
      <para>
-      Si l'on suppose que c'est pour une base de données, utilisez
+      Si l'on suppose que c'est pour une base de données, utiliser
       le mécanisme d'échappement fourni avec la base de données. Par
-      exemple, utilisez la fonction
+      exemple, utiliser la fonction
       <function>mysql_real_escape_string</function> avec MySQL et
       <function>pg_escape_string</function> avec PostgreSQL.
       Il y a également les fonctions génériques comme
@@ -243,11 +243,11 @@ foreach ($headers as $nom => $contenu) {
       Le modèle sécuritaire de IIS est en faute. C'est un problème commun à
       tous les programmes CGI fonctionnant avec IIS. Une alternative est de
       créer un fichier HTML (non exécuté par PHP) comme page d'entrée dans
-      le dossier où il faut s'identifier. Utilisez alors une balise META
-      pour rediriger vers la page PHP, ou encore proposez un lien vers
+      le dossier où il faut s'identifier. Utiliser alors une balise META
+      pour rediriger vers la page PHP, ou encore proposer un lien vers
       celle-ci. PHP reconnaîtra alors l'identification correctement.
       Cela ne devrait pas non
-      plus affecter d'autres serveurs NT. Pour plus d'informations, voyez : 
+      plus affecter d'autres serveurs NT. Pour plus d'informations, voir :
       <link xlink:href="&url.iis;">&url.iis;</link> et la section du manuel
       concernant l'<link linkend="features.http-auth">identification HTTP</link>.
      </para>
@@ -306,12 +306,12 @@ foreach ($headers as $nom => $contenu) {
     </question>
     <answer>
      <para>
-      Lisez la page du manuel qui concerne les <link linkend="language.variables.predefined">
+      Consulter la page du manuel qui concerne les <link linkend="language.variables.predefined">
       variables prédéfinies</link> vu qu'elle présente une liste
       partielle des variables prédéfinies disponibles dans un script. Une
       liste complète des variables disponibles (et beaucoup d'informations)
       peut être vue en appelant la fonction <function>phpinfo</function>.
-      Lisez la section du manuel traitant des  
+      Consulter la section du manuel traitant des
       <link linkend="language.variables.external">variables non-issues de
       PHP</link>, elle décrit des scénarios communs pour les variables
       externes, comme celles issues d'un formulaire HTML, d'un cookie, et de

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1107,7 +1107,7 @@ php -r 'print_r(get_defined_constants());'
      </para>
      <note>
       <para>
-       Lisez l'exemple attentivement, il n'y a ni balise d'ouverture, ni balise de fermeture !
+       Lire l'exemple attentivement, il n'y a ni balise d'ouverture, ni balise de fermeture !
        L'option <option>-r</option> rend caduque l'utilisation de celles-ci, et les ajouter conduirait
        alors à une erreur d'analyse syntaxique.
       </para>
@@ -1162,7 +1162,7 @@ $ some_application | some_filter | php | sort -u > final_output.txt
    le caractère <literal>-</literal>, il n'y a rien de spécial à surveiller.
    Le fait de passer des arguments au script qui commencent par
    <literal>-</literal> pose des problèmes car PHP
-   va penser qu'il doit les interpréter. Pour éviter cela, utilisez le séparateur
+   va penser qu'il doit les interpréter. Pour éviter cela, utiliser le séparateur
    <literal>--</literal>. Après cet argument, tous les arguments suivants seront
    passés au script sans être modifiés ou analysés par PHP.
   </para>
@@ -1916,7 +1916,7 @@ $ php -S localhost:8000 router.php
    <title>Gestion des types de fichiers non supportés</title> 
    <para>
     Pour servir une ressource statique pour laquelle le type
-    MIME n'est pas géré par le CLI du serveur web, utilisez ceci :
+    MIME n'est pas géré par le CLI du serveur web, utiliser ceci :
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/features/file-upload.xml
+++ b/features/file-upload.xml
@@ -164,7 +164,7 @@
    <example>
     <title>Validation de téléchargement de fichiers</title>
     <para>
-     Voyez aussi les fonctions <function>is_uploaded_file</function> et
+     Voir aussi les fonctions <function>is_uploaded_file</function> et
      <function>move_uploaded_file</function> pour plus d'informations.
      L'exemple suivant va télécharger un fichier venant d'un formulaire.
     </para>

--- a/features/gc.xml
+++ b/features/gc.xml
@@ -375,7 +375,7 @@ a: (refcount=2, is_ref=1)=array (
     Pour éviter d'avoir à appeler la routine de nettoyage à chaque décrémentation de refcount possible,
     l'algorithme place toutes les zval racines dans un "tampon de racines" (en les marquant en "violet").
     Il s'assure aussi que chaque racine n'apparaisse qu'une seule fois dans le tampon. Le
-    mécanisme de nettoyage n'intervient alors que lorsque le tampon est plein. Voyez l'étape A
+    mécanisme de nettoyage n'intervient alors que lorsque le tampon est plein. Voir l'étape A
     sur la figure ci-dessus.
    </para>
    <para>
@@ -425,7 +425,7 @@ a: (refcount=2, is_ref=1)=array (
     <function>gc_disable</function> respectivement. Utiliser ces fonctions aura le même effet que de
     modifier le paramètre de configuration. Il est aussi possible de forcer l'exécution du
     ramasse-miettes à un moment donné dans le script, même si le tampon n'est pas encore
-    complètement plein. Utilisez pour cela la fonction <function>gc_collect_cycles</function>,
+    complètement plein. Utiliser pour cela la fonction <function>gc_collect_cycles</function>,
     qui retournera le nombre de cycles alors collectés.
    </para>
    <para>

--- a/install/cloud/digitalocean.xml
+++ b/install/cloud/digitalocean.xml
@@ -28,7 +28,7 @@
    <para>
     <link xlink:href="&url.docean.app.platform;">App Platform</link>:
     Gérer des infrastructures pour construire, déployer et mettre à l'échelle rapidement des applications.
-    Apprenez à
+    Découvrir comment
     <link xlink:href="https://docs.digitalocean.com/products/app-platform/getting-started/sample-apps/php/">
      faire tourner des applications PHP sur la plateforme App
     </link>.
@@ -39,7 +39,7 @@
     <link xlink:href="&url.docean.functions;">Functions</link>:
     Plateforme sans serveur qui permet aux développeurs d'exécuter du code sans provisionner ni gérer de serveurs.
     PHP est supporté nativement.
-    Apprenez à
+    Découvrir comment
     <link xlink:href="https://docs.digitalocean.com/products/functions/reference/runtimes/php/">
      créer des fonctions sans serveur en PHP
     </link>.

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -175,7 +175,7 @@
     </term>
     <listitem>
      <para>
-      Envoie FPM en arrière-plan. Mettez 'no' pour garder FPM au premier plan lors du
+      Envoie FPM en arrière-plan. Mettre 'no' pour garder FPM au premier plan lors du
       débogage. Valeur par défaut : yes.
      </para> 
     </listitem>
@@ -570,7 +570,7 @@
       </term>
       <listitem>
        <para>
-        Spécifiez la priorité nice(2) à appliquer au processus de travail 
+        Spécifier la priorité nice(2) à appliquer au processus de travail 
         (uniquement s'il est défini). La valeur peut varier de -19 (priorité 
         la plus élevée) à 20 (priorité la plus basse).         Valeur par 
         défaut: non définie.
@@ -966,7 +966,7 @@
              accepter un format <literal>strftime(3)</literal> :
              <literal>%d/%b/%Y:%H:%M:%S %z</literal> (par défaut).
              Le format <literal>strftime(3)</literal> doit être encapsulé dans
-             une balise <literal>%{&lt;strftime_format&gt;}t</literal>, par exemple, pour une chaîne de temps au format ISO8601, utilisez :
+             une balise <literal>%{&lt;strftime_format&gt;}t</literal>, par exemple, pour une chaîne de temps au format ISO8601, utiliser :
              <literal>%{%Y-%m-%dT%H:%M:%S%z}t</literal>
             </entry>
            </row>
@@ -979,7 +979,7 @@
              format <literal>strftime(3)</literal> :
              <literal>%d/%b/%Y:%H:%M:%S %z</literal> (par défaut).
              Le format <literal>strftime(3)</literal> doit être encapsulé dans une
-             balise <literal>%{&lt;strftime_format&gt;}T</literal>, par exemple, pour une chaîne de temps au format ISO8601, utilisez :
+             balise <literal>%{&lt;strftime_format&gt;}T</literal>, par exemple, pour une chaîne de temps au format ISO8601, utiliser :
              <literal>%{%Y-%m-%dT%H:%M:%S%z}T</literal>
             </entry>
            </row>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -412,7 +412,7 @@ but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
         &htaccess;. Toute directive de PHP configurée avec le type
         <systemitem role="directive">php_admin_value</systemitem> ne peut pas être
         modifiée en utilisant le fichier &htaccess; ou la fonction <function>ini_set</function>.
-        Pour annuler une valeur qui aurait été modifiée au préalable, utilisez la
+        Pour annuler une valeur qui aurait été modifiée au préalable, utiliser la
         valeur <literal>none</literal>.
        </para>
       </listitem>

--- a/install/intro.xml
+++ b/install/intro.xml
@@ -42,7 +42,7 @@
   Pour utiliser PHP en ligne de commande
   (écrire des scripts de génération d'image hors ligne,
   par exemple, ou bien traiter des textes en fonction
-  d'informations fournies), un exécutable PHP est nécessaire. Pour plus de détails, lisez la
+  d'informations fournies), un exécutable PHP est nécessaire. Pour plus de détails, consulter la
   section <link linkend="features.commandline"> écrire des applications
    PHP en ligne de commande</link>. Dans ce cas, il
   n'est pas nécessaire d'avoir un serveur Web, ni un navigateur.

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -34,7 +34,7 @@
   <orderedlist>
    <listitem>
     <simpara>
-     Trouvez et ouvrez le fichier de configuration d'Apache. Par défaut, ce sera :
+     Trouver et ouvrir le fichier de configuration d'Apache. Par défaut, ce sera :
      <filename>/private/etc/apache2/httpd.conf</filename>
     </simpara>
     <simpara>
@@ -70,7 +70,7 @@
    </listitem>
    <listitem>
     <para>
-     Avec un éditeur de texte, décommentez les lignes (en effaçant le caractère #)
+     Avec un éditeur de texte, décommenter les lignes (en effaçant le caractère #)
      qui ressemblent aux lignes suivantes (ces 2 lignes ne se trouvent pas au même endroit) :
      <screen>
 <![CDATA[
@@ -129,8 +129,8 @@
    </listitem>
    <listitem>
     <simpara>
-     Définissez le chemin vers le fichier
-     &php.ini; ou utilisez le chemin par défaut.
+     Définir le chemin vers le fichier
+     &php.ini; ou utiliser le chemin par défaut.
     </simpara>
     <simpara>
      Le chemin par défaut sur macOS est
@@ -143,7 +143,7 @@
    </listitem>
    <listitem>
     <simpara>
-     Trouvez et définissez le <literal>DocumentRoot</literal>
+     Trouver et définir le <literal>DocumentRoot</literal>
     </simpara>
     <simpara>
      C'est le dossier principal pour tous les fichiers Web. Les fichiers dans
@@ -158,11 +158,11 @@
    </listitem>
    <listitem>
     <simpara>
-     Créez un fichier <function>phpinfo</function>.
+     Créer un fichier <function>phpinfo</function>.
     </simpara>
     <para>
      La fonction <function>phpinfo</function> affiche les informations sur PHP.
-     Créez un fichier dans le DocumentRoot avec le code PHP suivant :
+     Créer un fichier dans le DocumentRoot avec le code PHP suivant :
      <programlisting role="php">
 <![CDATA[
 <?php phpinfo(); ?>
@@ -172,7 +172,7 @@
    </listitem>
    <listitem>
     <simpara>
-     Redémarrez Apache et chargez le fichier PHP que nous venons de créer.
+     Redémarrer Apache et charger le fichier PHP créé précédemment.
     </simpara>
     <para>
      Pour redémarrer, exécutez la commande <literal>sudo apachectl graceful</literal>
@@ -189,7 +189,7 @@
  <simpara>
   <acronym>CLI</acronym> (ou <acronym>CGI</acronym> dans les anciennes versions) est nommé
   <filename>php</filename> et réside normalement dans
-  <filename>/usr/bin/php</filename>. Ouvrez un terminal, lisez la section sur
+  <filename>/usr/bin/php</filename>. Ouvrir un terminal, consulter la section sur
   <link linkend="features.commandline">la ligne de commande</link> du manuel PHP, et
   exécutez la commande <literal>php -v</literal> pour vérifier la version PHP de ce binaire.
   Un appel à la fonction <function>phpinfo</function> pourra également révéler cette

--- a/install/problems.xml
+++ b/install/problems.xml
@@ -7,7 +7,7 @@
    <title>Des problèmes ?</title>
 
    <sect1 xml:id="install.problems.faq">
-    <title>Lisez la FAQ</title>
+    <title>Lire la FAQ</title>
     <simpara>
      Certains problèmes sont récurrents : les plus communs
      sont listés dans la FAQ PHP, disponible
@@ -55,7 +55,7 @@
      de nouvelles fonctionnalités.
     </simpara>
     <simpara>
-     Lisez le guide <link xlink:href="&url.php.bugs.howtoreport;">Comment rapporter un bogue</link>
+     Lire le guide <link xlink:href="&url.php.bugs.howtoreport;">Comment rapporter un bogue</link>
      (Les bogues : ce qu'il faut faire, et ce qu'il ne faut pas faire)
      avant d'envoyer n'importe quel rapport !
     </simpara>

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -41,7 +41,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Téléchargez le serveur HTTP Apache depuis le site ci-dessus et décompressez-le :
+    Télécharger le serveur HTTP Apache depuis le site ci-dessus et le décompresser :
    </para>
    
    <informalexample>
@@ -55,7 +55,7 @@ tar -xzf httpd-2.x.NN.tar.gz
   
   <listitem>
    <para>
-    De la même façon, téléchargez et décompressez les sources de PHP :
+    De la même façon, télécharger et décompresser les sources de PHP :
    </para>
    
    <informalexample>
@@ -69,7 +69,7 @@ tar -xzf php-NN.tar.gz
   
   <listitem>
    <para>
-    Compilez et installez Apache. Consultez la documentation sur l'installation
+    Compiler et installer Apache. Consulter la documentation sur l'installation
     d'Apache pour plus de détails quant à la compilation de ce logiciel.
    </para>
    
@@ -218,7 +218,7 @@ LoadModule php7_module modules/libphp7.so
    
    <para>
     Configurer Apache pour analyser certaines extensions comme étant des scripts PHP.
-    Par exemple, laissez Apache passer à PHP les fichiers dont l'extension est
+    Par exemple, laisser Apache passer à PHP les fichiers dont l'extension est
     <literal>.php</literal>.
     Au lieu d'utiliser seulement la directive <literal>AddType</literal> d'Apache,
     nous souhaitons éviter tout risque potentiellement dangereux, lors
@@ -324,7 +324,7 @@ service httpd restart
   En ayant suivi les étapes précédentes, le serveur web est maintenant un
   Apache2 fonctionnel avec le support PHP comme module <literal>SAPI</literal>.
   Bien sûr, il y a une multitude d'autres options de configuration de disponibles
-  avec Apache et PHP. Pour plus d'informations, entrez la commande
+  avec Apache et PHP. Pour plus d'informations, entrer la commande
   <command>./configure --help</command> dans l'arbre source correspondant.
  </para>
  <para>

--- a/install/unix/litespeed.xml
+++ b/install/unix/litespeed.xml
@@ -37,7 +37,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Pour obtenir et installer LiteSpeed Web Server ou OpenLiteSpeed Web Server, visitez la
+    Pour obtenir et installer LiteSpeed Web Server ou OpenLiteSpeed Web Server, consulter la
     <link xlink:href="&url.litespeed.lsws;">page d'installation</link>
     de la documentation de LiteSpeed Web Server
     ou la
@@ -48,7 +48,7 @@
 
   <listitem>
    <para>
-    Téléchargez et décompressez le code source de PHP :
+    Télécharger et décompresser le code source de PHP :
    </para>
 
    <informalexample xml:id="install.unix.litespeed.extract.php">
@@ -66,8 +66,8 @@ cd php-x.x.x
 
   <listitem>
    <para>
-    Configurez et construisez PHP. C'est ici que PHP peut être personnalisé avec diverses options,
-    telles que les extensions qui seront activées. Exécutez ./configure --help pour obtenir une liste des options
+    Configurer et construire PHP. C'est ici que PHP peut être personnalisé avec diverses options,
+    telles que les extensions qui seront activées. Exécuter ./configure --help pour obtenir une liste des options
     disponibles. Dans l'exemple, nous utiliserons les options de configuration recommandées par défaut pour
     LiteSpeed Web Server :
    </para>
@@ -117,7 +117,7 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
    </informalexample>
 
    <para>
-    Remarquez le <literal>litespeed</literal> entre parenthèses. Cela signifie que le binaire PHP a été
+    Remarquer le <literal>litespeed</literal> entre parenthèses. Cela signifie que le binaire PHP a été
     construit avec le support LSAPI.
    </para>
   </listitem>
@@ -127,7 +127,7 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   Après avoir suivi les étapes ci-dessus, LiteSpeed / OpenLiteSpeed Web Server devrait
   maintenant fonctionner avec le support de PHP en tant qu'extension SAPI. Il existe de nombreuses autres
   options de configuration disponibles pour LSWS / OLS et PHP. Pour plus d'informations,
-  consultez la documentation LiteSpeed sur
+  consulter la documentation LiteSpeed sur
   <link xlink:href="&url.litespeed.php;">PHP</link>.
  </para>
 
@@ -215,7 +215,7 @@ PHP_LSAPI_MAX_REQUESTS=500 PHP_LSAPI_CHILDREN=35 /path/to/lsphp -b IP_address:po
  <para>
   Actuellement, LiteSpeed PHP peut être utilisé avec LiteSpeed Web Server,
   OpenLiteSpeed Web Server et Apache mod_lsapi. Pour les étapes de
-  configuration côté serveur, visitez les pages de documentation pour
+  configuration côté serveur, consulter les pages de documentation pour
   <link xlink:href="&url.litespeed.web.server;">LiteSpeed Web Server</link>
   et <link xlink:href="&url.litespeed.open;">OpenLiteSpeed</link>.
  </para>
@@ -238,14 +238,14 @@ PHP_LSAPI_MAX_REQUESTS=500 PHP_LSAPI_CHILDREN=35 /path/to/lsphp -b IP_address:po
 
  <para>
   cPanel:
-  Visitez la <link xlink:href="&url.litespeed.cpanel;">page de documentation</link> respective
+  Consulter la <link xlink:href="&url.litespeed.cpanel;">page de documentation</link> respective
   sur la façon d'installer LSPHP avec cPanel et LSWS/OLS en utilisant EasyApache 4.
  </para>
 
  <para>
   Plesk:
   Plesk peut être utilisé avec LSPHP sur CentOS, CloudLinux, Debian et Ubuntu,
-  pour plus de détails à ce sujet, visitez la <link xlink:href="&url.litespeed.plesk;">page de documentation</link> respective.
+  pour plus de détails à ce sujet, consulter la <link xlink:href="&url.litespeed.plesk;">page de documentation</link> respective.
  </para>
 </sect1>
 

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -213,7 +213,7 @@ location / {
 
    <para>
     La prochaine étape permet d'assurer que les fichiers .php soient passés
-    au backend PHP-FPM. Sous le bloc PHP commenté par défaut, entrez :
+    au backend PHP-FPM. Sous le bloc PHP commenté par défaut, entrer :
    </para>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx.php">
@@ -259,7 +259,7 @@ echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
    </informalexample>
 
    <para>
-    Maintenant, naviguez vers http://localhost. Le phpinfo()
+    Maintenant, naviguer vers http://localhost. Le phpinfo()
     devrait maintenant être affiché.
    </para>
   </listitem>
@@ -269,7 +269,7 @@ echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
   En suivant ces différentes étapes, le résultat devrait être un serveur
   web Nginx avec le support de PHP comme module <literal>FPM</literal> <literal>SAPI</literal>.
   Bien entendu, il y a beaucoup plus d'options de configuration
-  disponibles pour Nginx et PHP. Pour plus d'informations, tapez
+  disponibles pour Nginx et PHP. Pour plus d'informations, taper
   <command>./configure --help</command> dans la source correspondante.
  </para>
 

--- a/install/unix/openbsd.xml
+++ b/install/unix/openbsd.xml
@@ -21,7 +21,7 @@
    Le paquet principal à installer est <filename>php</filename>,
    qui contient le moteur de base (en plus de fpm, gettext et iconv) et pourrait
    être disponible sous plusieurs versions au choix.
-   Puis, jetez un oeil aux paquets de module, comme <filename>php-mysqli</filename>
+   Puis, jeter un œil aux paquets de module, comme <filename>php-mysqli</filename>
    ou <filename>php-imap</filename>. Il faut utiliser la commande
    <command>phpxs</command> pour activer et désactiver ces modules dans le
    &php.ini;.
@@ -33,12 +33,12 @@
 # pkg_add php
 # pkg_add php-apache
 # pkg_add php-mysqli
-  (install the PEAR libraries)
+  (installer les bibliothèques PEAR)
 # pkg_add pear
 
-Follow the instructions shown with each package!
+Suivre les instructions affichées avec chaque paquet !
 
-  (to remove packages)
+  (pour supprimer des paquets)
 # pkg_delete php
 # pkg_delete php-apache
 # pkg_delete php-mysqli
@@ -47,7 +47,7 @@ Follow the instructions shown with each package!
     </programlisting>
   </example>
   <simpara>
-   Lisez la page de manuel Unix <link xlink:href="&url.openbsd.packages;">packages(7)</link>
+   Lire la page de manuel Unix <link xlink:href="&url.openbsd.packages;">packages(7)</link>
     pour plus de détails sur les paquets binaires d'OpenBSD.
   </simpara>
  </sect2>

--- a/install/unix/solaris.xml
+++ b/install/unix/solaris.xml
@@ -12,7 +12,7 @@
   <title>Logiciels nécessaires</title>
   <para>
    Les installations <productname>Solaris</productname> sont généralement dépourvues de compilateurs C et de leurs
-   utilitaires. Lisez <link linkend="faq.installation.needgnu">cette FAQ</link>
+   utilitaires. Lire <link linkend="faq.installation.needgnu">cette FAQ</link>
    pour savoir pourquoi est-ce que les versions GNU de certains de ces outils
    sont nécessaires.
   </para>

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -9,7 +9,7 @@
  </para>
  <note>
   <para>
-   Veuillez lire d'abord les <link linkend="install.windows.manual">étapes
+   Il convient de lire d'abord les <link linkend="install.windows.manual">étapes
    d'installation manuelle</link> !
   </para>
  </note>
@@ -18,17 +18,17 @@
   Il est fortement recommandé de consulter la
   <link xlink:href="&url.apache2.docs;">documentation d'Apache</link>
    pour obtenir une compréhension de base du serveur Apache 2.x.
-   Considérez également la lecture des
+   Il est également recommandé de lire les
    <link xlink:href="&url.apache2.windows;">notes spécifiques à Windows</link>
    pour Apache 2.x avant de continuer ici.
  </para>
 
  <para>
-  Téléchargez la version la plus récente de
+  Télécharger la version la plus récente de
   <link xlink:href="&url.apachelounge.download;">Apache 2.x</link>
-  et une version PHP correspondante. Suivez les
+  et une version PHP correspondante. Suivre les
   <link linkend="install.windows.manual">étapes d'installation manuelle</link>
-  et revenez pour continuer avec l'intégration de PHP et Apache.
+  et revenir pour continuer avec l'intégration de PHP et Apache.
  </para>
 
  <para>
@@ -116,10 +116,10 @@ PHPIniDir "C:/php"
    l'exécution en tant que CGI. La configuration est assez simple :
   </para>
   <para>
-   Obtenez <literal>mod_fcgid</literal> depuis
+   Obtenir <literal>mod_fcgid</literal> depuis
    <link xlink:href="&url.apachelounge.download;">&url.apachelounge;</link>.
    Les binaires Win32 sont disponibles en téléchargement sur ce site.
-   Installez le module selon les instructions qui l'accompagneront.
+   Installer le module selon les instructions qui l'accompagneront.
   </para>
   <para>
    Configurer le serveur web comme indiqué ci-dessous, en prenant soin d'ajuster

--- a/install/windows/commandline.xml
+++ b/install/windows/commandline.xml
@@ -9,7 +9,7 @@
  </para>
  <note>
   <para>
-   Veuillez lire les <link linkend="install.windows.manual">étapes
+   Il convient de lire les <link linkend="install.windows.manual">étapes
    d'installation manuelle</link> en premier !
   </para>
  </note>
@@ -40,10 +40,10 @@ C:\php\php.exe -f "C:\PHP Scripts\script.php" -- -arg1 -arg2 -arg3
 
    <listitem>
     <para>
-     Ajoutez l'emplacement de l'exécutable PHP (<filename>php.exe</filename>,
+     Ajouter l'emplacement de l'exécutable PHP (<filename>php.exe</filename>,
      <filename>php-win.exe</filename> ou <filename>php-cli.exe</filename>
      selon la version de PHP et les préférences d'affichage) à la variable
-     d'environnement <envar>PATH</envar>. Lisez plus sur comment ajouter le
+     d'environnement <envar>PATH</envar>. Lire la section sur comment ajouter le
      répertoire PHP approprié à la variable d'environnement <envar>PATH</envar> dans la
      <link linkend="faq.installation.addtopath">entrée FAQ correspondante</link>.
     </para>
@@ -51,11 +51,11 @@ C:\php\php.exe -f "C:\PHP Scripts\script.php" -- -arg1 -arg2 -arg3
 
    <listitem>
     <para>
-     Ajoutez l'extension <literal>.PHP</literal>
+     Ajouter l'extension <literal>.PHP</literal>
      à la variable d'environnement <varname>PATHEXT</varname>. Ceci peut être fait
      en même temps que l'ajout de la variable d'environnement <envar>PATH</envar>.
-     Suivez les mêmes étapes que décrites dans la <link
-     linkend="faq.installation.addtopath">FAQ</link> mais modifiez la variable
+     Suivre les mêmes étapes que décrites dans la <link
+     linkend="faq.installation.addtopath">FAQ</link> mais modifier la variable
      d'environnement <varname>PATHEXT</varname> plutôt que la variable
      d'environnement <envar>PATH</envar>.
      <note>
@@ -72,7 +72,7 @@ C:\php\php.exe -f "C:\PHP Scripts\script.php" -- -arg1 -arg2 -arg3
 
    <listitem>
     <para>
-     Associez l'extension <literal>.PHP</literal> avec un type de fichier. Ceci
+     Associer l'extension <literal>.PHP</literal> avec un type de fichier. Ceci
      est fait en exécutant la commande suivante :
      <screen>
 <![CDATA[
@@ -84,7 +84,7 @@ assoc .php=phpfile
 
    <listitem>
     <para>
-     Associez le type de fichier <literal>phpfile</literal> avec l'exécutable PHP
+     Associer le type de fichier <literal>phpfile</literal> avec l'exécutable PHP
      approprié. Ceci est fait en exécutant la commande suivante :    
      <screen>
 <![CDATA[

--- a/install/windows/iis.xml
+++ b/install/windows/iis.xml
@@ -26,7 +26,7 @@
   <title>Configurer PHP avec IIS</title>
 
   <simpara>
-   Dans le gestionnaire IIS, installez le module FastCGI et ajoutez un mappage de gestionnaire pour
+   Dans le gestionnaire IIS, installer le module FastCGI et ajouter un mappage de gestionnaire pour
    <literal>.php</literal> au chemin de <filename>php-cgi.exe</filename>
    (pas <filename>php.exe</filename>)
   </simpara>

--- a/install/windows/recommended.xml
+++ b/install/windows/recommended.xml
@@ -49,7 +49,7 @@ opcache.enable_cli=On
    option de configuration pour utiliser le cache d'objet de l'utilisateur de
    WinCache.
    
-   Si des performances élevées sont nécessaires, utilisez le cache d'objets dans les applications.
+   Si des performances élevées sont nécessaires, utiliser le cache d'objets dans les applications.
    
    Voir : <link xlink:href="&url.pecl.package;WinCache">&url.pecl.package;WinCache</link>
    pour télécharger une DLL WinCache (ou <filename>WINCACHE_<replaceable>*</replaceable>.tgz</filename>)

--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -105,9 +105,9 @@ executeAction($copyAction);
    <para>
     La syntaxe des attributs consiste en plusieurs composants clés. Une déclaration d'attribut commence par <literal>#[</literal> et se termine par
     <literal>]</literal>. À l'intérieur, un ou plusieurs attributs peuvent être listés, séparés par des virgules. Le nom de l'attribut peut être non qualifié, qualifié,
-    ou complètement qualifié, comme décrit dans <link linkend="language.namespaces.basics">Utilisation des bases des espaces de noms</link>.
-    Les arguments de l'attribut sont optionnels et sont enfermés dans des parenthèses <literal>()</literal>. Les arguments peuvent uniquement être des valeurs littérales ou des expressions constantes.
-    La syntaxe des arguments positionnels et nommés est prise en charge.
+    ou complètement qualifié, comme décrit dans <link linkend="language.namespaces.basics">Utilisation de base des espaces de noms</link>.
+    Les arguments de l'attribut sont optionnels et sont placés entre parenthèses <literal>()</literal>. Les arguments peuvent uniquement être des valeurs littérales ou des expressions constantes.
+    La syntaxe des arguments positionnels et nommés est supportée.
    </para>
 
    <para>
@@ -173,14 +173,14 @@ class AnotherThing
 
    <para>
     Pour accéder aux attributs des classes, méthodes, fonctions, paramètres, propriétés
-    et constantes de classe, utilisez la méthode <function>getAttributes</function> fournie
+    et constantes de classe, il convient d'utiliser la méthode <function>getAttributes</function> fournie
     par l'API de réflexion. Cette méthode retourne un tableau d'instances de <classname>ReflectionAttribute</classname>.
     Ces instances permettent d'interroger le nom de l'attribut, ses arguments, et
-    peuvent être utilisées pour instancier une instance de l'attribut représenté.
+    peuvent être utilisées pour créer une instance de l'attribut représenté.
    </para>
 
    <para>
-    Séparer la représentation réfléchie d'un attribut de son instance réelle offre un meilleur
+    Séparer la représentation obtenue par réflexion d'un attribut de son instance réelle offre un meilleur
     contrôle sur la gestion des erreurs, comme l'absence de classe d'attribut, les arguments
     mal typés ou les valeurs manquantes. Les objets de la classe d'attribut ne sont instanciés
     qu'après l'appel à <function>ReflectionAttribute::newInstance</function>, garantissant que
@@ -337,7 +337,7 @@ class MyAttribute
 
    <para>
     Par défaut, un attribut ne peut être utilisé qu'une seule fois par déclaration.
-    Pour autoriser un attribut à être répété, spécifiez-le dans le masque de bits
+    Pour autoriser un attribut à être répété, il faut le spécifier dans le masque de bits
     de la déclaration <literal>#[Attribute]</literal> en utilisant le drapeau
     <constant>Attribute::IS_REPEATABLE</constant>.
    </para>

--- a/language/control-structures/include-once.xml
+++ b/language/control-structures/include-once.xml
@@ -22,7 +22,7 @@
   de fonctions ou de classes.
  </para>
  <para>
-  Voyez la structure <function>include</function>
+  Voir la structure <function>include</function>
   pour plus de détails sur son fonctionnement.
  </para>
 </sect1>

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -27,8 +27,8 @@
  </simpara>
  <simpara>
   Il est à noter que <literal>include</literal> et <literal>require</literal>
-  vont lancer des erreurs de type <constant>E_WARNING</constant>, si le
-  fichier n'est pas accessible, avant de lancer une erreur de type
+  vont lever des erreurs de type <constant>E_WARNING</constant>, si le
+  fichier n'est pas accessible, avant de lever une erreur de type
   <constant>E_WARNING</constant> ou <constant>E_ERROR</constant>, respectivement.
  </simpara>
  <simpara>
@@ -116,14 +116,12 @@ echo "Une $fruit $couleur"; // Une verte
   </example>
  </para>
  <simpara>
-  Il est important de noter que lorsqu'un fichier est
-  <function>include</function> ou <function>require</function>,
-  les erreurs d'analyse apparaîtront en HTML tout
-  au début du fichier, et l'analyse du fichier
-  parent ne sera pas interrompue. Pour cette raison, le code
-  qui est dans le fichier doit être placé entre
-  <link linkend="language.basic-syntax.phpmode">les balises
-  habituelles de PHP</link>.
+  Lorsqu'un fichier est inclus, l'analyse bascule du mode PHP
+  au mode HTML au début du fichier cible, et reprend à la fin
+  de celui-ci. Pour cette raison, tout code du fichier cible devant
+  être exécuté comme du code PHP doit être placé entre
+  <link linkend="language.basic-syntax.phpmode">des balises PHP
+  de début et de fin valides</link>.
  </simpara>
  <simpara>
   Si les <link linkend="ini.allow-url-include">gestionnaires d'inclusion d'URL</link>
@@ -263,7 +261,7 @@ echo $bar; // affiche 1
  </para>
  <simpara>
   <literal>$bar</literal> a la valeur de &one; car
-  l'inclusion était réussie. Notez la différence entre les deux
+  l'inclusion était réussie. Il est à noter la différence entre les deux
   exemples ci-dessus. Le premier utilise la commande
   <function>return</function>
   dans le fichier inclus, alors que le second ne le fait pas.

--- a/language/control-structures/return.xml
+++ b/language/control-structures/return.xml
@@ -32,7 +32,7 @@
   dans le fichier &php.ini;, alors l'exécution du script s'arrête.
  </simpara>
  <simpara>
-  Pour plus d'informations, voyez
+  Pour plus d'informations, voir
   <link linkend="functions.returning-values">retourner des valeurs</link>.
  </simpara>
  <para>

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -191,7 +191,7 @@ $e = $d = ++$b;     /* Pre-incrémentation, et assignation de la valeur aux
 $f = double($d++);  /* assignation du double de la valeur de $d à la variable $f ($f vaut 12),
                        puis incrémentation de la valeur de $d  */
 $g = double(++$e);  /* assigne deux fois la valeur de $e après
-                       incrémentation, 2*7 = 14 to $g */
+                       incrémentation, 2*7 = 14 à $g */
 $h = $g += 10;      /* Tout d'abord, $g est incrémentée de 10, et donc $g vaut 24.
                        Ensuite, la valeur de $g, (24) est assignée à la variable $h,
                        qui vaut donc elle aussi 24. */
@@ -220,16 +220,16 @@ $h = $g += 10;      /* Tout d'abord, $g est incrémentée de 10, et donc $g vaut
   
   Les constantes &true; et &false; (insensible à la casse) sont les deux
   valeurs possibles pour un booléen. Lorsque nécessaire, une expression
-  est automatiquement convertie en booléen. Lisez la
+  est automatiquement convertie en booléen. Consulter la
   <link linkend="language.types.typecasting">section sur le transtypage</link>
   pour plus de détails.
  </simpara>
  <simpara>
-  PHP propose une implémentation complète et détaillée des expressions.
-  PHP documente toutes ses expressions dans le présent manuel.
-  Les exemples qui vont suivre devraient donner une
-  bonne idée de ce qu'est une expression et comment construire ses propres
-  expressions. Dans tout ce qui va suivre, nous écrirons
+  PHP propose une implémentation complète et détaillée des expressions, et
+  la documenter entièrement va au-delà de la portée de ce manuel.
+  Les exemples ci-dessus devraient donner une
+  bonne idée de ce qu'est une expression et comment construire des
+  expressions utiles. Dans tout le reste de ce manuel, nous écrirons
   <varname>expr</varname> pour indiquer toute expression PHP valide.
  </simpara>
 </chapter>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -344,7 +344,7 @@ echo MonProjet\Connexion::start();
      <simpara>
       Une mise en garde : les noms sans qualificatif pour les fonctions et les
       constantes vont être pris dans le namespace global, si la fonction
-      n'est pas définie dans le namespace courant. Voyez
+      n'est pas définie dans le namespace courant. Voir
       <link linkend="language.namespaces.fallback">Utilisation des espaces de noms :
       retour au namespace global pour les fonctions et les constantes</link> pour
       plus de détails.
@@ -485,7 +485,7 @@ echo constant('constname'), "\n"; // affiche global
     </programlisting>
    </example>
    Il faut utiliser un nom absolu (le nom de la classe, avec son préfixe d'espace
-   de noms). Notez qu'il n'y a pas de différence entre un nom absolu et un nom qualifié
+   de noms). Il est à noter qu'il n'y a pas de différence entre un nom absolu et un nom qualifié
    dans un nom de classe, de fonction ou de constante dynamique, ce qui fait que l'antislash
    initial n'est pas nécessaire.
    <example>
@@ -1530,9 +1530,9 @@ $obj = new $a;
       ]]>
      </programlisting>
     </example>
-    Dans une chaîne à double guillemets, la séquence de protection est beaucoup plus
-    sécuritaire à utiliser, mais il est quand même recommandé de toujours protéger
-    les antislashs dans une chaîne qui contient un espace de noms.
+    Dans une chaîne à guillemets simples, la séquence de protection est beaucoup plus
+    sûre à utiliser, mais il est quand même recommandé de toujours protéger
+    les antislashs dans toutes les chaînes comme bonne pratique.
    </para>
   </sect2>
   <sect2 xml:id="language.namespaces.faq.constants">

--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -142,7 +142,7 @@ B
      Dans les contextes non statiques, la classe appelée sera celle de l'objet.
      Comme <literal>$this-></literal> essayera d'appeler
      des méthodes privées depuis le même contexte, utiliser <literal>static::</literal>
-     pourrait donner des résultats différents. Notez aussi que
+     pourrait donner des résultats différents. Il est aussi à noter que
      <literal>static::</literal> ne peut faire référence qu'à des attributs/méthodes
      statiques.
     </para>
@@ -157,7 +157,7 @@ class A
 {
     private function foo()
     {
-        echo "success!\n";
+        echo "Success!\n";
     }
     public function test()
     {

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -93,7 +93,7 @@
      Il n'est pas possible pour <link linkend="object.sleep">__sleep()</link> de retourner
      des noms de propriétés privées des classes parentes. Le faire
      résultera en une erreur de niveau <constant>E_NOTICE</constant>.
-     Utilisez <link linkend="object.serialize">__serialize()</link> à la place.
+     Utiliser <link linkend="object.serialize">__serialize()</link> à la place.
     </para>
    </note>
    <note>
@@ -282,18 +282,18 @@ class Connection
    </para>
    <warning>
     <para>
-     Un objet <interfacename>Stringable</interfacename>
-     <emphasis>ne</emphasis> sera pas accepté par une déclaration de type <type>string</type> si la
-     <link linkend="language.types.declarations.strict">déclaration de type strict</link> est activée.
-     Si un tel comportement est souhaité, la déclaration de type doit accepter
-     à la fois <interfacename>Stringable</interfacename> et <type>string</type> via un type union.
-    </para>
-    <para>
      À partir de PHP 8.0.0, la valeur de retour suit les sémantiques standard
      de PHP, signifiant que la valeur sera convertie en une <type>string</type>
      si possible et si le
      <link linkend="language.types.declarations.strict">typage strict</link>
      est désactivé.
+    </para>
+    <para>
+     Un objet <interfacename>Stringable</interfacename>
+     <emphasis>ne</emphasis> sera pas accepté par une déclaration de type <type>string</type> si la
+     <link linkend="language.types.declarations.strict">déclaration de type strict</link> est activée.
+     Si un tel comportement est souhaité, la déclaration de type doit accepter
+     à la fois <interfacename>Stringable</interfacename> et <type>string</type> via un type union.
     </para>
     <para>
      À partir de PHP 8.0.0, toute classe qui contient une méthode

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -91,7 +91,7 @@ class Cat extends Animal
   </informalexample>
 
   <para>
-   Notez qu'il n'y a pas de méthodes qui renvoient des valeurs dans cet exemple. Quelques fabriques
+   Il est à noter qu'il n'y a pas de méthodes qui renvoient des valeurs dans cet exemple. Quelques fabriques
    seront ajoutées et renverront un nouvel objet de classe de type <varname>Animal</varname>,
   <varname>Cat</varname>, ou <varname>Dog</varname>.
   </para>

--- a/language/operators/bitwise.xml
+++ b/language/operators/bitwise.xml
@@ -434,7 +434,7 @@ Expression : -2 = -4 >> 1
  Binaire :
   val=11111111111111111111111111111100
   res=11111111111111111111111111111110
- Note : copie du bit de signe à gauche
+ Note : copie du bit de signe maintenant à gauche
 
 Expression : -1 = -4 >> 2
  Décimal :
@@ -659,7 +659,7 @@ Expression : 0 = -4 << 62
  </para>
  <warning>
   <para>
-   Utilisez les fonctions de l'extension <link linkend="book.gmp">gmp</link>
+   Utiliser les fonctions de l'extension <link linkend="book.gmp">gmp</link>
    pour les manipulations sur les bits, lorsque les entiers dépassent
    <constant>PHP_INT_MAX</constant>.
   </para>

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -342,7 +342,7 @@ function standard_array_compare($op1, $op2)
 
  <note>
   <simpara>
-   Soyez conscient que la manipulation des types n'est pas toujours évidente lors de la comparaison
+   Il est important d'être conscient que la manipulation des types n'est pas toujours évidente lors de la comparaison
    de valeurs de différents types, en particulier comparant des &integer;s à des &boolean;s ou des
    &integer;s à des &string;s. Il est par conséquent généralement recommandé d'utiliser les
    opérateurs de comparaison <literal>===</literal> et <literal>!==</literal> au lieu de
@@ -508,7 +508,7 @@ if (isset($_POST['action'])) {
   </para>
   <note>
    <simpara>
-    Veuillez noter que l'opérateur null de fusion est une expression, et qu'il
+    Il est à noter que l'opérateur null de fusion est une expression, et qu'il
     ne s'évalue pas comme une variable, mais comme le résultat d'une expression.
     Il est important de le savoir pour renvoyer une variable
     par référence.
@@ -536,7 +536,7 @@ print 'Mr. ' . ($name ?? 'Anonymous');
   </note>
   <note>
    <para>
-    Veuillez noter que l'opérateur de fusion null permet une imbrication simple:
+    Il est à noter que l'opérateur de fusion null permet une imbrication simple :
     <example>
      <title>Imbrication de l'opération de fusion null</title>
      <programlisting role="php">

--- a/language/operators/execution.xml
+++ b/language/operators/execution.xml
@@ -6,7 +6,7 @@
  <titleabbrev>Exécution</titleabbrev>
  <para>
   PHP supporte un opérateur d'exécution : guillemets obliques
-  (<literal>``</literal>). Notez bien qu'il ne s'agit pas de guillemets simples. PHP
+  (<literal>``</literal>). Il est à noter qu'il ne s'agit pas de guillemets simples. PHP
   essaie d'exécuter le contenu de ces guillemets obliques comme une commande
   shell. Le résultat sera retourné (c'est-à-dire : il ne sera pas simplement
   envoyé à la sortie standard, il peut être affecté à une variable).

--- a/language/predefined/variables/session.xml
+++ b/language/predefined/variables/session.xml
@@ -13,7 +13,7 @@
   &reftitle.description;
   <para>
    Un tableau associatif des valeurs stockées dans les sessions,
-   et accessible au script courant. Voyez l'extension
+   et accessible au script courant. Voir l'extension
    <link linkend="ref.session">Sessions</link> pour plus de détails sur comment
    est utilisée cette variable.
   </para>

--- a/language/types.xml
+++ b/language/types.xml
@@ -40,7 +40,7 @@
    <link linkend="language.types.type-juggling">jongler de type</link> dans un
    type compatible avec l'opération.
    Ce processus dépend du contexte dans lequel la valeur est utilisée.
-   Pour plus d’informations, consultez la section sur le
+   Pour plus d’informations, consulter la section sur le
    <link linkend="language.types.type-juggling">jonglage de type</link>.
   </para>
 
@@ -63,13 +63,13 @@
 
   <para>
     Pour vérifier le type et la valeur d'une
-    <link linkend="language.expressions">expression</link>, utilisez la fonction
+    <link linkend="language.expressions">expression</link>, utiliser la fonction
     <function>var_dump</function>.
 
    Pour récupérer le type d'une
    <link linkend="language.expressions">expression</link>,
    utiliser la fonction <function>get_debug_type</function>.
-   Toutefois, pour vérifier si une expression est d'un certain type, utilisez
+   Toutefois, pour vérifier si une expression est d'un certain type, utiliser
    plutôt les fonctions
    <!-- TODO When PhD support is there: <function>is_<replaceable>type</replaceable></function> -->
    <literal>is_<replaceable>type</replaceable></literal>.

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -79,18 +79,20 @@ $array2 = [
     "foo" => "bar",
     "bar" => "foo",
 ];
+
+var_dump($array1, $array2);
 ?>
 ]]>
     </programlisting>
    </example>
-   
-   <para xml:id="language.types.array.key-casts">
+
+   <para>
     La clé <replaceable>key</replaceable> peut être soit un <type>int</type>,
     soit une &string;. La valeur <replaceable>value</replaceable> peut être
     de n'importe quel type.
    </para>
-   
-   <para>
+
+   <para xml:id="language.types.array.key-casts">
     De plus, les modifications de type suivantes surviendront pour la clé <replaceable>key</replaceable> :
     <itemizedlist>
      <listitem>
@@ -530,9 +532,9 @@ $arr[] = 56;    // Identique à $arr[13] = 56;
 $arr["x"] = 42; // Ceci ajoute un nouvel élément au
                 // tableau avec la clé "x"
 
-var_dump($arr);
-
 unset($arr[5]); // Ceci efface l'élément du tableau
+
+var_dump($arr);
 
 unset($arr);    // Ceci efface complètement le tableau
 
@@ -770,7 +772,7 @@ echo $b, PHP_EOL;    // Affiche 1
   <note>
    <para>
     La fonction <function>unset</function> permet d'effacer les clés d'un tableau.
-    Soyez attentif sur le fait que le tableau ne sera <emphasis>pas</emphasis>
+    Il est à noter que le tableau ne sera <emphasis>pas</emphasis>
     ré-indexé. Pour réaliser un effacement complet et une ré-indexation
     du tableau, il faut utiliser la fonction
     <function>array_values</function>.
@@ -855,7 +857,7 @@ echo $foo[bar];
 
    <simpara>
     Ceci ne signifie pas qu'il faut <emphasis>toujours</emphasis> mettre la clé entre guillemets.
-    N'utilisez pas de guillemets avec les clés qui sont des
+    Ne pas utiliser de guillemets avec les clés qui sont des
     <link linkend="language.constants">constantes</link> ou des
     <link linkend="language.variables">variables</link>, car cela empêcherait PHP de
     les interpréter.
@@ -1152,7 +1154,7 @@ array(3) {
   </para>
 
   <para>
-   La conversion de &null; en un tableau résultat en un tableau vide.
+   La conversion de &null; en un tableau résulte en un tableau vide.
   </para>
  </sect2>
 
@@ -1388,6 +1390,8 @@ Aimez-vous la couleur jaune ?
    <programlisting role="php">
 <![CDATA[
 <?php
+$colors = array('rouge', 'bleu', 'verte', 'jaune');
+
 foreach ($colors as &$color) {
     $color = mb_strtoupper($color);
 }
@@ -1519,7 +1523,7 @@ var_dump($juices);
 
   <para>
    L'assignation d'un tableau induit toujours la copie des valeurs.
-   Utilisez l'<link linkend="language.operators">opérateur de référence</link>
+   Utiliser l'<link linkend="language.operators">opérateur de référence</link>
    pour copier un tableau par référence.
   </para>
 

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -13,7 +13,7 @@
  <sect2 xml:id="language.types.boolean.syntax">
   <title>Syntaxe</title>
   <para>
-   Pour spécifier un &boolean; littéral, utilisez la constante &true; ou
+   Pour spécifier un &boolean; littéral, utiliser la constante &true; ou
    &false;. Les deux sont insensibles à la casse.
   </para>
 
@@ -65,7 +65,7 @@ if ($show_separators) {
   <title>Conversion en booléen</title>
 
   <simpara>
-  Pour convertir explicitement une valeur en <type>bool</type>, utilisez
+  Pour convertir explicitement une valeur en <type>bool</type>, utiliser
   le cast <literal>(bool)</literal>. Généralement, cela n'est pas nécessaire
   car lorsqu'une valeur est utilisée dans un contexte logique, elle sera
   automatiquement interprétée comme une valeur de type <type>bool</type>.

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -36,7 +36,7 @@ function foo(callable $callback) {
    Les callables peuvent être passés en tant qu'arguments aux fonctions ou méthodes qui
    attendent un paramètre callback ou ils peuvent être invoqués directement.
    Le type <type>callable</type> ne peut pas être utilisé comme déclaration de type pour les
-   propriétés. À la place, utilisez une déclaration de type <classname>Closure</classname>.
+   propriétés. À la place, utiliser une déclaration de type <classname>Closure</classname>.
   </simpara>
 
   <simpara>
@@ -170,7 +170,7 @@ print implode(' ', $new_numbers);
     où ils sont créés, les callables référençant des méthodes de classes sous forme
     de chaînes de caractères ou de tableaux sont résolus dans le scope où ils sont appelés.
     Pour créer un callable à partir d'une méthode privée ou protégée, qui peut ensuite être
-    invoqué depuis l'extérieur de la classe, utilisez
+    invoqué depuis l'extérieur de la classe, utiliser
     <methodname>Closure::fromCallable</methodname> ou la 
     <link linkend="functions.first_class_callable_syntax">syntaxe callable de
     première classe</link>
@@ -190,7 +190,7 @@ print implode(' ', $new_numbers);
     À partir de PHP 8.2.0, les callables dépendants du contexte
     sont dépréciés. Supprimez la dépendance au contexte en remplaçant
     <literal>'parent::method'</literal> par
-    <literal>parent::class . '::method'</literal> ou utilisez la
+    <literal>parent::class . '::method'</literal> ou utiliser la
     <link linkend="functions.first_class_callable_syntax">syntaxe callable de
     première classe</link>.
    </simpara>

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -284,7 +284,7 @@ Stack trace:
      Il n’est pas possible de combiner les deux types de singleton
      <literal>false</literal> et <literal>true</literal> ensemble dans une
      union de type.
-     Utilisez plutôt <type>bool</type>.
+     Utiliser plutôt <type>bool</type>.
     </simpara>
    </warning>
 

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -9,7 +9,7 @@
   <title>Initialisation des objets</title>
 
   <para>
-   Pour créer un nouvel objet, utilisez le mot clé <literal>new</literal>
+   Pour créer un nouvel objet, utiliser le mot clé <literal>new</literal>
    afin d'instancier une classe :
   </para>
 

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -844,7 +844,7 @@ Valeur de l'objet : chaîne.
     <note>
      <simpara>
       La clé du tableau doit être non citée, et il n'est donc pas possible de
-      référencer une constante comme clé avec la syntaxe de base. Utilisez la
+      référencer une constante comme clé avec la syntaxe de base. Utiliser la
       syntaxe <link linkend="language.types.string.parsing.advanced">avancée</link>
       à la place.
      </simpara>
@@ -898,7 +898,7 @@ Changer le caractère à l'indice -3 en o donne strong.
      <type>chaîne</type>, puis entourée de <literal>{</literal> et
      <literal>}</literal>. Étant donné que <literal>{</literal> ne peut pas être échappé, cette
      syntaxe ne sera reconnue que lorsque le <literal>$</literal> suit immédiatement le
-     <literal>{</literal>. Utilisez <literal>{\$</literal> pour obtenir un
+     <literal>{</literal>. Utiliser <literal>{\$</literal> pour obtenir un
      <literal>{$</literal>. Voici quelques exemples pour clarifier :
     </simpara>
 
@@ -1136,7 +1136,7 @@ string(1) "b"
   <para>
    Les <type>chaînes</type> peuvent être concaténées à l'aide de l'opérateur '.' (point). Notez
    que l'opérateur '+' (addition) ne fonctionnera <emphasis>pas</emphasis> pour cela.
-   Consultez <link linkend="language.operators.string">les opérateurs de chaîne</link> pour
+   Consulter <link linkend="language.operators.string">les opérateurs de chaîne</link> pour
    plus d'informations.
   </para>
 
@@ -1145,7 +1145,7 @@ string(1) "b"
   </para>
 
   <simpara>
-   Consultez la <link linkend="ref.strings">section des fonctions de chaîne</link> pour
+   Consulter la <link linkend="ref.strings">section des fonctions de chaîne</link> pour
    les fonctions générales, et la <link linkend="ref.pcre">section des fonctions d'expressions régulières compatibles Perl</link> pour
    des fonctionnalités avancées de recherche et de remplacement.
   </simpara>
@@ -1158,7 +1158,7 @@ string(1) "b"
   </simpara>
 
   <simpara>
-   Enfin, consultez également les <link linkend="ref.ctype">fonctions de type caractère</link>.
+   Enfin, consulter également les <link linkend="ref.ctype">fonctions de type caractère</link>.
   </simpara>
  </sect2>
 
@@ -1196,7 +1196,7 @@ string(1) "b"
     À partir de PHP 8.0.0, le caractère de la virgule décimale est toujours
     un point ("<literal>.</literal>"). Avant PHP 8.0.0,
     le caractère de la virgule décimale est défini dans la locale du script (catégorie
-    LC_NUMERIC). Consultez la fonction <function>setlocale</function>.
+    LC_NUMERIC). Consulter la fonction <function>setlocale</function>.
    </para>
   </note>
 
@@ -1204,8 +1204,8 @@ string(1) "b"
    Les <type>tableaux</type> sont toujours convertis en la <type>chaîne</type>
    <literal>"Array"</literal>; de ce fait, <function>echo</function> et
    <function>print</function> ne peuvent pas à eux seuls afficher le contenu d'un
-   <type>tableau</type>. Pour afficher un seul élément, utilisez une construction telle que
-   <literal>echo $arr['foo']</literal>. Consultez ci-dessous des conseils sur la visualisation de tout le contenu.
+   <type>tableau</type>. Pour afficher un seul élément, utiliser une construction telle que
+   <literal>echo $arr['foo']</literal>. Consulter ci-dessous les conseils sur la visualisation de tout le contenu.
   </para>
 
   <para>
@@ -1220,7 +1220,7 @@ string(1) "b"
    l'exécution. Bien que la structure exacte de cette chaîne ne doive pas être considérée comme
    fiable et soit sujette à changement, elle sera toujours unique pour une ressource donnée
    pendant la durée d'exécution d'un script (c'est-à-dire une requête Web ou un processus CLI)
-   et ne sera pas réutilisée. Pour obtenir le type d'une <type>resource</type>, utilisez
+   et ne sera pas réutilisée. Pour obtenir le type d'une <type>resource</type>, utiliser
    la fonction <function>get_resource_type</function>.
   </para>
 
@@ -1231,7 +1231,7 @@ string(1) "b"
   <para>
    Comme indiqué ci-dessus, convertir directement un <type>tableau</type>,
    un <type>objet</type> ou une <type>resource</type> en <type>chaîne</type> ne fournit
-   pas d'informations utiles sur la valeur au-delà de son type. Consultez les fonctions
+   pas d'informations utiles sur la valeur au-delà de son type. Consulter les fonctions
    <function>print_r</function> et <function>var_dump</function> pour
    des moyens plus efficaces d'inspecter le contenu de ces types.
   </para>

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -217,7 +217,7 @@ $unset_array[] = 'valeur'; // Ne génère pas d'avertissement.
    </simpara>
 
    <simpara>
-    Pour plus d'informations sur les fonctions liées aux variables, consultez la
+    Pour plus d'informations sur les fonctions liées aux variables, consulter la
     <link linkend="ref.var">Référence des fonctions sur les variables</link>.
    </simpara>
  </sect1>
@@ -264,7 +264,7 @@ $unset_array[] = 'valeur'; // Ne génère pas d'avertissement.
    de la ligne où l'inclusion a lieu.
   </simpara>
   <example>
-   <title>Les variables sont locales à la fonction</title>
+   <title>Exemple de portée de variable globale</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -1045,7 +1045,7 @@ if ($_POST) {
     <function>header</function>. Les données contenues dans les cookies
     sont alors disponibles dans les tableaux de cookies appropriés, comme
     <varname>$_COOKIE</varname> mais aussi <varname>$_REQUEST</varname>.
-    Lisez la page de la documentation sur la fonction
+    Consulter la page de la documentation sur la fonction
     <function>setcookie</function> pour plus de détails ainsi que des exemples.
    </simpara>
 
@@ -1077,7 +1077,7 @@ setcookie("MyCookie[bar]", 'Test 2', time()+3600);
    <simpara>
     Cela va créer deux cookies distincts bien que <varname>MyCookie</varname>
     est maintenant un simple tableau dans le script. Si seulement un cookie
-    doit être défini avec plusieurs valeurs, utilisez la fonction
+    doit être défini avec plusieurs valeurs, utiliser la fonction
     <function>serialize</function> ou <function>explode</function>
     sur la première valeur.
    </simpara>
@@ -1154,7 +1154,7 @@ setcookie("Panier[$compte]", $item, time()+3600);
     <function>is_int</function>,
     <function>is_object</function> et
     <function>is_string</function>.
-    Lisez également le chapitre sur les
+    Consulter également le chapitre sur les
     <link linkend="language.types">types</link>.
    </para>
     <para>

--- a/language/wrappers/compression.xml
+++ b/language/wrappers/compression.xml
@@ -19,7 +19,7 @@
    le fait que le flux peut être utilisé directement avec <function>fread</function>
    et les autres fonctions de système de fichiers. Cette notation est obsolète
    à cause d'ambiguïtés dues aux noms de fichiers
-   contenant des deux points ':'. Utilisez plutôt <filename>compress.zlib://</filename>.
+   contenant des deux points ':'. Utiliser plutôt <filename>compress.zlib://</filename>.
   </simpara>
 
   <simpara>
@@ -84,14 +84,14 @@
       <row>
        <entry>Support de la fonction <function>stat</function></entry>
        <entry>
-        Non, utilisez le gestionnaire <literal>file://</literal>
+        Non, utiliser le gestionnaire <literal>file://</literal>
         pour obtenir des informations sur les fichiers compressés.
        </entry>
       </row>
       <row>
        <entry>Support de la fonction <function>unlink</function></entry>
        <entry>
-        Non, utilisez le gestionnaire <literal>file://</literal>
+        Non, utiliser le gestionnaire <literal>file://</literal>
         pour supprimer les fichiers compressés.
        </entry>
       </row>

--- a/language/wrappers/phar.xml
+++ b/language/wrappers/phar.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <simpara>
    L'enveloppe de flux <filename>phar://</filename>.
-   Voyez <link linkend="phar.using.stream">enveloppe de flux Phar</link>
+   Voir <link linkend="phar.using.stream">enveloppe de flux Phar</link>
    pour une description détaillée.
   </simpara>
  </refsect1><!-- }}} -->

--- a/reference/apache/setup.xml
+++ b/reference/apache/setup.xml
@@ -10,7 +10,7 @@
  <section xml:id="apache.installation">
   &reftitle.install;
   <para>
-   Pour une installation de PHP sous Apache, lisez
+   Pour une installation de PHP sous Apache, consulter
    le <link linkend="install">chapitre sur l'installation</link>.
   </para>
  </section>

--- a/reference/apcu/setup.xml
+++ b/reference/apcu/setup.xml
@@ -39,7 +39,7 @@
   </note>
   <note>
    <simpara>
-    Pour plus de détails techniques approfondis sur l'implémentation, consultez le
+    Pour plus de détails techniques approfondis sur l'implémentation, consulter le
     <link xlink:href="&url.apc.technotes;">
      fichier TECHNOTES fourni par les développeurs
     </link>.

--- a/reference/array/book.xml
+++ b/reference/array/book.xml
@@ -25,7 +25,7 @@
    Se reporter à la section sur les
    <link linkend="language.types.array">tableaux</link> de ce manuel pour
    une explication détaillée sur la façon dont les tableaux sont implémentés
-   et utilisés en PHP. Lisez également les
+   et utilisés en PHP. Consulter également les
    <link linkend="language.operators.array">opérateurs sur les tableaux</link>
    afin de voir d'autres façons de manipuler les tableaux.
   </para>

--- a/reference/array/functions/array-flip.xml
+++ b/reference/array/functions/array-flip.xml
@@ -20,7 +20,7 @@
    et les valeurs sont les clés.
   </para>
   <para>
-   Notez bien que les valeurs de <parameter>array</parameter> doivent 
+   Il est à noter que les valeurs de <parameter>array</parameter> doivent
    être des clés valides, c'est-à-dire qu'elles doivent être des
    &integer; ou des &string;.
    Une alerte sera émise si une valeur est d'un type qui 

--- a/reference/array/functions/array-intersect-key.xml
+++ b/reference/array/functions/array-intersect-key.xml
@@ -107,7 +107,7 @@ array(2) {
   <para>
    Dans cet exemple, il est possible de voir que seules les clés <literal>'bleu'</literal>
    et <literal>'vert'</literal> sont présentes dans les deux tableaux et donc, 
-   elles sont retournées. Notez également que les valeurs pour les clés
+   elles sont retournées. Il est également à noter que les valeurs pour les clés
    <literal>'bleu'</literal> et <literal>'vert'</literal> diffèrent
    entre les deux tableaux. Néanmoins, elles correspondent toujours car
    uniquement les clés sont vérifiées.

--- a/reference/array/functions/array-intersect-ukey.xml
+++ b/reference/array/functions/array-intersect-ukey.xml
@@ -106,7 +106,7 @@ array(2) {
    Dans cet exemple, seules les clés
    <literal>'blue'</literal> et <literal>'green'</literal> sont présentes dans
    les deux tableaux et, donc, elles
-   sont retournées. Notez également que les valeurs pour les clés
+   sont retournées. Il est également à noter que les valeurs pour les clés
    <literal>'blue'</literal> et <literal>'green'</literal> diffèrent
    entre les deux tableaux. Néanmoins, elles correspondent toujours car
    uniquement les clés sont vérifiées. Les valeurs retournées sont celles du

--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -77,7 +77,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       L’utilisation de <type>null</type> dans le paramètre <parameter>key</parameter> est obsolète, utilisez une chaîne vide à la place.
+       L’utilisation de <type>null</type> dans le paramètre <parameter>key</parameter> est obsolète, utiliser une chaîne vide à la place.
       </entry>
      </row>
      <row>

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -139,7 +139,7 @@ Array
     <para>
      Si l'on veut ajouter des éléments du second tableau au premier
      sans pour autant écraser ou réindexer les éléments du premier,
-     utilisez l'opérateur d'union <literal>+</literal> :
+     utiliser l'opérateur d'union <literal>+</literal> :
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/array/functions/array-search.xml
+++ b/reference/array/functions/array-search.xml
@@ -73,7 +73,7 @@
   <para>
    Si <parameter>needle</parameter> est trouvé plus d'une fois dans
    <parameter>haystack</parameter>, la première clé concordante est
-   retournée. Pour trouver toutes les clés correspondantes, utilisez plutôt
+   retournée. Pour trouver toutes les clés correspondantes, utiliser plutôt
    la fonction <function>array_keys</function> avec le paramètre optionnel
    <parameter>filter_value</parameter>.
   </para>

--- a/reference/array/functions/array.xml
+++ b/reference/array/functions/array.xml
@@ -14,7 +14,7 @@
    <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crée un tableau. Lisez la section sur les
+   Crée un tableau. Consulter la section sur les
    <link linkend="language.types.array">types tableaux</link> pour plus d'informations
    sur ce qu'est un tableau, y compris les détails sur la syntaxe alternative de crochets (<literal>[]</literal>).
   </para>
@@ -49,7 +49,7 @@
   <para>
    Retourne un tableau des paramètres. Les paramètres peuvent fournir
    un index en utilisant l'opérateur <literal>=&gt;</literal>.
-   Lisez la section sur les <link linkend="language.types.array">types-tableaux</link>
+   Consulter la section sur les <link linkend="language.types.array">types-tableaux</link>
    pour plus d'informations sur ce qu'est un tableau.
   </para>
  </refsect1>
@@ -104,7 +104,7 @@ Array
    </example>
   </para>
   <para>
-   Notez bien que l'index '3' est défini deux fois, et conserve finalement
+   Il est à noter que l'index '3' est défini deux fois, et conserve finalement
    sa dernière valeur de 13. L'index '4' est défini après
    l'index '8', et l'index généré suivant (valeur 19) est
    9, puisque le plus grand index est alors 8.

--- a/reference/array/functions/extract.xml
+++ b/reference/array/functions/extract.xml
@@ -27,7 +27,7 @@
   </para>
   <warning>
    <para>
-    N'utilisez pas <function>extract</function> sur des données non sûres comme les entrées utilisateur
+    N'utiliser pas <function>extract</function> sur des données non sûres comme les entrées utilisateur
     (ex. <varname>$_GET</varname>, <varname>$_FILES</varname>).
    </para>
   </warning>
@@ -217,7 +217,7 @@ blue, large, sphere, medium
   &reftitle.notes;
   <warning>
    <para>
-    N'utilisez pas <function>extract</function> sur des données inconnues, comme
+    N'utiliser pas <function>extract</function> sur des données inconnues, comme
     les données utilisateurs (c.-à-d. <varname>$_GET</varname>,
     <varname>$_FILES</varname>, etc.).
     Si on le fait, il faut s'assurer d'utiliser l'une des constantes

--- a/reference/cmark/configure.xml
+++ b/reference/cmark/configure.xml
@@ -5,7 +5,7 @@
  &reftitle.install;
 
  <simpara>
-  Utilisez <option role="configure">--with-cmark[=DIR]</option> lors de la compilation PHP.
+  Utiliser <option role="configure">--with-cmark[=DIR]</option> lors de la compilation PHP.
  </simpara>
 
  <simpara>

--- a/reference/com/com/construct.xml
+++ b/reference/com/com/construct.xml
@@ -146,7 +146,7 @@
       <constant>CP_THREAD_ACP</constant> (utilise codepage/locale définie pour
       le thread en cours d'exécution ), <constant>CP_UTF7</constant>
       et <constant>CP_UTF8</constant>. Il est aussi possible d'utiliser le numéro pour
-      une codepage donnée ; consultez la documentation de Microsoft pour plus de
+      une codepage donnée ; consulter la documentation de Microsoft pour plus de
       détails sur les codepages et leurs valeurs numériques.
      </simpara>
     </listitem>

--- a/reference/com/examples.xml
+++ b/reference/com/examples.xml
@@ -68,7 +68,7 @@ foreach ($domainObject as $obj) {
       de contrôle &foreach;. Cela fonctionne
       car un SafeArray comporte des informations à propos de sa taille. Si
       une propriété à la façon des tableaux implémente IEnumVariant, alors on
-      peut aussi utiliser &foreach; pour cette propriété ; lisez <xref
+      peut aussi utiliser &foreach; pour cette propriété ; consulter <xref
       linkend="com.examples.foreach"/> pour plus d'informations à ce sujet.
      </para>
     </listitem>

--- a/reference/com/functions/variant-cast.xml
+++ b/reference/com/functions/variant-cast.xml
@@ -22,7 +22,7 @@
   </para>
   <para>
    Cette fonction est en fait la fonction VariantChangeType() de la bibliothèque COM ;
-   consultez MSDN pour plus d'informations.
+   consulter MSDN pour plus d'informations.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/com/ini.xml
+++ b/reference/com/ini.xml
@@ -122,7 +122,7 @@
     <para>
      Cette directive est activée par défaut et fait que les constantes
      trouvées dans les bibliothèques de types auto-chargées lors de l'instanciation d'objets <classname>COM</classname> seront enregistrées en mode 
-     sensible à la casse. Voyez <function>com_load_typelib</function> 
+     sensible à la casse. Voir <function>com_load_typelib</function> 
      pour plus de détails.
     </para>
     </listitem>

--- a/reference/com/reference.xml
+++ b/reference/com/reference.xml
@@ -11,7 +11,7 @@
   <section xml:id="com.seealso">
    &reftitle.seealso;
    <para>
-    Pour plus d'informations sur les objets COM, lisez les
+    Pour plus d'informations sur les objets COM, consulter les
     <link xlink:href="&url.comspecs;">spécifications COM</link>.
     Il est possible de trouver des informations utiles dans notre FAQ pour <xref
     linkend="faq.com"/>.

--- a/reference/com/variant/construct.xml
+++ b/reference/com/variant/construct.xml
@@ -44,7 +44,7 @@
       ils n'ont pas besoin d'être passés en tant qu'objets variant.
      </simpara>
      <simpara>
-      Consultez la bibliothèque <acronym>MSDN</acronym> pour des informations
+      Consulter la bibliothèque <acronym>MSDN</acronym> pour des informations
       additionnelles sur le type VARIANT.
      </simpara>
     </listitem>

--- a/reference/cubrid/configure.xml
+++ b/reference/cubrid/configure.xml
@@ -14,7 +14,7 @@
  </simpara>
  <simpara>
   Pour plus d'informations sur l'installation manuelle sous Linux et Windows,
-  lisez le fichier <filename>build-guide.html</filename> inclus dans le paquet.
+  consulter le fichier <filename>build-guide.html</filename> inclus dans le paquet.
  </simpara>
 
 </section>

--- a/reference/cubrid/cubridmysql/cubrid-db-name.xml
+++ b/reference/cubrid/cubridmysql/cubrid-db-name.xml
@@ -49,7 +49,7 @@
   <simpara>
    Retourne le nom de la base de données en cas de succès,
    et &false; si une erreur survient. Si &false; est retourné,
-   utilisez la fonction <function>cubrid_error</function> pour
+   utiliser la fonction <function>cubrid_error</function> pour
    déterminer la nature de l'erreur.
   </simpara>
  </refsect1>

--- a/reference/cubrid/cubridmysql/cubrid-result.xml
+++ b/reference/cubrid/cubridmysql/cubrid-result.xml
@@ -40,7 +40,7 @@
     <listitem><simpara>Le nom ou la position du champ <parameter>field</parameter>
      à récupérer. Ce peut être la position du champ, son nom, ou le nom de la table suivi
      d'un point, suivi du nom du champ (tablename.fieldname). Si le nom de la colonne
-     est un alias ('select foo as bar from...'), utilisez l'alias au lieu du nom
+     est un alias ('select foo as bar from...'), utiliser l'alias au lieu du nom
      de la colonne. Si non défini, le premier champ sera récupéré.</simpara></listitem>
    </varlistentry>
   </variablelist>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -198,7 +198,7 @@
    </term>
    <listitem>
     <para>
-     Un <type>string</type> avec un répertoire qui contient plusieurs certificats CA. Utilisez cette option
+     Un <type>string</type> avec un répertoire qui contient plusieurs certificats CA. Utiliser cette option
      en combinaison avec <constant>CURLOPT_SSL_VERIFYPEER</constant>.
      Disponible à partir de cURL 7.9.8.
     </para>
@@ -241,7 +241,7 @@
    </term>
    <listitem>
     <para>
-     Le nombre de secondes à attendre lors de la tentative de connexion. Utilisez 0 pour
+     Le nombre de secondes à attendre lors de la tentative de connexion. Utiliser 0 pour
      attendre indéfiniment.
      Cette option accepte toute valeur pouvant être convertie en un <type>int</type> valide.
      Par défaut, la valeur est <literal>300</literal>.
@@ -257,7 +257,7 @@
    <listitem>
     <para>
      Le nombre de millisecondes à attendre lors de la tentative de connexion.
-     Utilisez <literal>0</literal> pour attendre indéfiniment.
+     Utiliser <literal>0</literal> pour attendre indéfiniment.
      Si cURL est compilé pour utiliser le résolveur de noms système standard, cette
      partie de la connexion utilisera toujours une résolution à la seconde complète pour
      les délais d'attente avec un délai d'attente minimum autorisé d'une seconde.
@@ -860,7 +860,7 @@
    <listitem>
     <para>
      Un alias de
-     <constant>CURLOPT_TRANSFERTEXT</constant>. Utilisez plutôt cela.
+     <constant>CURLOPT_TRANSFERTEXT</constant>. Utiliser plutôt cela.
      Disponible à partir de cURL 7.1, obsolète à partir de cURL 7.11.1
      et dernière fois disponible à partir de cURL 7.15.5.
      Supprimé à partir de PHP 7.3.0.
@@ -1361,7 +1361,7 @@
     <para>
      Accepte un handle de fichier <type>resource</type> vers le fichier à partir duquel le transfert doit être lu lors du téléchargement.
      Disponible à partir de cURL 7.1.0 et déprécié à partir de cURL 7.9.7.
-     Utilisez <constant>CURLOPT_READDATA</constant> à la place.
+     Utiliser <constant>CURLOPT_READDATA</constant> à la place.
     </para>
    </listitem>
   </varlistentry>
@@ -1752,7 +1752,7 @@
    </term>
    <listitem>
     <para>
-     La quantité maximale de redirections HTTP à suivre. Utilisez cette option aux côtés de <constant>CURLOPT_FOLLOWLOCATION</constant>.
+     La quantité maximale de redirections HTTP à suivre. Utiliser cette option aux côtés de <constant>CURLOPT_FOLLOWLOCATION</constant>.
      La valeur par défaut de <literal>20</literal> est définie pour éviter les redirections infinies.
      Définir à <literal>-1</literal> permet les redirections infinies, et <literal>0</literal> refuse toutes les redirections.
      Disponible à partir de cURL 7.5.0.
@@ -1813,7 +1813,7 @@
     <para>
      Définir à &true; pour être complètement silencieux avec
      les fonctions cURL.
-     Utilisez <constant>CURLOPT_RETURNTRANSFER</constant> à la place.
+     Utiliser <constant>CURLOPT_RETURNTRANSFER</constant> à la place.
      Disponible à partir de cURL 7.1.0, déprécié à partir de cURL 7.8.0
      et dernier disponible à partir de cURL 7.15.5.
      Supprimé à partir de PHP 7.3.0.
@@ -2250,7 +2250,7 @@
       </para>
      </note>
      Disponible à partir de cURL 7.1.0 et obsolète à partir de cURL 7.32.0.
-     Utilisez <constant>CURLOPT_XFERINFOFUNCTION</constant> à la place.
+     Utiliser <constant>CURLOPT_XFERINFOFUNCTION</constant> à la place.
     </para>
    </listitem>
   </varlistentry>
@@ -2706,8 +2706,8 @@
     <para>
      Définir sur <literal>2</literal> pour vérifier dans les champs de nom du certificat du proxy
      contre le nom du proxy. Lorsqu'il est défini sur <literal>0</literal>, la connexion réussit
-     indépendamment des noms utilisés dans le certificat. Utilisez cette capacité avec prudence!
-     Définissez sur <literal>1</literal> à partir de cURL 7.28.0 et antérieur en tant qu'option de débogage.
+     indépendamment des noms utilisés dans le certificat. Utiliser cette capacité avec prudence!
+     Définir sur <literal>1</literal> à partir de cURL 7.28.0 et antérieur en tant qu'option de débogage.
      Définir sur <literal>1</literal> à partir de cURL 7.28.1 à 7.65.3 <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant> est renvoyé.
      À partir de cURL 7.66.0, <literal>1</literal> et <literal>2</literal> sont traités comme la même valeur. 
      Par défaut, la valeur de cette option doit être maintenue à <literal>2</literal>. 
@@ -3264,7 +3264,7 @@
      Lorsque plus d'une méthode est définie, cURL interrogera le serveur pour voir
      quelles méthodes il supporte et choisira la meilleure.
      Par défaut, <literal>CURLAUTH_BASIC|CURLAUTH_GSSAPI</literal>.
-     Définissez le nom d'utilisateur et le mot de passe réels avec l'option <constant>CURLOPT_PROXYUSERPWD</constant>.
+     Définir le nom d'utilisateur et le mot de passe réels avec l'option <constant>CURLOPT_PROXYUSERPWD</constant>.
      Disponible à partir de PHP 7.3.0 et cURL 7.55.0.
     </para>
    </listitem>
@@ -3953,7 +3953,7 @@
    <listitem>
     <para>
      Définir comment <constant>CURLOPT_TIMEVALUE</constant> est traité.
-     Utilisez <constant>CURL_TIMECOND_IFMODSINCE</constant> pour retourner la
+     Utiliser <constant>CURL_TIMECOND_IFMODSINCE</constant> pour retourner la
      page uniquement si elle a été modifiée depuis le temps spécifié dans
      <constant>CURLOPT_TIMEVALUE</constant>. Si elle n'a pas été modifiée,
      un en-tête <literal>304 Not Modified</literal> sera retourné
@@ -4450,7 +4450,7 @@
    <listitem>
     <para>
      Spécife le jeton d'accès OAuth 2.0.
-     Définissez sur &null; pour désactiver.
+     Définir sur &null; pour désactiver.
      Par défaut, c'est &null;.
      Disponible à partir de PHP 7.0.7 et cURL 7.33.0.
     </para>

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -50,7 +50,7 @@
       <literal>1970-01-01 00:00:00 UTC</literal>). Il est possible de faire cela 
       en incluant le caractère <literal>!</literal> comme premier caractère dans 
       <parameter>format</parameter>, ou <literal>|</literal> comme dernier. 
-      Veuillez consulter la documentation de chaque caractère ci-dessous pour 
+      Consulter la documentation de chaque caractère ci-dessous pour
       plus d'informations.
      </para>
      <para>

--- a/reference/datetime/datetimezone/listidentifiers.xml
+++ b/reference/datetime/datetimezone/listidentifiers.xml
@@ -71,7 +71,7 @@
   <para>
    Retourne le &array; des identificateurs des fuseaux horaires.
    Seuls les éléments non obsolètes sont retournés. Pour tout obtenir, 
-   y compris les identifiants de fuseau horaire obsolètes, utilisez 
+   y compris les identifiants de fuseau horaire obsolètes, utiliser 
    <literal>DateTimeZone::ALL_WITH_BC</literal> comme valeur pour 
    <parameter>timezoneGroup</parameter>.
   </para>

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -629,7 +629,7 @@ object(DateTimeImmutable)#1 (3) {
     sont définis à la place.
    </para>
    <para>
-    Pour analyser de manière cohérente seulement une année, utilisez
+    Pour analyser de manière cohérente seulement une année, utiliser
     <function>DateTimeImmutable::createFromFormat</function> avec le
     spécificateur <literal>Y</literal>.
    </para>
@@ -857,7 +857,7 @@ object(DateTimeImmutable)#1 (3) {
     est sensible à la casse ; l'on ne peut utiliser que la majuscule "W".
    </para>
    <para>
-    Le "T" dans les formats SOAP, XMRPC et WDDX est sensible à la casse ; utilisez toujours
+    Le "T" dans les formats SOAP, XMRPC et WDDX est sensible à la casse ; utiliser toujours
     la majuscule "T".
    </para>
    <para>

--- a/reference/dba/configure.xml
+++ b/reference/dba/configure.xml
@@ -165,7 +165,7 @@
         <simpara>
          Ceci a été ajouté pour assurer la compatibilité avec l'extension
          <literal>dbm</literal> qui est obsolète.
-         Utilisez ce gestionnaire seulement quand l'on ne peut installer
+         Utiliser ce gestionnaire seulement quand l'on ne peut installer
          aucun autre gestionnaire et qu'il n'est pas possible d'utiliser le
          gestionnaire cdb intégré.
         </simpara>

--- a/reference/dom/domattr.xml
+++ b/reference/dom/domattr.xml
@@ -126,7 +126,7 @@
         Il est à noter que les entités XML sont étendues lorsqu'une valeur est définie.
         Ainsi, le caractère <literal>&amp;</literal> a une signification spéciale.
         Définir <varname>value</varname> à lui-même échouera lorsque <varname>value</varname> contient un <literal>&amp;</literal>.
-        Pour éviter l'expansion des entités, utilisez plutôt <methodname>DOMElement::setAttribute</methodname>.
+        Pour éviter l'expansion des entités, utiliser plutôt <methodname>DOMElement::setAttribute</methodname>.
        </para>
       </note>
      </listitem>

--- a/reference/dom/domattr/construct.xml
+++ b/reference/dom/domattr/construct.xml
@@ -18,7 +18,7 @@
    Cet objet est en lecture seule. Il peut être ajouté à un document, mais les
    nœuds additionnels ne peuvent pas être ajoutés à ce nœud tant que ce nœud
    est associé à un document. Pour créer un nœud accessible en écriture,
-   utilisez <xref linkend="domdocument.createattribute"/>.
+   utiliser <xref linkend="domdocument.createattribute"/>.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/dom/domcomment/construct.xml
+++ b/reference/dom/domcomment/construct.xml
@@ -19,7 +19,7 @@
    Cet objet est en lecture seule. Il peut être ajouté à un document, mais les
    nœuds additionnels ne peuvent pas être ajoutés à ce nœud tant que ce nœud
    n'est pas associé à un document. Pour créer un nœud accessible en écriture,
-   utilisez
+   utiliser
    <xref linkend="domdocument.createcomment"/>.
   </para>
  </refsect1>

--- a/reference/dom/domdocument/createelement.xml
+++ b/reference/dom/domdocument/createelement.xml
@@ -132,7 +132,7 @@ Warning: DOMDocument::createElement(): unterminated entity reference            
   <note>
    <para>
     La valeur <parameter>value</parameter> ne sera <emphasis>pas</emphasis>
-    échappée. Utilisez la méthode <methodname>DOMDocument::createTextNode</methodname>
+    échappée. Utiliser la méthode <methodname>DOMDocument::createTextNode</methodname>
     pour créer un nœud de texte avec le <emphasis>support de l'échappement</emphasis>.
    </para>
   </note>

--- a/reference/dom/domdocument/savexml.xml
+++ b/reference/dom/domdocument/savexml.xml
@@ -30,7 +30,7 @@
      <term><parameter>node</parameter></term>
      <listitem>
       <para>
-       Utilisez ce paramètre pour afficher uniquement un nœud spécifique sans déclaration XML
+       Utiliser ce paramètre pour afficher uniquement un nœud spécifique sans déclaration XML
        plutôt que la totalité du document.
       </para>
      </listitem>

--- a/reference/dom/domelement/construct.xml
+++ b/reference/dom/domelement/construct.xml
@@ -21,7 +21,7 @@
    Cet objet est en lecture seule. Il peut être ajouté à un document, mais les
    nœuds additionnels ne peuvent pas être ajoutés à ce nœud tant qu'il
    est associé à un document. Pour créer un nœud accessible en écriture,
-   utilisez <xref linkend="domdocument.createelement"/> ou 
+   utiliser <xref linkend="domdocument.createelement"/> ou 
    <xref linkend="domdocument.createelementns"/>.
   </para>
  </refsect1>

--- a/reference/dom/domelement/getelementsbytagname.xml
+++ b/reference/dom/domelement/getelementsbytagname.xml
@@ -28,7 +28,7 @@
      <term><parameter>qualifiedName</parameter></term>
      <listitem>
       <para>
-       Le nom de la balise. Utilisez le caractère générique
+       Le nom de la balise. Utiliser le caractère générique
        <literal>*</literal> pour récupérer tous les éléments contenus
        dans l'arbre de l'élément.
       </para>

--- a/reference/dom/domelement/setidattribute.xml
+++ b/reference/dom/domelement/setidattribute.xml
@@ -33,7 +33,7 @@
      <term><parameter>isId</parameter></term>
      <listitem>
       <para>
-       Définissez à &true; si l'on veut que <parameter>qualifiedName</parameter>
+       Définir à &true; si l'on veut que <parameter>qualifiedName</parameter>
        soit de type ID, &false; sinon.
       </para>
      </listitem>

--- a/reference/dom/domelement/setidattributenode.xml
+++ b/reference/dom/domelement/setidattributenode.xml
@@ -34,7 +34,7 @@
      <term><parameter>isId</parameter></term>
      <listitem>
       <para>
-       Définissez à &true; si l'on veut que <parameter>name</parameter>
+       Définir à &true; si l'on veut que <parameter>name</parameter>
        soit de type ID, &false; sinon.
       </para>
      </listitem>

--- a/reference/dom/domelement/setidattributens.xml
+++ b/reference/dom/domelement/setidattributens.xml
@@ -43,7 +43,7 @@
      <term><parameter>isId</parameter></term>
      <listitem>
       <para>
-       Définissez à &true; si l'on veut que <parameter>name</parameter>
+       Définir à &true; si l'on veut que <parameter>name</parameter>
        soit de type ID, &false; sinon.
       </para>
      </listitem>

--- a/reference/dom/domnodelist/item.xml
+++ b/reference/dom/domnodelist/item.xml
@@ -20,7 +20,7 @@
   </para>
   <tip>
    <para>
-    S'il est nécessaire de connaître le nombre de nœuds dans la collection, utilisez
+    S'il est nécessaire de connaître le nombre de nœuds dans la collection, utiliser
     la propriété <literal>length</literal> de l'objet
     <classname>DOMNodeList</classname>.
    </para>

--- a/reference/dom/domprocessinginstruction/construct.xml
+++ b/reference/dom/domprocessinginstruction/construct.xml
@@ -20,7 +20,7 @@
    Cet objet est en lecture seule. Il peut être ajouté à un document, mais les
    nœuds additionnels ne peuvent pas être ajoutés à ce nœud tant qu'il
    est associé à un document. Pour créer un nœud accessible en écriture, 
-   utilisez
+   utiliser
    <xref linkend="domdocument.createprocessinginstruction"/>.
   </para>
  </refsect1>

--- a/reference/dom/domxpath/registerphpfunctions.xml
+++ b/reference/dom/domxpath/registerphpfunctions.xml
@@ -28,7 +28,7 @@
      <term><parameter>restrict</parameter></term>
      <listitem>
       <para>
-       Utilisez ce paramètre uniquement pour autoriser certaines fonctions
+       Utiliser ce paramètre uniquement pour autoriser certaines fonctions
        à être appelées depuis XPath.
       </para>
       <para>

--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -75,7 +75,7 @@
   <simpara>
    <function>eio_readdir</function> retourne la ressource demandée en cas
    de succès,&return.falseforfailure;.
-   Définissez l'argument
+   Définir l'argument
    <parameter>result</parameter> de la fonction de rappel
    <parameter>callback</parameter> suivant le drapeau
    <parameter>flags</parameter> utilisé :

--- a/reference/errorfunc/constants.xml
+++ b/reference/errorfunc/constants.xml
@@ -178,7 +178,7 @@
    <listitem>
     <simpara>
      Avis de dépréciation à l'exécution.
-     Activez ceci pour recevoir des avertissements concernant du code
+     Activer ceci pour recevoir des avertissements concernant du code
      qui ne fonctionnera plus dans les futures versions.
     </simpara>
     <simpara>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -167,11 +167,11 @@
     <listitem>
      <para>
       Fixe le niveau d'erreur. Ce paramètre est un entier, représentant un
-      champ de bits. Ajoutez les valeurs suivantes pour choisir le niveau
+      champ de bits. Ajouter les valeurs suivantes pour choisir le niveau
       que l'on désire, telles que décrites dans la section
       <link linkend="errorfunc.constants">Constantes pré-définies</link>,
       et dans le fichier &php.ini;. Pour modifier cette configuration durant
-      l'exécution du script, utilisez la fonction
+      l'exécution du script, utiliser la fonction
       <function>error_reporting</function>. Voir aussi la directive
       <link linkend="ini.display-errors">display_errors</link>.
      </para>
@@ -194,7 +194,7 @@
        <filename>httpd.conf</filename>, n'a pas de signification utile, donc dans ces cas,
        des valeurs entières sont nécessaires. Et depuis que les niveaux
        d'erreurs ont été ajoutés, la valeur maximale (pour <constant>E_ALL</constant>)
-       devrait changer. Donc, à la place de <constant>E_ALL</constant>, utilisez
+       devrait changer. Donc, à la place de <constant>E_ALL</constant>, utiliser
        plutôt une valeur plus grande pour couvrir tous les octets, une valeur numérique comme
        <literal>2147483647</literal> (incluant toutes les erreurs, et non juste
        les erreurs de type <constant>E_ALL</constant>).

--- a/reference/ev/ev.xml
+++ b/reference/ev/ev.xml
@@ -722,7 +722,7 @@
         Les opérateurs de bits devraient être appliqués ici
         (c.-à-d. <constant>Ev::BACKEND_ALL</constant> &amp; ~
         <constant>Ev::BACKEND_KQUEUE</constant>).
-        Utilisez la méthode
+        Utiliser la méthode
         <methodname>Ev::recommendedBackends</methodname> ou ne
         spécifiez aucun backend.
        </simpara>

--- a/reference/ev/evprepare/construct.xml
+++ b/reference/ev/evprepare/construct.xml
@@ -27,7 +27,7 @@
   <simpara>
    Construit un objet de watcher EvPrepare.
    Démarre le watcher automatiquement. S'il est nécessaire
-   d'un watcher stoppé, utilisez plutôt la méthode
+   d'un watcher stoppé, utiliser plutôt la méthode
    <methodname>EvPrepare::createStopped</methodname>.
   </simpara>
  </refsect1>

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -32,7 +32,7 @@
   </constructorsynopsis>
   <simpara>
    Construit un objet watcher EvSignal et le démarre automatiquement.
-   Pour un watcher périodique stoppé, utilisez plutôt la méthode
+   Pour un watcher périodique stoppé, utiliser plutôt la méthode
    <methodname>EvSignal::createStopped</methodname>.
   </simpara>
  </refsect1>

--- a/reference/event/event.constructing.signal.events.xml
+++ b/reference/event/event.constructing.signal.events.xml
@@ -6,7 +6,7 @@
  <title>Construction d'un événement de type signal</title>
  <para>
   Un événement peut aussi surveiller les signaux de style POSIX.
-  Pour construire un gestionnaire pour un signal, utilisez la méthode
+  Pour construire un gestionnaire pour un signal, utiliser la méthode
   <methodname>Event::__construct</methodname> avec le drapeau
   <constant>Event::SIGNAL</constant> ou la méthode factorielle
   <methodname>Event::signal</methodname>.

--- a/reference/event/eventbufferevent/connect.xml
+++ b/reference/event/eventbufferevent/connect.xml
@@ -29,7 +29,7 @@
    alloue un nouveau socket et le rend non bloquant en interne.
   </para>
   <para>
-   Pour résoudre les noms DNS (de façon asynchrone), utilisez la méthode
+   Pour résoudre les noms DNS (de façon asynchrone), utiliser la méthode
    <methodname>EventBufferEvent::connectHost</methodname>.
   </para>
  </refsect1>

--- a/reference/event/eventhttp/accept.xml
+++ b/reference/event/eventhttp/accept.xml
@@ -31,7 +31,7 @@
   <note>
    <para>
     Pour lier un socket, une connexion <literal>listen</literal> et une connexion
-    <literal>accept</literal> sur le socket en un seul appel, utilisez la méthode
+    <literal>accept</literal> sur le socket en un seul appel, utiliser la méthode
     <methodname>EventHttp::bind</methodname>.
     <methodname>EventHttp::accept</methodname> n'est nécessaire que si un socket
     est prêt à accepter les connexions.

--- a/reference/fann/functions/fann-create-standard-array.xml
+++ b/reference/fann/functions/fann-create-standard-array.xml
@@ -23,7 +23,7 @@
    Lors de l'exécution du réseau, les neurones de biais émettent toujours 1.
   </para>
   <para>
-   Pour détruire un réseau de neurones, utilisez la fonction <function>fann_destroy</function>.
+   Pour détruire un réseau de neurones, utiliser la fonction <function>fann_destroy</function>.
   </para>
  </refsect1>
 

--- a/reference/fann/setup.xml
+++ b/reference/fann/setup.xml
@@ -69,7 +69,7 @@ $ sudo apt-get install libfann-dev
    <title>Installation PECL</title>
 
    <para>
-    Cette extension est disponible sur PECL. L'installation est très simple. Exécutez simplement:
+    Cette extension est disponible sur PECL. L'installation est très simple. Exécuter simplement :
     <programlisting>
 <![CDATA[
 

--- a/reference/filesystem/functions/chmod.xml
+++ b/reference/filesystem/functions/chmod.xml
@@ -62,7 +62,7 @@ chmod("/somedir/somefile", 0755);  // notation octale : valeur du mode correcte
        le groupe du propriétaire et les autres, respectivement. Chaque
        composant peut être calculé en ajoutant les droits désirés.
        Le chiffre 1 donne les droits d'exécution, le chiffre 2 les droits
-       d'écriture et le chiffre 4 les droits de lecture. Ajoutez simplement
+       d'écriture et le chiffre 4 les droits de lecture. Ajouter simplement
        ces nombres pour spécifier les droits voulus. Il est aussi possible de
        lire le manuel des systèmes Unix avec <command>man 1 chmod</command> et 
        <command>man 2 chmod</command>.

--- a/reference/filesystem/functions/copy.xml
+++ b/reference/filesystem/functions/copy.xml
@@ -21,7 +21,7 @@
    vers le fichier <parameter>to</parameter>.
   </para>
   <para>
-   Pour déplacer un fichier, utilisez la fonction
+   Pour déplacer un fichier, utiliser la fonction
    <function>rename</function>.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/filectime.xml
+++ b/reference/filesystem/functions/filectime.xml
@@ -80,7 +80,7 @@ if (file_exists($filename)) {
     Sur la plupart des serveurs UNIX, un fichier est considéré
     comme modifié si les données de son inode sont modifiées.
     C'est-à-dire lorsque les permissions (utilisateur, groupe ou autre) ont
-    été modifiées. Voyez aussi <function>filemtime</function>
+    été modifiées. Voir aussi <function>filemtime</function>
     (qu'il sera possible d'utiliser lorsqu'on créera des indications
     telles que "Dernière modification : " sur les pages web) et
     <function>fileatime</function>.

--- a/reference/filesystem/functions/fseek.xml
+++ b/reference/filesystem/functions/fseek.xml
@@ -81,7 +81,7 @@
   <warning>
    <simpara>
     Cette fonction a été créée pour imiter la fonction du même nom en langage C.
-    Veuillez faire attention aux valeurs de retour car elles diffèrent de ce que
+    Il faut faire attention aux valeurs de retour car elles diffèrent de ce que
     l'on pourrait attendre en PHP.
    </simpara>
   </warning>

--- a/reference/filter/functions/filter-input-array.xml
+++ b/reference/filter/functions/filter-input-array.xml
@@ -35,7 +35,7 @@
        Le contenu de la superglobale qui est filtrée est le contenu original
        "brut" fourni par le <acronym>SAPI</acronym>,
        avant toute modification utilisateur de la superglobale.
-       Pour filtrer une superglobale modifiée utilisez
+       Pour filtrer une superglobale modifiée utiliser
        <function>filter_var_array</function> à la place.
       </simpara>
      </warning>

--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -31,7 +31,7 @@
        Le contenu de la superglobale qui est filtrée est le contenu original
        "brut" fourni par le <acronym>SAPI</acronym>,
        avant toute modification utilisateur de la superglobale.
-       Pour filtrer une superglobale modifiée utilisez
+       Pour filtrer une superglobale modifiée utiliser
        <function>filter_var</function> à la place.
       </simpara>
      </warning>

--- a/reference/gearman/constants.xml
+++ b/reference/gearman/constants.xml
@@ -164,7 +164,7 @@
     <simpara>
      Un code d'erreur de notification obtenu avec <methodname>GearmanClient::returnCode</methodname>
      lors de l'utilisation de <methodname>GearmanClient::do</methodname>. Envoyé pour mettre à jour le statut
-     d'une tâche longue. Utilisez <methodname>GearmanClient::doStatus</methodname> pour obtenir le pourcentage
+     d'une tâche longue. Utiliser <methodname>GearmanClient::doStatus</methodname> pour obtenir le pourcentage
      de complétion de la tâche.
     </simpara>
    </listitem>

--- a/reference/gearman/gearmanclient/do.xml
+++ b/reference/gearman/gearmanclient/do.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <simpara>
    La méthode <methodname>GearmanClient::do</methodname> est obsolète
-   depuis pecl/gearman 1.0.0. Utilisez la méthode
+   depuis pecl/gearman 1.0.0. Utiliser la méthode
    <methodname>GearmanClient::doNormal</methodname> à la place.
   </simpara>
  </refsect1>

--- a/reference/gearman/gearmanclient/echo.xml
+++ b/reference/gearman/gearmanclient/echo.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    La méthode <methodname>GearmanClient::echo</methodname> est obsolète
-   depuis pecl/gearman 1.0.0. Utilisez la méthode
+   depuis pecl/gearman 1.0.0. Utiliser la méthode
    <methodname>GearmanClient::ping</methodname> à la place.
   </simpara>
  </refsect1>

--- a/reference/gearman/gearmanjob/sendstatus.xml
+++ b/reference/gearman/gearmanjob/sendstatus.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Envoie des informations de statut au serveur de travaux
-   ainsi qu'à tous les clients à l'écoute. Utilisez cette méthode
+   ainsi qu'à tous les clients à l'écoute. Utiliser cette méthode
    pour spécifier le pourcentage de réalisation du travail courant.
   </simpara>
  </refsect1>

--- a/reference/gearman/gearmanjob/status.xml
+++ b/reference/gearman/gearmanjob/status.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    Envoie des informations de statut au serveur de travaux ainsi qu'à tous
-   les clients à l'écoute. Utilisez cette méthode pour spécifier le pourcentage
+   les clients à l'écoute. Utiliser cette méthode pour spécifier le pourcentage
    de réalisation d'un travail.
   </simpara>
   <note>

--- a/reference/ibm_db2/functions/db2-connect.xml
+++ b/reference/ibm_db2/functions/db2-connect.xml
@@ -197,7 +197,7 @@
           lors de la création de la connexion.
          </simpara>
          <simpara>
-          Pour catalogue la base de données, utilisez les commandes suivantes :
+          Pour catalogue la base de données, utiliser les commandes suivantes :
          </simpara>
          <literallayout>db2 catalog tcpip node loopback remote &lt;SERVERNAME&gt; server &lt;SERVICENAME&gt;
 db2 catalog database &lt;LOCALDBNAME&gt; as &lt;REMOTEDBNAME&gt; at node loopback
@@ -474,7 +474,7 @@ db2set DB2COMM=TCPIP</literallayout>
         <listitem>
          <simpara>
           Une chaîne indiquant la liste a utilisé pour résoudre les références
-          de fichiers non qualifiés. Spécifiez la liste en séparant les
+          de fichiers non qualifiés. Spécifier la liste en séparant les
           valeurs par un espace, comme ceci : 'i5_libl'=&gt;"MYLIB YOURLIB ANYLIB".
          </simpara>
          <note>

--- a/reference/ibm_db2/functions/db2-get-option.xml
+++ b/reference/ibm_db2/functions/db2-get-option.xml
@@ -52,7 +52,7 @@
       </simpara>
       <simpara>
        Pour s'assurer que les données spécifiées dans chaque option sont converties correctement
-       lors de la transmission vers une base de données, utilisez seulement les caractères de A à Z, 0 à 9
+       lors de la transmission vers une base de données, utiliser seulement les caractères de A à Z, 0 à 9
        et les caractères de soulignement (_) ou point (.).
       </simpara>
      </note>

--- a/reference/ibm_db2/functions/db2-num-rows.xml
+++ b/reference/ibm_db2/functions/db2-num-rows.xml
@@ -22,7 +22,7 @@
   </simpara>
   <simpara>
    Afin de déterminer le nombre de lignes que retournera une requête SELECT,
-   utilisez la requête SELECT COUNT(*) avec les mêmes attributs lorsqu'on
+   utiliser la requête SELECT COUNT(*) avec les mêmes attributs lorsqu'on
    a effectué la requête SELECT et la récupération des valeurs.
   </simpara>
   <simpara>

--- a/reference/ibm_db2/functions/db2-pconnect.xml
+++ b/reference/ibm_db2/functions/db2-pconnect.xml
@@ -206,7 +206,7 @@
           connexion.
          </simpara>
          <simpara>
-          Pour cataloguer la base, utilisez la commande suivante :
+          Pour cataloguer la base, utiliser la commande suivante :
          </simpara>
          <literallayout>db2 catalog tcpip node loopback remote &lt;SERVERNAME&gt; server &lt;SERVICENAME&gt;
 db2 catalog database &lt;LOCALDBNAME&gt; as &lt;REMOTEDBNAME&gt; at node loopback
@@ -479,7 +479,7 @@ db2set DB2COMM=TCPIP</literallayout>
         <listitem>
          <para>
           Un caractère qui indique la bibliothèque qui sera utilisée pour résoudre
-          les références de fichiers non qualifiées. Spécifiez la liste de bibliothèque
+          les références de fichiers non qualifiées. Spécifier la liste de bibliothèque
           sous la forme d'éléments séparés par des espaces :
           <literal>'i5_libl'=&gt;"MYLIB YOURLIB ANYLIB"</literal>.
           <note>

--- a/reference/ibm_db2/functions/db2-result.xml
+++ b/reference/ibm_db2/functions/db2-result.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
 
   <simpara>
-   Utilisez <function>db2_result</function> pour retourner une valeur d'une
+   Utiliser <function>db2_result</function> pour retourner une valeur d'une
    colonne spécifique dans la ligne courante d'un jeu de résultats. Il faut
    appeler <function>db2_fetch_row</function> avant d'appeler
    <function>db2_result</function> pour enregistrer les valeurs pointées du

--- a/reference/ibm_db2/functions/db2-set-option.xml
+++ b/reference/ibm_db2/functions/db2-set-option.xml
@@ -224,7 +224,7 @@
        </simpara>
        <simpara>
         Pour s'assurer que les données spécifiées dans chaque option seront converties
-        correctement lorsqu'elles seront transmises au système, utilisez seulement
+        correctement lorsqu'elles seront transmises au système, utiliser seulement
         les caractères d'A à Z, 0 à 9, les soulignés (<literal>_</literal>) et
         les points (<literal>.</literal>).
        </simpara>

--- a/reference/ibm_db2/functions/db2-statistics.xml
+++ b/reference/ibm_db2/functions/db2-statistics.xml
@@ -82,7 +82,7 @@
   &reftitle.returnvalues;
   <para>
    Ce que la fonction retourne, premièrement lors de succès, ensuite lors
-   d'échec. Voyez aussi l'entité &return.success;
+   d'échec. Voir aussi l'entité &return.success;
    <informaltable>
     <tgroup cols="2">
      <thead>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -446,9 +446,9 @@
      et que la localisation ne peut pas être modifiée.
     </simpara>
     <simpara>
-     Pour en savoir plus sur les CCSID sur IBM i, consultez la
+     Pour en savoir plus sur les CCSID sur IBM i, consulter la
      <link xlink:href="&url.ibm.ccsid;">documentation IBM</link>.
-     Pour savoir comment les localisations sur IBM i PASE sont mappées sur les CCSID, consultez la
+     Pour savoir comment les localisations sur IBM i PASE sont mappées sur les CCSID, consulter la
      <link xlink:href="&url.ibm.pase.i;">documentation IBM</link>.
     </simpara>
    </listitem>
@@ -482,7 +482,7 @@
      </itemizedlist>
     </para>
     <simpara>
-     Pour en savoir plus sur les modes de nommage sur IBM i, consultez la
+     Pour en savoir plus sur les modes de nommage sur IBM i, consulter la
      <link xlink:href="&url.db2.object.naming;">documentation IBM</link>.
     </simpara>
    </listitem>

--- a/reference/image/configure.xml
+++ b/reference/image/configure.xml
@@ -120,7 +120,7 @@
       <entry>
        Pour activer le support de FreeType 2, ajoutez l'option
        <option role="configure">--with-freetype-dir=DIR</option>.
-       À partir de PHP 7.4.0 utilisez <option role="configure">--with-freetype</option>
+       À partir de PHP 7.4.0 utiliser <option role="configure">--with-freetype</option>
        à la place, qui dépend de <productname>pkg-config</productname>.
       </entry>
      </row>

--- a/reference/image/functions/imagettftext.xml
+++ b/reference/image/functions/imagettftext.xml
@@ -104,7 +104,7 @@
        Les chaînes de caractères encodées en UTF-8 peuvent être passées directement.
       </para>
       <para>
-       Les entités nommées, comme <literal>&amp;copy;</literal>, ne sont pas supportées. Utilisez la
+       Les entités nommées, comme <literal>&amp;copy;</literal>, ne sont pas supportées. Utiliser la
        fonction <function>html_entity_decode</function> pour encoder ces entités
        nommées en chaîne UTF-8.
       </para>

--- a/reference/image/setup.xml
+++ b/reference/image/setup.xml
@@ -21,7 +21,7 @@
    <note>
     <simpara>
      libgd-2.1.0 ou supérieur est requis. Alternativement, 
-     utilisez la bibliothèque <acronym>GD</acronym> fournie avec PHP.
+     utiliser la bibliothèque <acronym>GD</acronym> fournie avec PHP.
     </simpara>
    </note>
    <note>

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -96,7 +96,7 @@
        <entry>PECL imagick 2.1.0</entry>
        <entry>
         Cette méthode supporte maintenant
-        la mise à l'échelle proportionnelle. Utilisez la valeur zéro comme
+        la mise à l'échelle proportionnelle. Utiliser la valeur zéro comme
         paramètre pour une mise à l'échelle proportionnelle.
        </entry>
       </row>

--- a/reference/imagick/imagick/adaptivesharpenimage.xml
+++ b/reference/imagick/imagick/adaptivesharpenimage.xml
@@ -33,7 +33,7 @@
      <listitem>
       <para>
        Le rayon de la gaussienne, en pixels, sans compter
-       le pixel du centre. Utilisez 0 pour l'auto-sélection.
+       le pixel du centre. Utiliser 0 pour l'auto-sélection.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/compareimages.xml
+++ b/reference/imagick/imagick/compareimages.xml
@@ -38,7 +38,7 @@
      <term><parameter>metric</parameter></term>
      <listitem>
       <para>
-       Une constante de type de métrique. Voyez la liste des
+       Une constante de type de métrique. Voir la liste des
        <link linkend="imagick.constants.metric">constantes de métriques</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/compositeimage.xml
+++ b/reference/imagick/imagick/compositeimage.xml
@@ -43,7 +43,7 @@
      <term><parameter>compose</parameter></term>
      <listitem>
       <para>
-       L'opérateur de composition. Voyez la liste des <link 
+       L'opérateur de composition. Voir la liste des <link 
        linkend="imagick.constants.compositeop">constantes d'opérateurs de composition</link>
       </para>
      </listitem>

--- a/reference/imagick/imagick/distortimage.xml
+++ b/reference/imagick/imagick/distortimage.xml
@@ -43,7 +43,7 @@
      <term><parameter>method</parameter></term>
      <listitem>
       <para>
-       La méthode de déformation de l'image. Voyez les <link 
+       La méthode de déformation de l'image. Voir les <link 
        linkend="imagick.constants.distortion">constantes de déformation</link>
       </para>
      </listitem>

--- a/reference/imagick/imagick/evaluateimage.xml
+++ b/reference/imagick/imagick/evaluateimage.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    Applique une expression arithmétique, relationnelle ou logique à une image.
-   Utilisez ces opérateurs pour éclaircir ou assombrir une image, pour
+   Utiliser ces opérateurs pour éclaircir ou assombrir une image, pour
    augmenter ou réduire le contraste, ou encore, produire une image inversée.
   </para>
  </refsect1>

--- a/reference/imagick/imagick/fximage.xml
+++ b/reference/imagick/imagick/fximage.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Évalue une expression pour chaque pixel d'une image. Consultez 
+   Évalue une expression pour chaque pixel d'une image. Consulter 
    <link xlink:href="&url.imagemagick;script/fx.php"><literal>The Fx Special Effects Image Operator</literal></link>
    pour plus de détails (en anglais).
   </para>

--- a/reference/imagick/imagick/gammaimage.xml
+++ b/reference/imagick/imagick/gammaimage.xml
@@ -19,7 +19,7 @@
   <para>
    Applique une correction gamma à l'image. La même image est vue sur différents
    écran vont avoir des différences de perceptions dans la représentation
-   des intensités. Spécifiez des corrections gamma individuelles pour 
+   des intensités. Spécifier des corrections gamma individuelles pour
    les différentes couleurs, ou bien ajustez les trois corrections gamma 
    d'un seul coup. Les valeurs typiques vont de 0.8 à 2.3.
   </para>

--- a/reference/imagick/imagick/getimageblob.xml
+++ b/reference/imagick/imagick/getimageblob.xml
@@ -19,7 +19,7 @@
    Implémente un formatage directe en mémoire. Il retourne la 
    séquence d'images sous forme de chaîne. Le format de l'image 
    détermine le format du BLOB retourné (GIF, JPEG, PNG, etc.). 
-   Pour retourner un format différent, utilisez
+   Pour retourner un format différent, utiliser
    Imagick::setImageFormat().
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getimagesblob.xml
+++ b/reference/imagick/imagick/getimagesblob.xml
@@ -19,7 +19,7 @@
    Implémente le formatage direct en mémoire. Il retourne toutes les
    images de la séquence sous forme de chaîne. Le format de l'image
    détermine le format du BLOB retourné (GIF, JPEG, PNG, etc.). Pour
-   retourner un format d'image différent, utilisez 
+   retourner un format d'image différent, utiliser 
    <function>Imagick::setImageFormat</function>.
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getresource.xml
+++ b/reference/imagick/imagick/getresource.xml
@@ -28,7 +28,7 @@
      <term><parameter>type</parameter></term>
      <listitem>
       <para>
-       Voyez la liste des
+       Voir la liste des
        <link linkend="imagick.constants.resourcetypes">constantes de type de ressources</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/getsize.xml
+++ b/reference/imagick/imagick/getsize.xml
@@ -21,7 +21,7 @@
    <para>
     Cette méthode retourne simplement la taille qui a été définie à l'aide de 
     <function>Imagick::setSize</function>. Pour obtenir la 
-    largeur/hauteur réelle de l'image, utilisez <function>Imagick::getImageWidth</function> et 
+    largeur/hauteur réelle de l'image, utiliser <function>Imagick::getImageWidth</function> et 
     <function>Imagick::getImageHeight</function>.
    </para>
   </note>

--- a/reference/imagick/imagick/montageimage.xml
+++ b/reference/imagick/imagick/montageimage.xml
@@ -57,7 +57,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       Le mode de cadrage des miniatures. Voyez la liste des <link 
+       Le mode de cadrage des miniatures. Voir la liste des <link 
        linkend="imagick.constants.montagemode">constantes de mode de montage</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/motionblurimage.xml
+++ b/reference/imagick/imagick/motionblurimage.xml
@@ -22,7 +22,7 @@
    Ajoute un flou de déplacement. Une convolution de l'image
    avec un opérateur gaussien, pour un rayon et une déviation donnés
    est utilisé. Pour des résultats raisonnables, le rayon doit être
-   plus grand que la déviation. Utilisez un rayon de zéro, et 
+   plus grand que la déviation. Utiliser un rayon de zéro, et 
    Imagick va choisir sa valeur pour. L'angle donne la 
    direction du flou de déplacement.
   </para>
@@ -62,7 +62,7 @@
       <para>
        Une constante de canal, valide pour le mode de canal. Pour spécifier un
        ou plusieurs canaux, combinez les constantes de canaux avec les opérateurs logiques.
-       Voyez la liste de constantes de <link linkend="imagick.constants.channel">canaux</link>.
+       Voir la liste de constantes de <link linkend="imagick.constants.channel">canaux</link>.
        L'argument de canal est disponible uniquement si Imagick est compilé avec 
        ImageMagick, version 6.4.4 ou plus récent.
       </para>

--- a/reference/imagick/imagick/previewimages.xml
+++ b/reference/imagick/imagick/previewimages.xml
@@ -30,7 +30,7 @@
      <term><parameter>preview</parameter></term>
      <listitem>
       <para>
-       Type de prévisualisation. Voyez la liste des <link linkend="imagick.constants.preview">constantes de prévisualisation</link>
+       Type de prévisualisation. Voir la liste des <link linkend="imagick.constants.preview">constantes de prévisualisation</link>
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/profileimage.xml
+++ b/reference/imagick/imagick/profileimage.xml
@@ -21,7 +21,7 @@
    il est retiré de l'image plutôt qu'ajouté.
   </simpara>
   <simpara>
-   Pour retirer tous les profils de l'image, utilisez <literal>'*'</literal>
+   Pour retirer tous les profils de l'image, utiliser <literal>'*'</literal>
    comme <parameter>name</parameter> et &null; pour le
    <parameter>profile</parameter>.
   </simpara>

--- a/reference/imagick/imagick/setimageindex.xml
+++ b/reference/imagick/imagick/setimageindex.xml
@@ -23,7 +23,7 @@
    Modifie la position de l'itérateur à l'index <parameter>index</parameter>.
   </para>
   <para>
-   Cette méthode est obsolète. Voyez <function>Imagick::setIteratorIndex</function>
+   Cette méthode est obsolète. Voir <function>Imagick::setIteratorIndex</function>
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/setimageopacity.xml
+++ b/reference/imagick/imagick/setimageopacity.xml
@@ -25,7 +25,7 @@
    Cette méthode opère sur tous les canaux, ce qui signifie que, par exemple,
    une valeur d'opacité de 0.5 va définir toutes les zones transparentes
    en partiellement opaques. Pour ajouter de la transparence aux zones qui ne
-   sont actuellement pas transparents, utilisez la méthode
+   sont actuellement pas transparents, utiliser la méthode
    <link linkend="imagick.evaluateimage">Imagick::evaluateImage()</link>.
   </para>
   

--- a/reference/imagick/imagick/sharpenimage.xml
+++ b/reference/imagick/imagick/sharpenimage.xml
@@ -22,7 +22,7 @@
    utilisant le paramètre <parameter>radius</parameter> et la déviation
    standard <parameter>sigma</parameter>. Pour de bons résultats,
    le paramètre <parameter>radius</parameter> doit être plus élevé
-   que le paramètre <parameter>sigma</parameter>. Utilisez un <parameter>radius</parameter>
+   que le paramètre <parameter>sigma</parameter>. Utiliser un <parameter>radius</parameter>
    de 0 et <function>Imagick::sharpenImage</function> choisira un bon
    <parameter>radius</parameter> au place.
   </para>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -26,7 +26,7 @@
    ne rien faire, 3 est une valeur typique, 20 est une valeur élevée) ;
    le point du milieu indique où les tons moyens seront dans l'image
    résultante (0 correspond à blanc, 50 correspond à gris, 100 correspond
-   à noir). Définissez le paramètre <parameter>sharpen</parameter>
+   à noir). Définir le paramètre <parameter>sharpen</parameter>
    à &true; pour augmenter le contraste de l'image, sinon, le contraste
    sera réduit.
   </para>

--- a/reference/imagick/imagick/sketchimage.xml
+++ b/reference/imagick/imagick/sketchimage.xml
@@ -22,7 +22,7 @@
    un opérateur Gaussien avec le paramètre <parameter>radius</parameter>
    et la déviation standard <parameter>sigma</parameter>. Pour de bons
    résultats, le paramètre <parameter>radius</parameter> doit être plus
-   élevé que le paramètre <parameter>sigma</parameter>. Utilisez un
+   élevé que le paramètre <parameter>sigma</parameter>. Utiliser un
    <parameter>sigma</parameter> de 0 et Imagick::sketchImage() sélectionnera
    automatiquement un bon radius au place. Le paramètre
    <parameter>angle</parameter> fournit l'angle du flou du mouvement.

--- a/reference/imagick/imagickdraw/settextencoding.xml
+++ b/reference/imagick/imagickdraw/settextencoding.xml
@@ -20,7 +20,7 @@
    Spécifie le jeu de caractères à utiliser pour les annotations de texte.
    Le seul jeu de caractères qui peut être spécifié actuellement est 
    "UTF-8", qui représente l'Unicode sous forme d'une séquence d'octets.
-   Spécifiez une chaîne vide pour utiliser le jeu de caractères du système.
+   Spécifier une chaîne vide pour utiliser le jeu de caractères du système.
    Le dessin des textes peut avoir besoin d'une police qui supporte Unicode.
   </para>
  </refsect1>

--- a/reference/imagick/imagickdraw/setvectorgraphics.xml
+++ b/reference/imagick/imagickdraw/setvectorgraphics.xml
@@ -18,7 +18,7 @@
   &warn.undocumented.func;
   <para>
    Configure le vecteur graphique associé à l'objet ImagickDraw.
-   Utilisez cette méthode avec <methodname>ImagickDraw::getVectorGraphics</methodname>, pour
+   Utiliser cette méthode avec <methodname>ImagickDraw::getVectorGraphics</methodname>, pour
    faire persister l'état du vecteur graphique.
   </para>
  </refsect1>

--- a/reference/imagick/imagickpixeliterator/resetiterator.xml
+++ b/reference/imagick/imagickpixeliterator/resetiterator.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Réinitialise l'itérateur de pixel. Utilisez cette méthode avec
+   Réinitialise l'itérateur de pixel. Utiliser cette méthode avec
    ImagickPixelIterator::getNextIteratorRow() pour itérer sur tous les
    pixels d'un conteneur de pixels.
   </para>

--- a/reference/imap/setup.xml
+++ b/reference/imap/setup.xml
@@ -31,7 +31,7 @@
   <note>
    <para>
     Pour compiler la bibliothèque C cliente avec
-    SSL et/ou avec le support Kerberos, lisez la doc fournie dans
+    SSL et/ou avec le support Kerberos, consulter la doc fournie dans
     la distribution.
    </para>
   </note>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -427,7 +427,7 @@
    <listitem>
     <simpara>
      Le masque est un champ de bits qui permet de connaître la présence
-     de différentes fonctionnalités de Windows. Voyez la table ci-dessous
+     de différentes fonctionnalités de Windows. Voir la table ci-dessous
      pour connaître les différents champs.
     </simpara>
    </listitem>

--- a/reference/info/functions/phpinfo.xml
+++ b/reference/info/functions/phpinfo.xml
@@ -82,7 +82,7 @@
            <entry>4</entry>
            <entry>
             Valeurs courantes locales et générales des directives PHP.
-            Voyez aussi la fonction <function>ini_get</function>.
+            Voir aussi la fonction <function>ini_get</function>.
            </entry>
           </row>
           <row>

--- a/reference/inotify/functions/inotify-add-watch.xml
+++ b/reference/inotify/functions/inotify-add-watch.xml
@@ -52,7 +52,7 @@
     <term><parameter>mask</parameter></term>
     <listitem>
      <simpara>
-      Événements à surveiller. Voyez
+      Événements à surveiller. Voir
       <link linkend="inotify.constants">&ReservedConstants;</link>.
      </simpara>
     </listitem>

--- a/reference/intl/constants.xml
+++ b/reference/intl/constants.xml
@@ -75,7 +75,7 @@
     </term>
     <listitem>
      <simpara>
-      Vérifiez si l'entrée pour les fonctions IDN est conforme aux règles de noms
+      Vérifier si l'entrée pour les fonctions IDN est conforme aux règles de noms
       de domaine ASCII.
      </simpara>
     </listitem>

--- a/reference/intl/intlchar/islower.xml
+++ b/reference/intl/intlchar/islower.xml
@@ -18,7 +18,7 @@
   </para>
   <note>
    <para>
-    Cela manque certains caractères qui sont également en minuscules mais ont une valeur de catégorie générale différente. Pour les inclure, utilisez <function>IntlChar::isULowercase</function>.
+    Cela manque certains caractères qui sont également en minuscules mais ont une valeur de catégorie générale différente. Pour les inclure, utiliser <function>IntlChar::isULowercase</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/intl/intlchar/isupper.xml
+++ b/reference/intl/intlchar/isupper.xml
@@ -18,7 +18,7 @@
   </para>
   <note>
    <para>
-    Ceci manque certains caractères qui sont également en majuscules mais ont une valeur de catégorie générale différente. Pour les inclure, utilisez <function>IntlChar::isUUppercase</function>.
+    Ceci manque certains caractères qui sont également en majuscules mais ont une valeur de catégorie générale différente. Pour les inclure, utiliser <function>IntlChar::isUUppercase</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/intl/intlchar/isxdigit.xml
+++ b/reference/intl/intlchar/isxdigit.xml
@@ -74,7 +74,7 @@ bool(false)
   &reftitle.notes;
   <note>
    <para>
-    Pour restreindre la définition des chiffres hexadécimaux uniquement aux caractères ASCII, utilisez :
+    Pour restreindre la définition des chiffres hexadécimaux uniquement aux caractères ASCII, utiliser :
    </para>
    <programlisting role="php">
     <![CDATA[

--- a/reference/intl/messageformatter/format-message.xml
+++ b/reference/intl/messageformatter/format-message.xml
@@ -30,7 +30,7 @@
   </methodsynopsis>
   <para>
    Fonction de formatage rapide, qui formate une chaîne sans avoir à 
-   créer explicitement un objet de formatage. Utilisez cette fonction
+   créer explicitement un objet de formatage. Utiliser cette fonction
    lorsque l'opération de formatage n'est effectuée qu'une seule fois
    et qu'il n'est pas nécessaire de conserver des paramètres ou des états,
    ou lorsqu'on souhaite personnaliser la sortie en fournissant

--- a/reference/intl/messageformatter/parse-message.xml
+++ b/reference/intl/messageformatter/parse-message.xml
@@ -30,7 +30,7 @@
   </methodsynopsis>
   <para>
    Analyse la chaîne d'entrée sans créer explicitement d'objet formateur.
-   Utilisez cette fonction lorsque l'opération de formatage est fait une seule
+   Utiliser cette fonction lorsque l'opération de formatage est fait une seule
    fois, et n'a pas besoin de paramètres ou d'état.
   </para>
  </refsect1>

--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -411,7 +411,7 @@
      </term>
      <listitem>
       <simpara>
-       La position à laquelle le complément se fait. Voyez les 
+       La position à laquelle le complément se fait. Voir les 
        constantes de complément pour avoir les différentes valeurs possibles.
       </simpara>
      </listitem>

--- a/reference/intl/numberformatter/parse.xml
+++ b/reference/intl/numberformatter/parse.xml
@@ -63,7 +63,7 @@
        à utiliser. Par défaut, <constant>NumberFormatter::TYPE_DOUBLE</constant> 
        est utilisé.
        Il est à noter que <constant>NumberFormatter::TYPE_CURRENCY</constant> n'est pas pris en charge ;
-       utilisez <methodname>NumberFormatter::parseCurrency</methodname> à la place.
+       utiliser <methodname>NumberFormatter::parseCurrency</methodname> à la place.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/transliterator/construct.xml
+++ b/reference/intl/transliterator/construct.xml
@@ -18,7 +18,7 @@
    l'instantiation avec l'opérateur <link linkend="language.oop5.basic.new">new</link> operator.
   </para>
   <para>
-   Utilisez les méthodes factorisées
+   Utiliser les méthodes factorisées
    <methodname>Transliterator::create</methodname> et
    <methodname>Transliterator::createFromRules</methodname> à la place.
   </para>

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -686,7 +686,7 @@
    </term>
    <listitem>
     <simpara>
-     Constante de contrôle - N'utilisez pas Copier (<link xlink:href="&url.rfc;6171">RFC 6171</link>).
+     Constante de contrôle - N'utiliser pas Copier (<link xlink:href="&url.rfc;6171">RFC 6171</link>).
      &php.version.added; 7.3.0.
     </simpara>
    </listitem>

--- a/reference/ldap/controls.xml
+++ b/reference/ldap/controls.xml
@@ -78,7 +78,7 @@ if (!in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($ds, $result)[0]['supp
      </term>
      <listitem>
       <simpara>
-       Si applicable, la valeur du contrôle. Lisez ci-dessous pour plus d'informations.
+       Si applicable, la valeur du contrôle. Consulter ci-dessous pour plus d'informations.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/ldap/functions/ldap-err2str.xml
+++ b/reference/ldap/functions/ldap-err2str.xml
@@ -19,7 +19,7 @@
    Retourne le message lisible expliquant l'erreur dont le numéro est
    <parameter>errno</parameter>. Bien que les numéros d'erreur
    LDAP soient standardisés, différentes bibliothèques retournent des
-   messages différents ou même des textes d'erreur localisés. N'utilisez
+   messages différents ou même des textes d'erreur localisés. N'utiliser
    jamais les messages d'erreur pour identifier une erreur, mais bien les
    numéros.
   </para>

--- a/reference/ldap/functions/ldap-mod-add.xml
+++ b/reference/ldap/functions/ldap-mod-add.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Ajoute l'attribut <parameter>entry</parameter> à l'entrée <parameter>dn</parameter>.
-   Pour ajouter un nouvel objet entier, consultez la fonction <function>ldap_add</function> .
+   Pour ajouter un nouvel objet entier, consulter la fonction <function>ldap_add</function> .
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -55,7 +55,7 @@
      <listitem>
       <para>
        Un filtre ne peut être vide. Pour lire toutes les informations
-       d'une entrée, utilisez le filtre "<literal>objectClass=*</literal>".
+       d'une entrée, utiliser le filtre "<literal>objectClass=*</literal>".
        Si on sait quels sont les types qui sont utilisés dans le serveur de
        dossiers, il est également possible d'utiliser un filtre approprié, comme
        "<literal>objectClass=inetOrgPerson</literal>".

--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -78,7 +78,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       Utilisez <enumname>RoundingMode</enumname> ou l'une des constantes suivantes pour spécifier la méthode d'arrondi.
+       Utiliser <enumname>RoundingMode</enumname> ou l'une des constantes suivantes pour spécifier la méthode d'arrondi.
        <informaltable>
         <tgroup cols="2">
          <thead>

--- a/reference/mbstring/encodings.xml
+++ b/reference/mbstring/encodings.xml
@@ -213,7 +213,7 @@
      de <literal>IBM932 / CP932</literal>, qui est utilisé par
      <literal>OS/2®</literal> et Microsoft® Windows®.
      Pour échanger des informations avec ces plates-formes, 
-     utilisez <literal>EUCJP-WIN</literal>.
+     utiliser <literal>EUCJP-WIN</literal>.
     </seg>
    </seglistitem>
    <seglistitem>
@@ -229,7 +229,7 @@
      <literal>"SJIS"</literal> et <literal>"Shift_JIS"</literal> sont
      souvent utilisés à tort, pour ces jeux.
     </seg>
-    <seg>Pour <literal>CP932</literal>, utilisez <literal>SJIS-WIN</literal>.</seg>
+    <seg>Pour <literal>CP932</literal>, utiliser <literal>SJIS-WIN</literal>.</seg>
    </seglistitem>
    <seglistitem>
     <seg>(none)</seg>

--- a/reference/mbstring/functions/mb-convert-kana.xml
+++ b/reference/mbstring/functions/mb-convert-kana.xml
@@ -41,7 +41,7 @@
        L'option de conversion.
       </para>
       <para>
-       Spécifiez les conversions en combinant les valeurs suivantes.
+       Spécifier les conversions en combinant les valeurs suivantes.
        <table>
         <title>Options de conversions disponibles</title>
         <tgroup cols="2">

--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -171,7 +171,7 @@ function escape_javascript_string($str) {
 $convmap = [ 0x0, 0xffff, 0, 0xffff ];
 $msg = '';
 for ($i=0; $i < 1000; $i++) {
-  // chr() ne peut pas générer de données correctes UTF-8 plus grande valeur que 128, utilisez mb_decode_numericentity().
+  // chr() ne peut pas générer de données correctes UTF-8 plus grande valeur que 128, utiliser mb_decode_numericentity().
   $msg .= mb_decode_numericentity('&#'.$i.';', $convmap, 'UTF-8');
 }
  

--- a/reference/mbstring/functions/mb-ereg-match.xml
+++ b/reference/mbstring/functions/mb-ereg-match.xml
@@ -51,7 +51,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       L'option de recherche. Pour plus d'explications, consultez <function>mb_regex_set_options</function>.
+       L'option de recherche. Pour plus d'explications, consulter <function>mb_regex_set_options</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-ereg-replace-callback.xml
+++ b/reference/mbstring/functions/mb-ereg-replace-callback.xml
@@ -79,7 +79,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       L'option de recherche. Pour plus d'explications, consultez <function>mb_regex_set_options</function>.
+       L'option de recherche. Pour plus d'explications, consulter <function>mb_regex_set_options</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-ereg-replace.xml
+++ b/reference/mbstring/functions/mb-ereg-replace.xml
@@ -60,7 +60,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <simpara>
-       L'option de recherche. Pour plus d'explications, consultez <function>mb_regex_set_options</function>.
+       L'option de recherche. Pour plus d'explications, consulter <function>mb_regex_set_options</function>.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-ereg-search-init.xml
+++ b/reference/mbstring/functions/mb-ereg-search-init.xml
@@ -51,7 +51,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       L'option de recherche. Pour plus d'explications, consultez <function>mb_regex_set_options</function>.
+       L'option de recherche. Pour plus d'explications, consulter <function>mb_regex_set_options</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-ereg-search-pos.xml
+++ b/reference/mbstring/functions/mb-ereg-search-pos.xml
@@ -42,7 +42,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       L'option de recherche. Pour plus d'explications, consultez <function>mb_regex_set_options</function>.
+       L'option de recherche. Pour plus d'explications, consulter <function>mb_regex_set_options</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-ereg-search-regs.xml
+++ b/reference/mbstring/functions/mb-ereg-search-regs.xml
@@ -37,7 +37,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       L'option de recherche. Pour plus d'explications, consultez <function>mb_regex_set_options</function>.
+       L'option de recherche. Pour plus d'explications, consulter <function>mb_regex_set_options</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-ereg-search.xml
+++ b/reference/mbstring/functions/mb-ereg-search.xml
@@ -37,7 +37,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       L'option de recherche. Pour plus d'explications, consultez <function>mb_regex_set_options</function>.
+       L'option de recherche. Pour plus d'explications, consulter <function>mb_regex_set_options</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-regex-set-options.xml
+++ b/reference/mbstring/functions/mb-regex-set-options.xml
@@ -95,7 +95,7 @@
       <note>
        <para>
         L'option <literal>"e"</literal> n'a pas d'effet lorsqu'elle est définie par la <function>mb_regex_set_options</function>.
-        Utilisez-la avec <function>mb_ereg_replace</function> ou <function>mb_eregi_replace</function>.
+        Utiliser-la avec <function>mb_ereg_replace</function> ou <function>mb_eregi_replace</function>.
        </para>
       </note>
       <table>

--- a/reference/mcrypt/functions/mcrypt-encrypt.xml
+++ b/reference/mcrypt/functions/mcrypt-encrypt.xml
@@ -94,7 +94,7 @@
 <?php
     # --- CHIFFREMENT ---
 
-    # la clé devrait être un binaire aléatoire, utilisez la fonction scrypt, bcrypt
+    # la clé devrait être un binaire aléatoire, utiliser la fonction scrypt, bcrypt
     # ou PBKDF2 pour convertir une chaîne de caractères en une clé.
     # La clé est spécifiée en utilisant une notation hexadécimale.
     $key = pack('H*', "bcb04b7e103a0cd8b54763051cef08bc55abe029fdebae5e1d417e2ffb2a00a3");

--- a/reference/mcrypt/functions/mcrypt-generic.xml
+++ b/reference/mcrypt/functions/mcrypt-generic.xml
@@ -30,11 +30,11 @@
    Pour enregistrer les données chiffrées dans une base de données
    il faut s'assurer d'enregistrer la chaîne entière retournée par cette fonction,
    sinon la chaîne ne sera pas déchiffrée correctement. Si la chaîne d'origine
-   comporte 10 caractères et que la taille d'un bloc est de 8 (utilisez
+   comporte 10 caractères et que la taille d'un bloc est de 8 (utiliser
    <function>mcrypt_enc_get_block_size</function> pour déterminer cette taille),
    on aura besoin d'au moins 16 caractères dans le champ de la base de données.
    À noter que la chaîne retournée par <function>mdecrypt_generic</function> aura
-   16 caractères de long... utilisez <literal>rtrim($str, "\0")</literal>
+   16 caractères de long... utiliser <literal>rtrim($str, "\0")</literal>
    pour supprimer le complément.
   </simpara>
   <simpara>

--- a/reference/mcrypt/ini.xml
+++ b/reference/mcrypt/ini.xml
@@ -47,7 +47,7 @@
     <simpara>
      Le dossier contenant les algorithmes. Par défaut il s'agit du dossier indiqué à la
      compilation de libmcrypt, typiquement il s'agit de
-     <emphasis>/usr/local/lib/libmcrypt</emphasis>. Voyez
+     <emphasis>/usr/local/lib/libmcrypt</emphasis>. Voir
      <function>mcrypt_list_algorithms</function> pour plus de détails.
     </simpara>
    </listitem>
@@ -61,7 +61,7 @@
     <simpara>
      Le dossier contenant les modes. Par défaut il s'agit du dossier indiqué à la
      compilation de libmcrypt, typiquement il s'agit de
-     <emphasis>/usr/local/lib/libmcrypt</emphasis>. Voyez
+     <emphasis>/usr/local/lib/libmcrypt</emphasis>. Voir
      <function>mcrypt_list_modes</function> pour plus de détails.
     </simpara>
    </listitem>

--- a/reference/memcache/ini.xml
+++ b/reference/memcache/ini.xml
@@ -270,7 +270,7 @@
   </term>
   <listitem>
    <simpara>
-    Utilisez memcache comme gestionnaire de session en définissant cette valeur à
+    Utiliser memcache comme gestionnaire de session en définissant cette valeur à
     <literal>memcache</literal>.
    </simpara>
   </listitem>

--- a/reference/memcache/memcache/add.xml
+++ b/reference/memcache/memcache/add.xml
@@ -58,7 +58,7 @@
     <term><parameter>flag</parameter></term>
     <listitem>
      <simpara>
-      Utilisez <constant>MEMCACHE_COMPRESSED</constant> pour compresser l'élément
+      Utiliser <constant>MEMCACHE_COMPRESSED</constant> pour compresser l'élément
       (utilise zlib).
      </simpara>
     </listitem>

--- a/reference/memcache/memcache/addserver.xml
+++ b/reference/memcache/memcache/addserver.xml
@@ -85,7 +85,7 @@
     <listitem>
      <simpara>
       Pointe au port où memcache écoute pour des connexions.
-      Définissez ce paramètre à <literal>0</literal> lors de l'utilisation des sockets Unix.
+      Définir ce paramètre à <literal>0</literal> lors de l'utilisation des sockets Unix.
      </simpara>
      <simpara>
       Note : Par défaut, le paramètre <parameter>port</parameter>

--- a/reference/memcache/memcache/connect.xml
+++ b/reference/memcache/memcache/connect.xml
@@ -52,7 +52,7 @@
     <term><parameter>port</parameter></term>
     <listitem>
      <simpara>
-      Pointe au port où memcache écoute pour des connexions. Définissez ce paramètre à
+      Pointe au port où memcache écoute pour des connexions. Définir ce paramètre à
       <literal>0</literal> lors de l'utilisation des sockets Unix.
      </simpara>
      <simpara>

--- a/reference/memcache/memcache/pconnect.xml
+++ b/reference/memcache/memcache/pconnect.xml
@@ -53,7 +53,7 @@
     <term><parameter>port</parameter></term>
     <listitem>
      <simpara>
-      Pointe au port où memcache écoute pour des connexions. Définissez ce paramètre
+      Pointe au port où memcache écoute pour des connexions. Définir ce paramètre
       à <literal>0</literal> lors de l'utilisation des sockets Unix.
      </simpara>
     </listitem>

--- a/reference/memcache/memcache/replace.xml
+++ b/reference/memcache/memcache/replace.xml
@@ -62,7 +62,7 @@
     <term><parameter>flag</parameter></term>
     <listitem>
      <simpara>
-      Utilisez <constant>MEMCACHE_COMPRESSED</constant> pour enregistrer
+      Utiliser <constant>MEMCACHE_COMPRESSED</constant> pour enregistrer
       l'élément compressé (utilise zlib).
      </simpara>
     </listitem>

--- a/reference/memcache/memcache/set.xml
+++ b/reference/memcache/memcache/set.xml
@@ -72,7 +72,7 @@
     <term><parameter>flag</parameter></term>
     <listitem>
      <simpara>
-      Utilisez <constant>MEMCACHE_COMPRESSED</constant> pour enregistrer
+      Utiliser <constant>MEMCACHE_COMPRESSED</constant> pour enregistrer
       l'élément compressé (utilise zlib).
      </simpara>
     </listitem>

--- a/reference/memcached/configure.xml
+++ b/reference/memcached/configure.xml
@@ -11,24 +11,24 @@
    xlink:href="&url.pecl.package;memcached">&url.pecl.package;memcached</link>
  </para>
  <para>
-  Si libmemcached est installé dans un dossier non-standard, utilisez l'option
+  Si libmemcached est installé dans un dossier non-standard, utiliser l'option
   <option role="configure">--with-libmemcached-dir=DIR</option>, où DIR est le préfixe
   d'installation libmemcached. Ce dossier doit contenir le fichier 
     <filename>include/libmemcached/memcached.h</filename>.
  </para>
  <para>
   Zlib est nécessaire pour le support de la compression. Pour spécifier un dossier
-  d'installation non-standard de Zlib, utilisez l'option
+  d'installation non-standard de Zlib, utiliser l'option
   <option role="configure">--with-zlib-dir=DIR</option>, où DIR est le préfixe
   d'installation.
  </para>
  <para>
   Le support du gestionnaire de sessions est activé par défaut. Pour le désactiver,
-  utilisez <option role="configure">--disable-memcached-session</option>.
+  utiliser <option role="configure">--disable-memcached-session</option>.
  </para>
  <para>
   Le support de l'authentification SASL est désactivé par défaut. Pour l'activer,
-  utilisez l'option de compilation <option role="configure">--enable-memcached-sasl</option>.
+  utiliser l'option de compilation <option role="configure">--enable-memcached-sasl</option>.
   Ceci nécessite l'installation préalable de la bibliothèque libsasl2 ainsi que
   la compilation de libmemcached avec l'activation du support SASL.
  </para>

--- a/reference/memcached/constants.xml
+++ b/reference/memcached/constants.xml
@@ -175,7 +175,7 @@
     <simpara>
      Spécifie l'algorithme de hachage utilisé pour les clés. Les valeurs valides
      sont fournies avec les constantes <constant>Memcached::HASH_<replaceable>*</replaceable></constant>.
-     Chaque algorithme de hachage a ses avantages et inconvénients. Utilisez
+     Chaque algorithme de hachage a ses avantages et inconvénients. Utiliser
      celui qui est donné par défaut, si on ne comprenez pas, ou que peu l'on
      importe.
     </simpara>
@@ -367,7 +367,7 @@
    <term><constant>Memcached::OPT_BINARY_PROTOCOL</constant></term>
    <listitem>
     <simpara>
-     Activez cette option pour utiliser le protocole binaire. 
+     Activer cette option pour utiliser le protocole binaire.
      À noter qu'il n'est pas possible de changer cette option pour 
      une connexion déjà ouverte.
     </simpara>

--- a/reference/memcached/ini.xml
+++ b/reference/memcached/ini.xml
@@ -424,7 +424,7 @@
      <listitem>
       <para>
        Définit le protocole memcached par défaut pour les nouvelles connexions. (Pour configurer le protocole memcached pour
-       les connexions utilisées par les sessions, utilisez <literal>memcached.sess_binary_protocol</literal> à la place.)
+       les connexions utilisées par les sessions, utiliser <literal>memcached.sess_binary_protocol</literal> à la place.)
 
        Si défini à <literal>On</literal>, le protocole binaire memcached est utilisé par défaut.
        Si défini à <literal>Off</literal>, le protocole texte memcached est utilisé.
@@ -440,7 +440,7 @@
      <listitem>
       <para>
        Définit le délai de connexion memcached par défaut pour les nouvelles connexions.
-      (Pour configurer le délai de connexion memcached pour les sessions, utilisez <literal>memcached.sess_connect_timeout</literal> à la place.)
+      (Pour configurer le délai de connexion memcached pour les sessions, utiliser <literal>memcached.sess_connect_timeout</literal> à la place.)
 
        Dans un mode non bloquant, cela change la valeur du délai.
        Pendant la connexion du socket en millisecondes.
@@ -459,7 +459,7 @@
       <para>
        Définit le hachage consistant par défaut pour les nouvelles connexions.
        (Pour configurer le hachage consistant pour les connexions utilisées par les sessions,
-       utilisez <literal>memcached.sess_consistent_hash</literal> à la place.)
+       utiliser <literal>memcached.sess_consistent_hash</literal> à la place.)
 
        Si défini à <literal>On</literal>, le hachage consistant (libketama) est utilisé pour la
        gestion des sessions. Lorsque le hachage consistant est utilisé, on peut ajouter ou supprimer des nœuds de cache

--- a/reference/memcached/memcached/addserver.xml
+++ b/reference/memcached/memcached/addserver.xml
@@ -28,7 +28,7 @@
   </para>
   <para>
    Le même serveur peut apparaître plusieurs fois dans le pool, car aucune
-   recherche de doublon n'est faite. Ce n'est pas recommandé : utilisez plutôt
+   recherche de doublon n'est faite. Ce n'est pas recommandé : utiliser plutôt
    le paramètre <parameter>weight</parameter> pour augmenter le poids d'un serveur
    dans la sélection.
   </para>

--- a/reference/memcached/memcached/construct.xml
+++ b/reference/memcached/memcached/construct.xml
@@ -30,7 +30,7 @@
      <listitem>
       <para>
        Par défaut, les instances Memcached sont détruites à la fin de la 
-       requête. Pour créer un objet qui persiste entre les requêtes, utilisez
+       requête. Pour créer un objet qui persiste entre les requêtes, utiliser
        le paramètre <parameter>persistent_id</parameter> pour spécifier un identifiant
        unique pour l'instance. Tous les objets créés avec le même 
        identifiant <parameter>persistent_id</parameter> partageront la même connexion.

--- a/reference/memcached/memcached/fetchall.xml
+++ b/reference/memcached/memcached/fetchall.xml
@@ -29,7 +29,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne les résultats&return.falseforfailure;.
-   Utilisez <methodname>Memcached::getResultCode</methodname> si nécessaire.
+   Utiliser <methodname>Memcached::getResultCode</methodname> si nécessaire.
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/getoption.xml
+++ b/reference/memcached/memcached/getoption.xml
@@ -18,7 +18,7 @@
    Retourne la valeur de l'option Memcached 
    <parameter>option</parameter>. Ces options sont définies par 
    libmemcached, et d'autres sont spécifiques à cette extension.
-   Voyez <link linkend="memcached.constants">constantes Memcached</link> 
+   Voir <link linkend="memcached.constants">constantes Memcached</link> 
    pour plus d'informations.
   </para>
  </refsect1>

--- a/reference/memcached/memcached/getstats.xml
+++ b/reference/memcached/memcached/getstats.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    <function>Memcached::getStats</function> retourne un tableau contenant
-   l'état de toutes les machines en fonctionnement. Voyez le  
+   l'état de toutes les machines en fonctionnement. Voir le  
    <link xlink:href="&url.memcache.protocol;">protocole memcached</link> pour
    plus de détails sur ces statistiques.
   </para>

--- a/reference/mhash/book.xml
+++ b/reference/mhash/book.xml
@@ -26,7 +26,7 @@
   </para>
   <note>
    <para>
-    Cette extension est obsolète. Veuillez utiliser l'extension
+    Cette extension est obsolète. Il convient d'utiliser l'extension
     <link linkend="book.hash">Hash</link> à la place.
    </para>
   </note>
@@ -35,7 +35,7 @@
     À partir de PHP 7.0.0 l'extension Mhash a été complètement intégrée dans
     l'extension <link linkend="book.hash">Hash</link>. Par conséquent il n'est 
     plus possible de détecter le support de Mhash grâce à <function>
-    extension_loaded</function> ; utilisez <function>function_exists</function> à 
+    extension_loaded</function> ; utiliser <function>function_exists</function> à 
     la place. De plus, Mhash n'est plus signalé par <function>
     get_loaded_extensions</function> et les fonctionnalités liées.
    </para>

--- a/reference/misc/functions/defined.xml
+++ b/reference/misc/functions/defined.xml
@@ -25,9 +25,9 @@
   <note>
    <para>
     Pour vérifier si une variable existe,
-    utilisez <function>isset</function> car <function>defined</function> 
+    utiliser <function>isset</function> car <function>defined</function> 
     ne s'applique qu'aux <link linkend="language.constants">constantes</link>.
-    Pour voir si une fonction existe, utilisez
+    Pour voir si une fonction existe, utiliser
     <function>function_exists</function>.
    </para>
   </note>

--- a/reference/misc/functions/highlight-file.xml
+++ b/reference/misc/functions/highlight-file.xml
@@ -24,7 +24,7 @@
    afficher le source colorisé, avec l'extension
    <emphasis>phps</emphasis>. Par exemple,
    <filename>example.phps</filename> va afficher le source du script.
-   Pour activer cette fonctionnalité, utilisez cette ligne dans
+   Pour activer cette fonctionnalité, utiliser cette ligne dans
    &httpd.conf; :
   </para>
   <screen>

--- a/reference/misc/functions/sleep.xml
+++ b/reference/misc/functions/sleep.xml
@@ -22,7 +22,7 @@
   <note>
    <para>
     Afin de retarder l'exécution d'un programme pendant une fraction de seconde,
-    utilisez la fonction <function>usleep</function> car la fonction <function>sleep</function> attend un &integer;.
+    utiliser la fonction <function>usleep</function> car la fonction <function>sleep</function> attend un &integer;.
     Par exemple, <code>sleep(0.25)</code> retardera l'exécution du programme pendant <literal>0</literal> seconde.
    </para>
   </note>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -678,7 +678,7 @@ class UpperClass implements MongoDB\BSON\Persistable
           <para>
            La fonctionnalité <property>__pclass</property> repose sur le fait
            que la propriété soit partie d'un document MongoDB récupéré. Si l'on
-           utilisez une
+           utiliser une
            <link linkend="mongodb-driver-query.construct-queryOptions">projection</link>
            lors de la recherche de documents, il faut inclure le champ
            <property>__pclass</property> dans la projection pour que cette

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -203,7 +203,7 @@ PHP Warning:  PHP Startup: Unable to load dynamic library 'mongodb'
   <para>
    Pour les développeurs et les utilisateurs intéressés par les dernières corrections de bogues,
    l'extension peut être compilée à partir du dernier code source sur
-   <link xlink:href="&url.mongodb.github.new;">Github</link>. Exécutez les commandes suivantes
+   <link xlink:href="&url.mongodb.github.new;">Github</link>. Exécuter les commandes suivantes
    pour cloner et construire le projet :
    <programlisting role="shell">
 <![CDATA[

--- a/reference/mongodb/functions/bson/tojson.xml
+++ b/reference/mongodb/functions/bson/tojson.xml
@@ -49,7 +49,7 @@
     ces valeurs (<link xlink:href="&url.mongodb.libbson;">libbson</link> va 
     produire <literal>nan</literal> et <literal>inf</literal> littérallement, 
     qui ne peuvent pas être analysés comme JSON valide). Si on travaille avec 
-    BSON qui peut contenir des nombres non finis, utilisez svp 
+    BSON qui peut contenir des nombres non finis, utiliser svp 
     <function>MongoDB\BSON\toCanonicalExtendedJSON</function> ou  
     <function>MongoDB\BSON\toRelaxedExtendedJSON</function>.
    </simpara>

--- a/reference/mongodb/ini.xml
+++ b/reference/mongodb/ini.xml
@@ -44,22 +44,22 @@
        dans l'extension (et libmongoc).
       </para>
       <para>
-       Spécifiez une chaîne vide, <literal>"0"</literal>,
+       Spécifierune chaîne vide, <literal>"0"</literal>,
        <literal>"off"</literal>, <literal>"no"</literal>, ou
        <literal>"false"</literal> pour désactiver le journal.
       </para>
       <para>
-       Spécifiez <literal>"stderr"</literal> ou <literal>"stdout"</literal> pour journaliser
+       Spécifier<literal>"stderr"</literal> ou <literal>"stdout"</literal> pour journaliser
        vers <literal>stderr</literal> ou <literal>stdout</literal>, respectivement.
       </para>
       <para>
-       Spécifiez <literal>"1"</literal>, <literal>"on"</literal>,
+       Spécifier<literal>"1"</literal>, <literal>"on"</literal>,
        <literal>"yes"</literal>, ou <literal>"true"</literal> pour journaliser dans un nouveau
        fichier temporaire dans le répertoire temporaire système par défaut (c'est-à-dire
        <function>sys_get_temp_dir</function>).
       </para>
       <para>
-       Spécifiez une autre chaîne pour journaliser dans un nouveau fichier temporaire dans ce
+       Spécifierune autre chaîne pour journaliser dans un nouveau fichier temporaire dans ce
        répertoire. Si le répertoire ne peut pas être utilisé, le répertoire temporaire système par défaut
        sera utilisé à la place.
       </para>

--- a/reference/mongodb/mongodb/driver/command/construct.xml
+++ b/reference/mongodb/mongodb/driver/command/construct.xml
@@ -49,7 +49,7 @@
     <listitem>
      <note>
       <simpara>
-       N'utilisez pas ce paramètre pour spécifier les options décrites dans la 
+       N'utiliser pas ce paramètre pour spécifier les options décrites dans la 
        référence de la commande dans le manuel MongoDB. Ce paramètre ne doit 
        être utilisé que pour les options explicitement énumérées ci-dessous.
       </simpara>

--- a/reference/mongodb/mongodb/driver/cursor.xml
+++ b/reference/mongodb/mongodb/driver/cursor.xml
@@ -117,7 +117,7 @@ $query = new MongoDB\Driver\Query( [] );
 $cursor = $manager->executeQuery("test.asteroids", $query);
 
 /* $cursor contient maintenant un objet qui entoure le jeu de résultats. 
- * Utilisez foreach() pour itérer sur tous les résultats */
+ * Utiliser foreach() pour itérer sur tous les résultats */
 foreach($cursor as $document) {
     print_r($document);
 }

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -200,7 +200,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
             Par défaut, fournir un seul membre dans la chaîne de connexion
             établira une connexion directe ou découvrira des membres supplémentaires
             selon que l'option d'URI <literal>"replicaSet"</literal> est omise ou présente,
-            respectivement. Spécifiez &false; pour forcer la découverte à se produire
+            respectivement. Spécifier &false; pour forcer la découverte à se produire
             (si <literal>"replicaSet"</literal> est omis)
             ou spécifiez &true; pour forcer une connexion directe (si
             <literal>"replicaSet"</literal> est présent).

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -52,7 +52,7 @@
            <para>
             Configure la cohérence causale dans une session. Si &true;, chaque opération
             dans la session sera ordonnée de manière causale après l'opération de lecture
-            ou d'écriture précédente. Définissez à &false; pour désactiver la cohérence causale.
+            ou d'écriture précédente. Définir à &false; pour désactiver la cohérence causale.
            </para>
            <para>
             Voir

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -368,7 +368,7 @@
        <entry>PECL mongodb 2.0.0</entry>
        <entry>
         <para>
-         L'option <literal>"partial"</literal> a été supprimée. Utilisez
+         L'option <literal>"partial"</literal> a été supprimée. Utiliser
          <literal>"allowPartialResults"</literal> à la place.
         </para>
         <para>

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -101,7 +101,7 @@ $r = $m->executeCommand( 'dramio', $cmd );
   <para>
    Maintenant MongoDB exécute la chaîne JavaScript
    <literal>"print('Hello, '); db.users.drop(); print('!');"</literal>.
-   Cette attaque est facile à éviter : utilisez <literal>args</literal> pour passer
+   Cette attaque est facile à éviter : utiliser <literal>args</literal> pour passer
    des variables de PHP à JavaScript :
   </para>
   <programlisting role="php">
@@ -140,7 +140,7 @@ $r = $m->executeCommand( 'dramio', $cmd );
    Il est recommandé de rester à l'écart de la clause <link
    xlink:href="&url.mongodb.docs;reference/operator/query/where/#considerations">$where</link>
    dans les requêtes, car elle impacte significativement les performances. Dans
-   la mesure du possible, utilisez soit des opérateurs de requête normaux, soit
+   la mesure du possible, utiliser soit des opérateurs de requête normaux, soit
    le <link xlink:href="&url.mongodb.docs;core/aggregation-pipeline">Framework
    d'agrégation</link>.
   </para>

--- a/reference/mysql/configure.xml
+++ b/reference/mysql/configure.xml
@@ -10,7 +10,7 @@
  </warning>
 
  <simpara xml:id="mysql.configure">
-  Pour compiler, utilisez tout simplement l'option de configuration
+  Pour compiler, utiliser tout simplement l'option de configuration
   <option role="configure">--with-mysql[=DIR]</option>
   où le paramètre optionnel <literal>[DIR]</literal> pointe vers
   le dossier d'installation de MySQL.
@@ -18,7 +18,7 @@
  <simpara>
   Bien que cette extension MySQL soit compatible avec MySQL 4.1.0 et supérieur,
   elle ne supporte pas les fonctionnalités supplémentaires que cette version fournit.
-  Pour cela, utilisez plutôt l'extension <link linkend="book.mysqli">MySQLi</link>.
+  Pour cela, utiliser plutôt l'extension <link linkend="book.mysqli">MySQLi</link>.
  </simpara>
  <simpara>
   Pour installer l'extension mysqli en même temps que l'extension
@@ -93,7 +93,7 @@
     Un fichier nommé <filename>libmysql.dll</filename> est inclus dans
     la distribution de PHP pour Windows et pour que PHP puisse discuter
     avec MySQL, ce fichier doit être disponible dans le <envar>PATH</envar>
-    du système Windows. Lisez la FAQ intitulée
+    du système Windows. Consulter la FAQ intitulée
     "<link linkend="faq.installation.addtopath">Où dois-je ajouter mon répertoire PHP à la variable
     <envar>PATH</envar> sous Windows ?</link>" pour plus d'informations sur
     la réalisation de cela. Néanmoins, le fait de copier le fichier
@@ -106,7 +106,7 @@
     <filename>php_mysql.dll</filename>), la directive PHP
     <link linkend="ini.extension-dir">extension_dir</link> doit être définie
     et doit pointer vers le dossier où sont stockées les extensions PHP.
-    Lisez également le
+    Consulter également le
     <link linkend="install.windows.manual">manuel d'installation sous Windows</link>.
     Par exemple, voici une valeur possible pour la directive
     extension_dir en PHP 5 :

--- a/reference/mysql/functions/mysql-connect.xml
+++ b/reference/mysql/functions/mysql-connect.xml
@@ -98,7 +98,7 @@
       <constant>MYSQL_CLIENT_COMPRESS</constant>,
       <constant>MYSQL_CLIENT_IGNORE_SPACE</constant> ou
       <constant>MYSQL_CLIENT_INTERACTIVE</constant>.
-      Lisez la section à propos de <xref linkend="mysql.client-flags"/>
+      Consulter la section à propos de <xref linkend="mysql.client-flags"/>
       pour plus d'informations.
       En &sqlsafemode;, ce paramètre est ignoré.
      </simpara>
@@ -189,7 +189,7 @@ mysql_close($link);
     Toutes les fois qu'on spécifie &quot;localhost&quot; ou
     &quot;localhost:port&quot; en tant que serveur, la bibliothèque client
     MySQL surchargera cela et essaiera de se connecter à un socket local
-    (nommé pipe sous Windows). Pour utiliser TCP/IP, utilisez
+    (nommé pipe sous Windows). Pour utiliser TCP/IP, utiliser
     &quot;127.0.0.1&quot; au lieu de &quot;localhost&quot;. Si la bibliothèque
     client MySQL essaie de se connecter au mauvais socket local,
     le chemin correct doit être défini comme <link linkend="ini.mysql.default-host">mysql.default_host</link>

--- a/reference/mysql/functions/mysql-db-name.xml
+++ b/reference/mysql/functions/mysql-db-name.xml
@@ -65,7 +65,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne le nom de base de données en cas de succès et &false; en cas
-   d'échec. Si &false; est retourné, utilisez <function>mysql_error</function>
+   d'échec. Si &false; est retourné, utiliser <function>mysql_error</function>
    pour déterminer la nature de l'erreur.
   </simpara>
  </refsect1>

--- a/reference/mysql/functions/mysql-insert-id.xml
+++ b/reference/mysql/functions/mysql-insert-id.xml
@@ -80,7 +80,7 @@ printf("Le dernier ID inséré dans est le id %d\n", mysql_insert_id());
     de la fonction native MySQL C API <literal>mysql_insert_id()</literal>
     en un type <literal>long</literal> (nommé <type>int</type> en PHP).
     Si le colonne AUTO_INCREMENT a une colonne de type BIGINT (64 bits),
-    la conversion peut résulter en une valeur incorrecte. À la place, utilisez
+    la conversion peut résulter en une valeur incorrecte. À la place, utiliser
     la fonction SQL interne à MySQL LAST_INSERT_ID() dans une requête SQL.
     Pour plus d'informations sur les valeurs entières maximales en PHP,
     se reporter à la documentation sur les

--- a/reference/mysql/functions/mysql-list-dbs.xml
+++ b/reference/mysql/functions/mysql-list-dbs.xml
@@ -44,7 +44,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne une ressource de pointeurs de résultats en cas de succès, ou &false; si une
-   erreur survient. Utilisez la fonction <function>mysql_tablename</function>
+   erreur survient. Utiliser la fonction <function>mysql_tablename</function>
    pour parcourir ce résultat ou tout autre fonction pour les résultats de table, comme
    la fonction <function>mysql_fetch_array</function>.
   </simpara>

--- a/reference/mysql/functions/mysql-list-tables.xml
+++ b/reference/mysql/functions/mysql-list-tables.xml
@@ -55,7 +55,7 @@
    Une ressource de pointeurs de résultats en cas de succès&return.falseforfailure;.
   </simpara>
   <simpara>
-   Utilisez la fonction <function>mysql_tablename</function>
+   Utiliser la fonction <function>mysql_tablename</function>
    pour parcourir ce pointeur de résultats ou tout autre fonction
    pour les résultats de tables, comme la fonction
    <function>mysql_fetch_array</function>.

--- a/reference/mysql/functions/mysql-num-rows.xml
+++ b/reference/mysql/functions/mysql-num-rows.xml
@@ -29,7 +29,7 @@
    Récupère le nombre de lignes d'un jeu de résultat. Cette commande n'est
    disponible que pour les requêtes comme SELECT ou SHOW qui retournent
    un jeu de résultats. Pour récupérer le nombre de lignes
-   affectées par une requête INSERT, UPDATE, REPLACE ou DELETE, utilisez la
+   affectées par une requête INSERT, UPDATE, REPLACE ou DELETE, utiliser la
    fonction <function>mysql_affected_rows</function>.
   </simpara>
  </refsect1>

--- a/reference/mysql/functions/mysql-pconnect.xml
+++ b/reference/mysql/functions/mysql-pconnect.xml
@@ -127,7 +127,7 @@
   <note>
    <simpara>
     À noter que les connexions persistantes ne fonctionnent que si on utilise
-    PHP en version module. Lisez la section sur les
+    PHP en version module. Consulter la section sur les
     <link linkend="features.persistent-connections">connexions persistantes
     aux bases de données</link> pour plus d'informations.
    </simpara>

--- a/reference/mysql/functions/mysql-query.xml
+++ b/reference/mysql/functions/mysql-query.xml
@@ -73,7 +73,7 @@
    données retournées.
   </simpara>
   <simpara>
-   Utilisez <function>mysql_num_rows</function> pour trouver le nombre
+   Utiliser <function>mysql_num_rows</function> pour trouver le nombre
    de lignes retournées pour une requête du type <literal>SELECT</literal> ou
    <function>mysql_affected_rows</function> pour trouver le nombre
    de lignes affectées par les requêtes du type <literal>DELETE</literal>,

--- a/reference/mysql/functions/mysql-result.xml
+++ b/reference/mysql/functions/mysql-result.xml
@@ -67,7 +67,7 @@
       (<literal>tablename.fieldname</literal>).
       Si un alias a été utilisé pour le nom de la colonne
       (<literal>"selected foo as bar from..."</literal>),
-      utilisez plutôt l'alias. Si ce paramètre n'est pas défini, le premier champ
+      utiliser plutôt l'alias. Si ce paramètre n'est pas défini, le premier champ
       sera récupéré.
      </simpara>
     </listitem>

--- a/reference/mysql/functions/mysql-tablename.xml
+++ b/reference/mysql/functions/mysql-tablename.xml
@@ -63,7 +63,7 @@
    Le nom de la table en cas de succès&return.falseforfailure;.
   </simpara>
   <simpara>
-   Utilisez la fonction <function>mysql_tablename</function>
+   Utiliser la fonction <function>mysql_tablename</function>
    pour parcourir ce pointeur de résultats, ou n'importe quelle fonction
    pour les résultats de tables comme la fonction
    <function>mysql_fetch_array</function>.

--- a/reference/mysql_xdevapi/examples.xml
+++ b/reference/mysql_xdevapi/examples.xml
@@ -99,7 +99,7 @@ array(4) {
   il ne faut pas s'y fier. Se référer à la documentation du type de données JSON de MySQL pour plus de détails.
  </para>
  <para>
-  Optionnellement, utilisez les itérateurs de PHP pour récupérer plusieurs documents :
+  Optionnellement, utiliser les itérateurs de PHP pour récupérer plusieurs documents :
  </para>
  <example>
   <title>Récupérer et Itérer sur Plusieurs Documents</title>

--- a/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/offset.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/offset.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Ignore (décale) un nombre donné d'éléments qui autrement seraient retournés
-   par l'opération find. Utilisez avec la méthode limit().
+   par l'opération find. Utiliser avec la méthode limit().
   </para>
   <para>
    Définir un décalage plus grand que la taille de l'ensemble de résultats donne un ensemble vide.

--- a/reference/mysql_xdevapi/mysql_xdevapi/table/delete.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/table/delete.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un objet TableDelete; utilisez la méthode execute() pour exécuter la requête de suppression.
+   Un objet TableDelete; utiliser la méthode execute() pour exécuter la requête de suppression.
   </para>
  </refsect1>
 

--- a/reference/mysql_xdevapi/mysql_xdevapi/table/insert.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/table/insert.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un objet TableInsert; utilisez la méthode execute() pour exécuter l'instruction d'insertion.
+   Un objet TableInsert; utiliser la méthode execute() pour exécuter l'instruction d'insertion.
   </para>
  </refsect1>
 

--- a/reference/mysql_xdevapi/mysql_xdevapi/table/select.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/table/select.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un objet TableSelect; utilisez la méthode execute() pour exécuter la
+   Un objet TableSelect; utiliser la méthode execute() pour exécuter la
    sélection et retourner un objet RowResult.
   </para>
  </refsect1>

--- a/reference/mysql_xdevapi/mysql_xdevapi/table/update.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/table/update.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un objet TableUpdate; utilisez la méthode execute() pour exécuter l'instruction de mise à jour.
+   Un objet TableUpdate; utiliser la méthode execute() pour exécuter l'instruction de mise à jour.
   </para>
  </refsect1>
 

--- a/reference/mysql_xdevapi/mysql_xdevapi/tableselect/construct.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/tableselect/construct.xml
@@ -14,7 +14,7 @@
    <void />
   </constructorsynopsis>
   <para>
-   Un objet retourné par la méthode select(); utilisez execute() pour
+   Un objet retourné par la méthode select(); utiliser execute() pour
    exécuter la requête.
   </para>
 

--- a/reference/mysql_xdevapi/setup.xml
+++ b/reference/mysql_xdevapi/setup.xml
@@ -86,29 +86,29 @@ pdo_mysql
     <itemizedlist>
       <listitem>
         <para>
-          Le nom de l'extension est 'mysql_xdevapi', donc utilisez <literal>--enable-mysql-xdevapi</literal>.
+          Le nom de l'extension est 'mysql_xdevapi', donc utiliser <literal>--enable-mysql-xdevapi</literal>.
         </para>
       </listitem>
       <listitem>
         <para>
-          Boost; requis, utilisez optionnellement l'option de configuration --with-boost=DIR
+          Boost; requis, utiliser optionnellement l'option de configuration --with-boost=DIR
           ou définissez la variable d'environnement MYSQL_XDEVAPI_BOOST_ROOT. Seuls les
           fichiers d'en-tête boost sont requis; pas les binaires.
         </para>
       </listitem>
       <listitem>
         <para>
-          Google Protocol Buffers (protobuf): requis, utilisez optionnellement l'option de configuration
+          Google Protocol Buffers (protobuf): requis, utiliser optionnellement l'option de configuration
           --with-protobuf=DIR ou définissez la variable d'environnement MYSQL_XDEVAPI_PROTOBUF_ROOT.
         </para>
         <para>
-          Optionnellement utilisez <literal>make protobufs</literal> pour générer les fichiers protobuf (*.pb.cc/.h),
+          Optionnellement utiliser <literal>make protobufs</literal> pour générer les fichiers protobuf (*.pb.cc/.h),
           et <literal>make clean-protobufs</literal> pour supprimer les fichiers protobuf générés.
         </para>
         <para>
           Note spécifique à Windows : selon l'environnement, la bibliothèque statique avec
           un runtime DLL multi-thread peut être nécessaire.
-          Pour préparer, utilisez les options suivantes :
+          Pour préparer, utiliser les options suivantes :
           <emphasis>-Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF</emphasis>
         </para>
       </listitem>

--- a/reference/mysqli/mysqli/autocommit.xml
+++ b/reference/mysqli/mysqli/autocommit.xml
@@ -26,7 +26,7 @@
    connexion.
   </para>
   <para>
-   Pour vérifier l'état de l'auto-commit, utilisez la commande SQL
+   Pour vérifier l'état de l'auto-commit, utiliser la commande SQL
    <literal>SELECT @@autocommit</literal>.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -272,7 +272,7 @@ if (mysqli_errno($mysqli)) {
   <note>
    <para>
     &style.oop; uniquement : si la connexion a échoué, un objet est quand même retourné.
-    Pour vérifier si la connexion a échoué, utilisez soit la fonction 
+    Pour vérifier si la connexion a échoué, utiliser soit la fonction 
     <function>mysqli_connect_error</function> ou la propriété 
     <link linkend="mysqli.connect-error">mysqli-&gt;connect_error</link>
     comme dans l'exemple ci-dessus.

--- a/reference/mysqli/mysqli/kill.xml
+++ b/reference/mysqli/mysqli/kill.xml
@@ -34,7 +34,7 @@
    appelant la fonction <function>mysqli_thread_id</function>.
   </para>
   <para>
-   Pour arrêter une requête en cours d'exécution, utilisez la commande SQL
+   Pour arrêter une requête en cours d'exécution, utiliser la commande SQL
    <literal>KILL QUERY process_id</literal>.
   </para>
  </refsect1>
@@ -75,7 +75,7 @@
       <entry>8.4.0</entry>
       <entry>
        Les méthodes <methodname>mysqli::kill</methodname> et
-       <function>mysqli_kill</function> sont désormais obsolètes. Utilisez
+       <function>mysqli_kill</function> sont désormais obsolètes. Utiliser
        plutôt la commande SQL <literal>KILL</literal>.
       </entry>
      </row>

--- a/reference/mysqli/mysqli/real-connect.xml
+++ b/reference/mysqli/mysqli/real-connect.xml
@@ -178,7 +178,7 @@
       <note>
        <para>
         Pour des raisons de sécurité, l'option <constant>MULTI_STATEMENT</constant> n'est
-        pas supportée en PHP. Pour exécuter plusieurs commandes, utilisez
+        pas supportée en PHP. Pour exécuter plusieurs commandes, utiliser
         la fonction <function>mysqli_multi_query</function>.
        </para>
       </note>

--- a/reference/mysqli/mysqli/refresh.xml
+++ b/reference/mysqli/mysqli/refresh.xml
@@ -79,7 +79,7 @@
       <entry>
        Les méthodes <methodname>mysqli::refresh</methodname> et
        <function>mysqli_refresh</function> sont désormais obsolètes.
-       Utilisez les commandes SQL <literal>FLUSH</literal> à la place.
+       Utiliser les commandes SQL <literal>FLUSH</literal> à la place.
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli_result/fetch-column.xml
+++ b/reference/mysqli/mysqli_result/fetch-column.xml
@@ -56,7 +56,7 @@
   <warning>
    <para>
     Il n'y a aucun moyen de retourner une autre colonne de la même ligne si l'on
-    utilisez cette fonction pour récupérer des données.
+    utiliser cette fonction pour récupérer des données.
    </para>
   </warning>
  </refsect1>

--- a/reference/mysqli/mysqli_result/num-rows.xml
+++ b/reference/mysqli/mysqli_result/num-rows.xml
@@ -101,7 +101,7 @@ Le jeu de résultats a 239 lignes.
    <para>
     Contrairement à la fonction <function>mysqli_stmt_num_rows</function>,
     cette fonction n'a pas de variante de méthode orientée objet.
-    Dans le style orienté objet, utilisez le getter de la propriété.
+    Dans le style orienté objet, utiliser le getter de la propriété.
    </para>
   </note>
  </refsect1>

--- a/reference/mysqli/mysqli_stmt/bind-result.xml
+++ b/reference/mysqli/mysqli_stmt/bind-result.xml
@@ -56,7 +56,7 @@
    <para>
     Cette fonction est utile pour les résultats basiques.
     Pour récupérer un ensemble de résultats itérable, ou récupérer chaque ligne sous forme
-    de tableau ou d'objet, utilisez la <function>mysqli_stmt_get_result</function>.
+    de tableau ou d'objet, utiliser la <function>mysqli_stmt_get_result</function>.
    </para>
   </tip>
  </refsect1>

--- a/reference/mysqli/mysqli_stmt/reset.xml
+++ b/reference/mysqli/mysqli_stmt/reset.xml
@@ -32,7 +32,7 @@
    requête préparée (ou lorsuq'on les ferme).
   </para>
   <para>
-   Pour préparer de nouveau une requête, utilisez la fonction
+   Pour préparer de nouveau une requête, utiliser la fonction
    <function>mysqli_stmt_prepare</function>.
   </para>
  </refsect1>

--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -706,7 +706,7 @@
  <note>
   <para>
    Les alias sont fournis pour assurer la compatibilité ascendante.
-   Ne les utilisez pas dans de nouveaux projets.
+   Ne les utiliser pas dans de nouveaux projets.
   </para>
  </note>
 

--- a/reference/mysqlnd/memory.xml
+++ b/reference/mysqlnd/memory.xml
@@ -102,7 +102,7 @@
   Le driver natif MySQL supprime la référence aux variables utilisateurs lorsque
   le jeu de résultat est libéré ou qu'une opération de copie-sur-lecture
   est effectuée. Un observateur peut voir la consommation mémoire totale croître
-  tant que le jeu de résultat n'est pas libéré. Utilisez les
+  tant que le jeu de résultat n'est pas libéré. Utiliser les
   <link linkend="mysqlnd.stats">statistiques</link> pour vérifier si un script
   libère le jeu de résultats explicitement, ou si le driver le libère implicitement,
   faisant ainsi que la mémoire soit utilisée plus longtemps que nécessaire.

--- a/reference/mysqlnd/plugin.xml
+++ b/reference/mysqlnd/plugin.xml
@@ -487,7 +487,7 @@ void minit_register_hooks(TSRMLS_D) {
   </simpara>
   <note>
    <simpara>
-    N'utilisez aucune logique de taille fixe lors de la manipulation
+    N'utiliser aucune logique de taille fixe lors de la manipulation
     de la table de fonction <literal>mysqlnd</literal> : les nouvelles
     méthodes peuvent être ajoutées à la fin de la table de fonction.
     La table de fonction peut être modifiée à tout moment par la suite.

--- a/reference/network/constants.xml
+++ b/reference/network/constants.xml
@@ -591,7 +591,7 @@
    <listitem>
     <simpara>
      Ressource d'information sur l'hôte.
-     Pour plus d'explications et de significations de ces valeurs, consultez la page de l'IANA sur
+     Pour plus d'explications et de significations de ces valeurs, consulter la page de l'IANA sur
      <link xlink:href="&url.iana.system-names;">Noms des systèmes d'exploitation</link>.
     </simpara>
    </listitem>

--- a/reference/network/functions/dns-get-record.xml
+++ b/reference/network/functions/dns-get-record.xml
@@ -56,7 +56,7 @@
       <para>
        Par défaut, <function>dns_get_record</function> va rechercher toutes les
        ressources associées à <parameter>hostname</parameter>.
-       Pour limiter la requête, utilisez l'une des constantes
+       Pour limiter la requête, utiliser l'une des constantes
        <constant>DNS_<replaceable>*</replaceable></constant>.
       </para>
      </listitem>

--- a/reference/network/functions/fsockopen.xml
+++ b/reference/network/functions/fsockopen.xml
@@ -97,7 +97,7 @@
       <note>
        <para>
         Si on a besoin de définir un délai limite pour lire/écrire des
-        données à travers ce socket, utilisez la fonction
+        données à travers ce socket, utiliser la fonction
         <function>stream_set_timeout</function>, car le paramètre
         <parameter>timeout</parameter> de la fonction
         <function>fsockopen</function> est uniquement appliqué lors de la

--- a/reference/network/functions/getmxrr.xml
+++ b/reference/network/functions/getmxrr.xml
@@ -79,7 +79,7 @@
   <note>
    <para>
     Pour une compatibilité avec les versions non supportées,
-    utilisez la classe <link xlink:href="&url.php.pear;">PEAR</link> :
+    utiliser la classe <link xlink:href="&url.php.pear;">PEAR</link> :
     <link xlink:href="&url.pear.package;Net_DNS">Net_DNS</link>.
    </para>
   </note>

--- a/reference/network/functions/headers-list.xml
+++ b/reference/network/functions/headers-list.xml
@@ -16,7 +16,7 @@
   <para>
    <function>headers_list</function> retourne un tableau avec la liste des en-têtes
    qui seront transmis au navigateur. Pour déterminer si ces en-têtes ont
-   déjà été envoyés ou pas, utilisez la fonction <function>headers_sent</function>.
+   déjà été envoyés ou pas, utiliser la fonction <function>headers_sent</function>.
   </para>
  </refsect1>
 

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -169,7 +169,7 @@
       <note>
        <simpara>
         Pour définir un cookie qui inclut des attributs qui ne figurent pas parmi les clés répertoriées,
-        utilisez <function>header</function>.
+        utiliser <function>header</function>.
        </simpara>
       </note>
       <note>
@@ -406,7 +406,7 @@ one : cookieone
      <simpara>
       Du fait que l'assignation d'une valeur valant &false; à un cookie
       tente de l'effacer, les valeurs booléennes ne devraient pas être utilisées.
-      À la place, utilisez <emphasis>0</emphasis> pour &false;
+      À la place, utiliser <emphasis>0</emphasis> pour &false;
       et <emphasis>1</emphasis> pour &true;.
      </simpara>
     </listitem>
@@ -415,7 +415,7 @@ one : cookieone
       Les noms des cookies peuvent être des tableaux de noms et seront
       disponibles dans les scripts PHP sous la forme de tableaux, mais
       des cookies différents seront placés sur le navigateur.
-      Utilisez <function>json_encode</function> pour définir un cookie
+      Utiliser <function>json_encode</function> pour définir un cookie
       avec des noms et des valeurs multiples. Il n'est pas recommandé d'utiliser
       la fonction <function>serialize</function> pour cela, car
       cela peut conduire à des problèmes de sécurité.

--- a/reference/oauth/oauth/getaccesstoken.xml
+++ b/reference/oauth/oauth/getaccesstoken.xml
@@ -40,7 +40,7 @@
      <simpara>
       L'identifiant de session. Ce paramètre n'a pas d'existence
       dans les spécifications OAuth 1.0, mais peut être mis en
-      place par de grosses implémentations. Voyez
+      place par de grosses implémentations. Voir
       <link xlink:href="&url.oauth.scale;"><literal>ScalableOAuth</literal></link>
       pour plus de détails.
      </simpara>
@@ -58,7 +58,7 @@
       automatiquement passé et l'appelant n'a pas besoin de préciser
       de paramètre <parameter>verifier_token</parameter> (généralement, le token
       d'accès est échangé via l'URL de rappel <parameter>callback_url</parameter>.).
-      Voyez <link xlink:href="&url.oauth.scale;">ScalableOAuth</link>
+      Voir <link xlink:href="&url.oauth.scale;">ScalableOAuth</link>
       pour plus d'informations.
      </simpara>
     </listitem>

--- a/reference/oci8/configure.xml
+++ b/reference/oci8/configure.xml
@@ -8,7 +8,7 @@
  <section xml:id="oci8.configure" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Configuration de PHP avec OCI8</title>
   <para>
-   Relisez la section précédente sur les
+   Consulter la section précédente sur les
    <link linkend="oci8.requirements">Pré-requis</link> avant de configurer OCI8.
   </para>
   <para>
@@ -53,7 +53,7 @@ pear config-set http_proxy http://my-proxy.example.com:80/
     </listitem>
     <listitem>
      <para>
-      Exécutez :
+      Exécuter :
      </para>
      <para>
       <informalexample>
@@ -65,7 +65,7 @@ pecl install oci8
       </informalexample>
      </para>
      <para>
-      Pour PHP 7, utilisez <literal>pecl install oci8-2.2.0</literal>.
+      Pour PHP 7, utiliser <literal>pecl install oci8-2.2.0</literal>.
      </para>
     </listitem>
     <listitem>
@@ -85,7 +85,7 @@ pecl install oci8
       Si on obtient une erreur <literal>oci8_dtrace_gen.h: Aucun fichier ou
       répertoire de ce type</literal>, cela signifie que PHP a été compilé
       avec <link linkend="features.dtrace">DTrace Dynamic Tracing</link> activé.
-      Installez en utilisant la commande :
+      Installer en utilisant la commande :
      </para>
      <para>
       <informalexample>
@@ -100,7 +100,7 @@ $ pecl install oci8
    </listitem>
    <listitem>
     <para>
-      Modifiez le fichier &php.ini; et ajoutez la ligne :
+      Modifier le fichier &php.ini; et ajouter la ligne :
      </para>
      <para>
       <informalexample>
@@ -204,7 +204,7 @@ make install
        Si on obtient une erreur <literal>oci8_dtrace_gen.h: Aucun fichier ou
        répertoire de ce type</literal>, cela signifie que PHP a été compilé
        avec <link linkend="features.dtrace">DTrace Dynamic Tracing</link> activé.
-       Exécutez à nouveau les commandes <literal>configure</literal> et <literal>make</literal>
+       Exécuter à nouveau les commandes <literal>configure</literal> et <literal>make</literal>
        après avoir défini cette variable d'environnement :
       </para>
       <para>
@@ -219,7 +219,7 @@ $ export PHP_DTRACE=yes
      </listitem>
      <listitem>
       <para>
-       Modifiez le fichier &php.ini; et ajoutez la ligne :
+       Modifier le fichier &php.ini; et ajouter la ligne :
       </para>
       <para>
        <informalexample>
@@ -246,7 +246,7 @@ extension=oci8.so
    Si on compile PHP à partir du code source, l'option de configuration <literal>shared</literal> peut être utilisée pour construire OCI8 en tant que bibliothèque partagée qui peut être chargée dynamiquement dans PHP. La construction d'une extension partagée permet à OCI8 d'être facilement mis à jour sans avoir d'impact sur le reste de PHP.
   </para>
   <para>
-   Configurez OCI8 en utilisant l'une des options de configuration suivantes.
+   Configurer OCI8 en utilisant l'une des options de configuration suivantes.
   </para>
   <para>
    <itemizedlist>
@@ -436,7 +436,7 @@ extension=oci8.so
   </para>
   <para>
    Pour vérifier si les variables d'environnement ont été définies
-   correctement, utilisez la fonction <function>phpinfo</function>
+   correctement, utiliser la fonction <function>phpinfo</function>
    et s'attarder sur la section <emphasis>Environment</emphasis>
    (et non la section <emphasis>Apache Environment</emphasis>) ;
    elle doit contenir toutes les variables définies.
@@ -475,7 +475,7 @@ extension=oci8.so
       <row>
        <entry>LD_LIBRARY_PATH</entry>
        <entry>
-        Définissez cette variable (ou son équivalent sur la plateforme
+        Définir cette variable (ou son équivalent sur la plateforme
         courante, comme <literal>LIBPATH</literal>,
         ou <literal>SHLIB_PATH</literal>)
         comme le chemin vers les bibliothèques Oracle, par exemple
@@ -536,7 +536,7 @@ extension=oci8.so
    <function>oci_connect</function> ou <function>oci_pconnect</function>.
    L'erreur peut être une erreur purement PHP comme <emphasis>Call to undefined function
    oci_connect()</emphasis>, une erreur Oracle comme ORA-12705 ou
-   encore un arrêt brutal d'Apache. Vérifiez le contenu des fichiers de
+   encore un arrêt brutal d'Apache. Vérifier le contenu des fichiers de
    log d'Apache lors de son démarrage et se reporter aux sections
    ci-dessus pour résoudre le problème.
   </para>
@@ -561,7 +561,7 @@ extension=oci8.so
   <note>
    <title>Si le serveur Web ne démarre pas ou échoue au démarrage</title>
    <para>
-    Vérifiez qu'Apache est lié avec la bibliothèque pthread :
+    Vérifier qu'Apache est lié avec la bibliothèque pthread :
    </para>
    <para>
     <informalexample>

--- a/reference/oci8/constants.xml
+++ b/reference/oci8/constants.xml
@@ -95,7 +95,7 @@
      <entry>
       Mode d'exécution de la requête pour <function>oci_execute</function>.
       La transaction n'est pas automatiquement validée lors de l'utilisation
-      de ce mode. Pour plus de lisibilité dans le code, utilisez cette
+      de ce mode. Pour plus de lisibilité dans le code, utiliser cette
       valeur plutôt que l'ancienne valeur <constant>OCI_DEFAULT</constant>.
      </entry>
     </row>

--- a/reference/oci8/dtrace.xml
+++ b/reference/oci8/dtrace.xml
@@ -344,7 +344,7 @@ php*:::oci8-execute-mode
   </para>
 
   <para>
-   Exécutez un script PHP ou une application. Le script de surveillance D
+   Exécuter un script PHP ou une application. Le script de surveillance D
    affiche chaque argument de découvertes lancé. Par exemple, un simple
    script PHP qui requête une table va produire les traces suivantes :
    <informalexample>

--- a/reference/oci8/examples.xml
+++ b/reference/oci8/examples.xml
@@ -14,7 +14,7 @@
 
  <para>
   Ces exemples se connectent à la base de données
-  <literal>XE</literal> de la machine. Modifiez la chaîne de connexion
+  <literal>XE</literal> de la machine. Modifier la chaîne de connexion
   afin de correspondre à la base de données avant d'exécuter les
   exemples de cette documentation.
  </para>
@@ -152,7 +152,7 @@ oci_close($conn);
  <example>
   <title>Insertion de données dans une colonne CLOB</title>
   <para>
-   Pour de lourdes données, utilisez un objet binaire long (BLOB)
+   Pour de lourdes données, utiliser un objet binaire long (BLOB)
    ou un objet de caractères long (CLOB). Cet exemple utilise les CLOB.
   </para>
   <programlisting role="php">

--- a/reference/oci8/fan.xml
+++ b/reference/oci8/fan.xml
@@ -56,7 +56,7 @@
    <itemizedlist>
     <listitem>
      <simpara>
-      Avec les privilèges d'administrateur de la base de données, utilisez
+      Avec les privilèges d'administrateur de la base de données, utiliser
       un programme comme SQL*Plus pour activer le service de base de données
       pour poster les événements FAN ; par exemple :
      </simpara>

--- a/reference/oci8/functions/oci-bind-by-name.xml
+++ b/reference/oci8/functions/oci-bind-by-name.xml
@@ -471,7 +471,7 @@ oci_close($conn);
   </para>
 
   <para>
-   Pour quelques conditions utilisées dans les clauses IN, utilisez
+   Pour quelques conditions utilisées dans les clauses IN, utiliser
    des variables liées individuelles. Les valeurs inconnues au moment
    de l'exécution pourront être définies à NULL.
    Ceci permet d'utiliser une seule requête pour l'ensemble des utilisateurs
@@ -812,7 +812,7 @@ var_dump($output2);  // false
   &reftitle.notes;
   <warning>
    <para>
-    N'utilisez pas la fonction <function>addslashes</function> et
+    N'utiliser pas la fonction <function>addslashes</function> et
     <function>oci_bind_by_name</function> simultanément, car aucun ajout
     de guillemets n'est nécessaire. Si c'est le cas, alors les guillemets ajoutés
     seront écrits dans la base de données ; en effet, la fonction
@@ -851,7 +851,7 @@ foreach ($myarray as $key => $value)  {
     Ceci associe chaque clé à la valeur pointée par $value,
     aussi, toutes les variables associées pointent vers la
     valeur de la dernière itération de la boucle.
-    A la place, utilisez ceci :
+    A la place, utiliser ceci :
    </para>
    <informalexample>
      <programlisting role="php">

--- a/reference/oci8/functions/oci-connect.xml
+++ b/reference/oci8/functions/oci-connect.xml
@@ -35,7 +35,7 @@
    retourné lors du premier appel. Cela signifie que les transactions effectuées
    sur un gestionnaire seront actives sur les autres, sachant qu'elles utilisent
    la <emphasis>même</emphasis> connexion sous-jacente. Si 2 gestionnaires doivent avoir
-   des transactions isolées, utilisez à la place la fonction <function>oci_new_connect</function>.
+   des transactions isolées, utiliser à la place la fonction <function>oci_new_connect</function>.
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-fetch-all.xml
+++ b/reference/oci8/functions/oci-fetch-all.xml
@@ -135,14 +135,14 @@
        </table>
       </para>
       <para>
-       Utilisez l'opérateur d'addition &quot;+&quot; pour choisir une
+       Utiliser l'opérateur d'addition &quot;+&quot; pour choisir une
        combinaison de structures de tableaux et de modes d'index.
       </para>
       <para>
        Les noms de colonnes qui ne sont pas sensibles à la casse (par défaut sous Oracle),
        auront des noms d'attributs en majuscule. Les noms de colonnes qui sont sensibles à la
        casse, auront des noms d'attributs utilisant exactement la même casse de la colonne.
-       Utilisez la fonction <function>var_dump</function> sur l'objet de résultat pour vérifier
+       Utiliser la fonction <function>var_dump</function> sur l'objet de résultat pour vérifier
        la casse appropriée à utiliser pour chaque requête.
       </para>
       <para>

--- a/reference/oci8/functions/oci-fetch.xml
+++ b/reference/oci8/functions/oci-fetch.xml
@@ -132,7 +132,7 @@ oci_close($conn);
    <para>
     Cette fonction ne retournera pas de lignes depuis le jeu de
     résultats implicite depuis une base de données Oracle.
-    Utilisez plutôt la fonction
+    Utiliser plutôt la fonction
     <function>oci_fetch_array</function>.
    </para>
   </note>

--- a/reference/oci8/functions/oci-field-type-raw.xml
+++ b/reference/oci8/functions/oci-field-type-raw.xml
@@ -19,7 +19,7 @@
    Lit les données brutes "SQLT" du type du champ <parameter>column</parameter>.
   </para>
   <para>
-   Pour avoir le nom du type du champ, utilisez la fonction
+   Pour avoir le nom du type du champ, utiliser la fonction
    <function>oci_field_type</function>.
   </para>
  </refsect1>

--- a/reference/oci8/functions/oci-lob-copy.xml
+++ b/reference/oci8/functions/oci-lob-copy.xml
@@ -22,7 +22,7 @@
   </para>
   <para>
    S'il faut copier une partie spécifique d'un LOB vers une position particulière d'un LOB,
-   utilisez la fonction <function>OCILob::seek</function> pour déplacer le
+   utiliser la fonction <function>OCILob::seek</function> pour déplacer le
    pointeur interne de LOB.
   </para>
  </refsect1>

--- a/reference/oci8/functions/oci-new-descriptor.xml
+++ b/reference/oci8/functions/oci-new-descriptor.xml
@@ -68,7 +68,7 @@
  * Il attend les variables $user, $password, $table, $where, et $commitsize
  * Le script efface alors les lignes sélectionnées avec ROWID et valide
  * l'effacement après chaque groupe de $commitsize lignes.
- * (Utilisez avec prudence, car il n'y a pas d'annulation possible).
+ * (Utiliser avec prudence, car il n'y a pas d'annulation possible).
  */
 $conn = oci_connect($user, $password);
 $stmt = oci_parse($conn, "select rowid from $table $where");

--- a/reference/oci8/functions/oci-set-edition.xml
+++ b/reference/oci8/functions/oci-set-edition.xml
@@ -126,7 +126,7 @@ echo "Le résultat est $r\n";
    <title>Connexions persistantes</title>
    <para>
     Pour éviter les inconsistances de données ou des erreurs inattendues,
-    n'utilisez pas la requête ALTER SESSION SET EDITION pour changer
+    n'utiliser pas la requête ALTER SESSION SET EDITION pour changer
     une édition sur les connexions persistantes.
    </para>
   </caution>

--- a/reference/oci8/ini.xml
+++ b/reference/oci8/ini.xml
@@ -268,7 +268,7 @@
        hautement rentables, mais cela empêche PHP de détecter les problèmes de connexion,
        comme les problèmes de réseau, ou si le serveur Oracle a été éteint depuis la
        connexion de PHP, tant que la connexion n'est pas utilisée plus tard dans le script.
-       Consultez la documentation de la fonction
+       Consulter la documentation de la fonction
        <function>oci_pconnect</function> pour plus d'informations.
       </simpara>
      </note>
@@ -344,7 +344,7 @@
       ré-utilisées.
      </para>
      <para>
-      Définissez cette valeur à la taille du jeu de requêtes courantes
+      Définir cette valeur à la taille du jeu de requêtes courantes
       utilisées par l'application. Le fait de définir une valeur trop petite
       peut faire que les requêtes seront supprimées du cache avant qu'elles ne
       soient utilisées.

--- a/reference/oci8/ocilob/seek.xml
+++ b/reference/oci8/ocilob/seek.xml
@@ -48,7 +48,7 @@
         </member>
         <member>
          <constant>OCI_SEEK_END</constant> - ajoute <parameter>offset</parameter>
-         octets à la fin du LOB (utilisez une valeur négative pour obtenir une
+         octets à la fin du LOB (utiliser une valeur négative pour obtenir une
          position avant la fin du LOB).
         </member>
        </simplelist>

--- a/reference/oci8/setup.xml
+++ b/reference/oci8/setup.xml
@@ -11,14 +11,14 @@
   &reftitle.required;
   <para>
    OCI8 3.0 est incluse avec PHP 8. Elle est également disponible depuis
-   &link.pecl;. Pour PHP 7, utilisez OCI8 2.2 depuis &link.pecl;.
+   &link.pecl;. Pour PHP 7, utiliser OCI8 2.2 depuis &link.pecl;.
    OCI8 requiert Oracle 10<emphasis>g</emphasis>
    ou bibliothèques cliente ultérieures.
   </para>
   <para>
    Si la base de données Oracle est sur la même machine que PHP, le logiciel
    de base de données contient déjà les bibliothèques et en-têtes nécessaires.
-   Lorsque PHP est sur une machine différente, utilisez les bibliothèques gratuites
+   Lorsque PHP est sur une machine différente, utiliser les bibliothèques gratuites
    <link xlink:href="&url.oracle.instant.client;">Oracle Instant Client</link>.
   </para>
   <para>

--- a/reference/oci8/taf.xml
+++ b/reference/oci8/taf.xml
@@ -14,7 +14,7 @@
   détecte que l'instance de base de données est hors service ou injoignable. Elle établit une connexion
   à un autre nœud dans une configuration Oracle <link xlink:href="&url.oracle.taf.rac;">RAC</link>,
   une base de données de secours à chaud, ou la même instance de base de données
-  elle-même. Consultez le <link xlink:href="&url.oracle.taf.ociguide;">Guide du programmeur de l'interface d'appel Oracle</link>
+  elle-même. Consulter le <link xlink:href="&url.oracle.taf.ociguide;">Guide du programmeur de l'interface d'appel Oracle</link>
   pour plus d'informations sur OCI TAF.
  </para>
  <para>
@@ -45,7 +45,7 @@
   <para>
    Configurer TAF dans PHP OCI8 (le côté client) en incluant le
    paramètre FAILOVER_MODE dans la partie CONNECT_DATA d'un
-   descripteur de connexion. Consultez la section
+   descripteur de connexion. Consulter la section
    Configuration de la reprise transparente d'application
    du <link xlink:href="&url.oracle.taf.clientconfig;">
    Guide de l'administrateur Oracle Database Net Services</link>

--- a/reference/oci8/testing.xml
+++ b/reference/oci8/testing.xml
@@ -67,7 +67,7 @@
   </programlisting>
  </para>
  <para>
-  Exécutez tous les tests PHP avec la commande :
+  Exécuter tous les tests PHP avec la commande :
   <programlisting>
 <![CDATA[
     $ cd your_php_src_directory
@@ -106,12 +106,12 @@
   </programlisting>
  </para>
  <para>
-  Définissez l'environnement nécessaire à Oracle grâce au fichier
+  Définir l'environnement nécessaire à Oracle grâce au fichier
   <filename>oracle_env.sh</filename> ou
   <filename>oraenv</filename>, tel que défini ci-dessus.
  </para>
  <para>
-  Démarrez l'utilitaire en ligne de commande SQL*Plus et augmentez la valeur
+  Démarrer l'utilitaire en ligne de commande SQL*Plus et augmenter la valeur
   du paramètre <literal>PROCESSES</literal>
   <programlisting>
 <![CDATA[
@@ -121,7 +121,7 @@
   </programlisting>
  </para>
  <para>
-  Redémarrez la base de données :
+  Redémarrer la base de données :
   <programlisting>
 <![CDATA[
     SQL> startup force

--- a/reference/opcache/functions/opcache-is-script-cached-in-file-cache.xml
+++ b/reference/opcache/functions/opcache-is-script-cached-in-file-cache.xml
@@ -19,7 +19,7 @@
    Ceci peut être utilisé pour détecter facilement le « réchauffement » du cache pour
    un script particulier.
    Cette fonction ne vérifie que le cache de fichiers, pas le cache en mémoire.
-   Pour vérifier le cache en mémoire, utilisez
+   Pour vérifier le cache en mémoire, utiliser
    <function>opcache_is_script_cached</function>.
   </simpara>
  </refsect1>

--- a/reference/opcache/functions/opcache-is-script-cached.xml
+++ b/reference/opcache/functions/opcache-is-script-cached.xml
@@ -19,7 +19,7 @@
    Ceci peut être utilisé pour détecter facilement le « réchauffement » du cache pour
    un script particulier.
    Cette fonction ne vérifie que le cache en mémoire, pas le cache des fichiers.
-   Pour vérifier le cache des fichiers, utilisez
+   Pour vérifier le cache des fichiers, utiliser
    <function>opcache_is_script_cached_in_file_cache</function>.
   </simpara>
  </refsect1>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1261,7 +1261,7 @@ function getA() { return A; }
    <listitem>
     <simpara>
      Un masque de bits spécifiant quelle sortie de débogage de JIT activer
-     Pour les valeurs possibles, consultez <link xlink:href="&url.php.git.src.master.view;ext/opcache/jit/zend_jit.h">zend_jit.h</link>
+     Pour les valeurs possibles, consulter <link xlink:href="&url.php.git.src.master.view;ext/opcache/jit/zend_jit.h">zend_jit.h</link>
      (voir les définitions de macro commençant par <code>ZEND_JIT_DEBUG</code>).
     </simpara>
    </listitem>

--- a/reference/opcache/preload.xml
+++ b/reference/opcache/preload.xml
@@ -47,7 +47,7 @@ opcache.preload=preload.php
   root avant de passer à un utilisateur système non privilégié, ou si PHP est exécuté en tant que root
   (non recommandé), la valeur <link linkend="ini.opcache.preload-user">opcache.preload_user</link>
   peut spécifier l'utilisateur système pour exécuter le préchargement. L'exécution du préchargement en tant que root n'est pas autorisée
-  par défaut. Définissez <literal>opcache.preload_user=root</literal> pour l'autoriser explicitement.
+  par défaut. Définir <literal>opcache.preload_user=root</literal> pour l'autoriser explicitement.
  </simpara>
 
  <simpara>

--- a/reference/openssl/functions/openssl-open.xml
+++ b/reference/openssl/functions/openssl-open.xml
@@ -26,7 +26,7 @@
    <parameter>cipher_algo</parameter> et <parameter>iv</parameter>. Le VI est requis uniquement si la
    méthode de chiffrement l'exige. La fonction remplit <parameter>output</parameter> avec les données
    déchiffrées. La clé d'enveloppe est généralement générée lorsque les données sont scellées à l'aide d'une clé publique
-   associée à la clé privée. Consultez <function>openssl_seal</function> pour plus d'informations.
+   associée à la clé privée. Consulter <function>openssl_seal</function> pour plus d'informations.
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-pkcs12-export.xml
+++ b/reference/openssl/functions/openssl-pkcs12-export.xml
@@ -42,7 +42,7 @@
      <listitem>
       <para>
        Clé privée du fichier <acronym>PKCS</acronym>#12.
-       Consultez <link linkend="openssl.certparams">Public/Private Key Parameters</link> pour obtenir la liste des valeurs valides.
+       Consulter <link linkend="openssl.certparams">Public/Private Key Parameters</link> pour obtenir la liste des valeurs valides.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-pkcs7-verify.xml
+++ b/reference/openssl/functions/openssl-pkcs7-verify.xml
@@ -65,7 +65,7 @@
       <para>
        Si le paramètre <parameter>ca_info</parameter> est spécifié, il doit
        contenir les informations sur les tiers de certificats de confiance
-       utilisé lors de la vérification. Voyez
+       utilisé lors de la vérification. Voir
        <link linkend="openssl.cert.verification">vérification des certificats</link>
        pour plus de détails.
       </para>

--- a/reference/openssl/functions/openssl-pkey-export-to-file.xml
+++ b/reference/openssl/functions/openssl-pkey-export-to-file.xml
@@ -59,7 +59,7 @@
       <para>
        <parameter>options</parameter> peut être utilisé pour calibrer le processus
        d'exportation en spécifiant ou remplaçant les options du fichier
-       de configuration d'OpenSSl. Voyez <function>openssl_csr_new</function> 
+       de configuration d'OpenSSl. Voir <function>openssl_csr_new</function> 
        pour plus d'informations sur <parameter>options</parameter>.
       </para>
      </listitem>

--- a/reference/openssl/functions/openssl-pkey-export.xml
+++ b/reference/openssl/functions/openssl-pkey-export.xml
@@ -57,7 +57,7 @@
       <para>
        <parameter>options</parameter> peut être utilisé pour calibrer le processus
        d'exportation en spécifiant ou remplaçant les options du fichier
-       de configuration d'OpenSSl. Voyez <function>openssl_csr_new</function> 
+       de configuration d'OpenSSl. Voir <function>openssl_csr_new</function> 
        pour plus d'informations sur <parameter>options</parameter>.
       </para>
      </listitem>

--- a/reference/openssl/functions/openssl-pkey-new.xml
+++ b/reference/openssl/functions/openssl-pkey-new.xml
@@ -34,7 +34,7 @@
        Ces options peuvent soit être des paramètres spécifiques à l'algorithme utilisés pour la
        génération de clés, soit des options génériques également utilisées pour la génération
        de <acronym>CSR</acronym> si non spécifiées.
-       Consultez <function>openssl_csr_new</function> pour plus d'informations
+       Consulter <function>openssl_csr_new</function> pour plus d'informations
        sur l'utilisation de <parameter>options</parameter> pour un <acronym>CSR</acronym>.
        Parmi ces options, seules <literal>private_key_bits</literal>,
        <literal>private_key_type</literal>, <literal>curve_name</literal>,

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -19,7 +19,7 @@
    Cette fonction active la mise en mémoire tampon de la sortie.
    Lorsque la mise en mémoire tampon est active, aucune sortie n'est envoyée depuis le script ;
    au lieu de cela, la sortie est stockée dans une mémoire tampon interne.
-   Consultez <xref linkend="outcontrol.what-output-is-buffered"/>
+   Consulter <xref linkend="outcontrol.what-output-is-buffered"/>
    pour savoir exactement quelles sorties sont concernées.
   </para>
   <para>
@@ -28,10 +28,10 @@
    Si plusieurs tampons de sortie sont actifs,
    la sortie est filtrée séquentiellement
    à travers chacun d'eux dans l'ordre d'emboîtement.
-   Consultez <xref linkend="outcontrol.nesting-output-buffers"/> pour plus de détails.
+   Consulter <xref linkend="outcontrol.nesting-output-buffers"/> pour plus de détails.
   </para>
   <para>
-   Consultez <xref linkend="outcontrol.user-level-output-buffers"/>
+   Consulter <xref linkend="outcontrol.user-level-output-buffers"/>
    pour une description détaillée des tampons de sortie.
   </para>
  </refsect1>
@@ -78,7 +78,7 @@
            <link linkend="constant.php-output-handler-start">
             <constant>PHP_OUTPUT_HANDLER_<replaceable>*</replaceable></constant>
            </link>.
-           Consultez <xref linkend="outcontrol.flags-passed-to-output-handlers"/>
+           Consulter <xref linkend="outcontrol.flags-passed-to-output-handlers"/>
            pour plus de détails.
           </simpara>
          </listitem>
@@ -88,7 +88,7 @@
       <para>
        Si <parameter>callback</parameter> renvoie &false;,
        le contenu du tampon est renvoyé.
-       Consultez <xref linkend="outcontrol.output-handler-return-values"/>
+       Consulter <xref linkend="outcontrol.output-handler-return-values"/>
        pour plus de détails.
       </para>
       <warning>
@@ -102,7 +102,7 @@
        </simpara>
       </warning>
       <para>
-       Consultez <xref linkend="outcontrol.output-handlers"/>
+       Consulter <xref linkend="outcontrol.output-handlers"/>
        et <xref linkend="outcontrol.working-with-output-handlers"/>
        pour plus de détails sur les <parameter>callback</parameter>s (gestionnaires de sortie).
       </para>
@@ -118,7 +118,7 @@
        <parameter>chunk_size</parameter>.
        La valeur par défaut <literal>0</literal> signifie
        que toute la sortie est mise en mémoire tampon jusqu'à ce que la mémoire tampon soit désactivée.
-       Consultez <xref linkend="outcontrol.buffer-size"/> pour plus de détails.
+       Consulter <xref linkend="outcontrol.buffer-size"/> pour plus de détails.
       </para>
      </listitem>
     </varlistentry>
@@ -133,7 +133,7 @@
        <link linkend="outcontrol.constants.buffer-control-flags">
         indicateurs de contrôle de la mémoire tampon
        </link>.
-       Consultez <xref linkend="outcontrol.operations-on-buffers"/>
+       Consulter <xref linkend="outcontrol.operations-on-buffers"/>
        pour plus de détails.
       </para>
       <para>

--- a/reference/outcontrol/ini.xml
+++ b/reference/outcontrol/ini.xml
@@ -111,7 +111,7 @@
     <note>
      <para>
       Seules les fonctions internes peuvent être utilisées avec cette directive.
-      Pour les fonctions utilisateurs, utilisez <function>ob_start</function>.
+      Pour les fonctions utilisateurs, utiliser <function>ob_start</function>.
      </para>
     </note>
    </listitem>

--- a/reference/parallel/configure.xml
+++ b/reference/parallel/configure.xml
@@ -6,7 +6,7 @@
  &reftitle.install;
 
  <simpara>
-  utilisez l'option <option role="configure">--with-parallel[=DIR]</option>
+  utiliser l'option <option role="configure">--with-parallel[=DIR]</option>
   lors de la compilation de PHP.
  </simpara>
 

--- a/reference/parle/parle/rlexer/push.xml
+++ b/reference/parle/parle/rlexer/push.xml
@@ -71,7 +71,7 @@
        Le nouveau nom de l'état, après l'application de la règle.
       </para>
       <para>
-       Si '.' est spécifié comme état de sortie, alors l'état du lexer n'est pas modifié lorsque cette règle correspond. Un état de sortie avec '&gt;' avant le nom signifie pousser. Utilisez la signature sans id pour soit la continuation ou pour commencer la correspondance, quand une continuation ou une récursion est requise.
+       Si '.' est spécifié comme état de sortie, alors l'état du lexer n'est pas modifié lorsque cette règle correspond. Un état de sortie avec '&gt;' avant le nom signifie pousser. Utiliser la signature sans id pour soit la continuation ou pour commencer la correspondance, quand une continuation ou une récursion est requise.
       </para>
       <para>
        Si '&lt;' est spécifié comme état de sortie, cela signifie pop. Dans ce cas, la signature contenant l'id peut être utilisée pour identifier la correspondance. Il est à noter que même dans le cas où un id est spécifié, la règle se terminera d'abord lorsque tous les poussées précédentes auront été enlevées.

--- a/reference/pcntl/functions/pcntl-getpriority.xml
+++ b/reference/pcntl/functions/pcntl-getpriority.xml
@@ -19,7 +19,7 @@
    <function>pcntl_getpriority</function> retourne la priorité de 
    <parameter>process_id</parameter>. Comme les niveaux
    de priorités changent entre les types de systèmes et les versions de
-   kernel, lisez la page de manuel getpriority(2) du système pour
+   kernel, consulter la page de manuel getpriority(2) du système pour
    des détails spécifiques.
   </para>
  </refsect1>

--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -170,7 +170,7 @@ pcntl_signal(SIGTERM, "sig_handler");
 pcntl_signal(SIGHUP,  "sig_handler");
 pcntl_signal(SIGUSR1, "sig_handler");
 
-// ou bien utilisez un objet
+// ou bien utiliser un objet
 // pcntl_signal(SIGUSR1, array($obj, "faire_quelque_chose"));
 
 echo"Génération d'un signal SIGUSR1 à moi-même...\n";

--- a/reference/pcntl/functions/pcntl-sigtimedwait.xml
+++ b/reference/pcntl/functions/pcntl-sigtimedwait.xml
@@ -43,7 +43,7 @@
      <listitem>
       <para>
        Le paramètre <parameter>info</parameter> reçoit les informations
-       du signal, sous forme de tableau. Voyez 
+       du signal, sous forme de tableau. Voir 
        <function>pcntl_sigwaitinfo</function>.
       </para>
      </listitem>

--- a/reference/pcntl/functions/pcntl-wait.xml
+++ b/reference/pcntl/functions/pcntl-wait.xml
@@ -24,7 +24,7 @@
    de l'appel de la fonction, c'est-à-dire si le processus est un
    zombie, alors la fonction se termine immédiatement. Toutes les
    ressources système utilisées par le processus fils sont libérées.
-   Lisez le manuel du système à wait(2) pour avoir des
+   Consulter le manuel du système à wait(2) pour avoir des
    détails spécifiques sur le fonctionnement de wait() sur celui-ci.
   </para>
   <note>

--- a/reference/pcntl/functions/pcntl-waitid.xml
+++ b/reference/pcntl/functions/pcntl-waitid.xml
@@ -54,7 +54,7 @@
    <para>
     Cette documentation couvre la spécification POSIX de la fonction
     <literal>waitid</literal>, avec quelques paramètres supplémentaires spécifiques
-    aux implémentations sur Linux, NetBSD et FreeBSD. Veuillez consulter la page
+    aux implémentations sur Linux, NetBSD et FreeBSD. Consulter la page
     manuel du système <literal>waitid(2)</literal> pour des détails spécifiques
     sur le fonctionnement de <literal>waitid</literal> sur le système.
    </para>

--- a/reference/pcre/book.xml
+++ b/reference/pcre/book.xml
@@ -36,7 +36,7 @@
   <warning>
    <para>
     Il faut être conscient des limitations de PCRE.
-    Lisez <link xlink:href="&url.pcre.man;">&url.pcre.man;</link> pour plus de détails.
+    Consulter <link xlink:href="&url.pcre.man;">&url.pcre.man;</link> pour plus de détails.
    </para>
   </warning>
   <!-- FIXME: Check what Perl version implementation corresponds -->

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -275,7 +275,7 @@ Array
         <parameter>subject</parameter>, car 
         <parameter>pattern</parameter> peut contenir des assertions comme
         <emphasis>^</emphasis>, <emphasis>$</emphasis> ou
-        <emphasis>(?&lt;=x)</emphasis>. Lisez la documentation 
+        <emphasis>(?&lt;=x)</emphasis>. Consulter la documentation 
         sur la fonction <function>preg_match</function> pour des exemples.
        </para>
       </note>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -400,9 +400,9 @@ Array
   &reftitle.notes;
   <tip>
    <para>
-    N'utilisez pas <function>preg_match</function> pour uniquement
+    N'utiliser pas <function>preg_match</function> pour uniquement
     savoir si une chaîne est contenue dans une autre.
-    Utilisez <function>strpos</function> à la place car ça sera plus rapide.
+    Utiliser <function>strpos</function> à la place car ça sera plus rapide.
    </para>
   </tip>
  </refsect1>

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -14,7 +14,7 @@
    <para>
     PDO et le pilote <link linkend="ref.pdo-sqlite">PDO_SQLITE</link>
     sont activés par défaut. Il faut activer
-    le pilote PDO de la base de données de son choix ; consultez
+    le pilote PDO de la base de données de son choix ; consulter
     la documentation pour les
     <link linkend="pdo.drivers">pilotes spécifiques au base
      de données</link> pour plus d'informations.
@@ -52,7 +52,7 @@ extension=pdo
    <para>
     PDO est activé par défaut.
     Choisissez les autres fichiers DLL spécifiques à la base de données
-    et utilisez soit la fonction <function>dl</function> pour les charger
+    et utiliser soit la fonction <function>dl</function> pour les charger
     au moment de l'exécution ou activez-les dans le fichier &php.ini;.
     Par exemple, ceci charge le pilote
     <link linkend="ref.pdo-sqlite">PDO_SQLITE</link> mais

--- a/reference/pdo/ini.xml
+++ b/reference/pdo/ini.xml
@@ -42,7 +42,7 @@
    </term>
    <listitem>
     <para>
-     Définit un alias DSN. Voyez <methodname>PDO::__construct</methodname> pour
+     Définit un alias DSN. Voir <methodname>PDO::__construct</methodname> pour
      une explication complète.
     </para>
    </listitem>

--- a/reference/pdo/pdo/exec.xml
+++ b/reference/pdo/pdo/exec.xml
@@ -23,7 +23,7 @@
   <para>
    <methodname>PDO::exec</methodname> ne retourne pas de résultat pour une requête
    SELECT. Pour une requête SELECT dont on aurait besoin une seule fois dans
-   le programme, utilisez plutôt la fonction <methodname>PDO::query</methodname>.
+   le programme, utiliser plutôt la fonction <methodname>PDO::query</methodname>.
    Pour une requête dont on aurait besoin plusieurs fois, préparez un objet
    <classname>PDOStatement</classname> avec la fonction <methodname>PDO::prepare</methodname> et exécutez
    la requête avec la fonction <methodname>PDOStatement::execute</methodname>.

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -24,7 +24,7 @@
    lorsque la requête sera exécutée.
    L'utilisation à la fois des paramètres nommés ainsi que les marqueurs est
    impossible dans un modèle de déclaration ; seul l'un ou l'autre style de paramètre.
-   Utilisez ces paramètres pour lier les entrées utilisateurs, ne les incluez pas
+   Utiliser ces paramètres pour lier les entrées utilisateurs, ne les incluez pas
    directement dans la requête.
   </para>
   <para>

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -33,7 +33,7 @@
    en cache une version compilée de la requête.
   </para>
   <para>
-   Tous les pilotes PDO n'implémentent pas cette méthode (comme PDO_ODBC). Utilisez
+   Tous les pilotes PDO n'implémentent pas cette méthode (comme PDO_ODBC). Utiliser
    les requêtes préparées à la place.
   </para>
   <caution>

--- a/reference/pdo/pdoexception.xml
+++ b/reference/pdo/pdoexception.xml
@@ -81,7 +81,7 @@
      <term><varname>code</varname></term>
      <listitem>
       <para>
-       Code erreur <literal>SQLSTATE</literal>. Utilisez la méthode
+       Code erreur <literal>SQLSTATE</literal>. Utiliser la méthode
        <methodname>Exception::getCode</methodname> pour y accéder.
       </para>
      </listitem>

--- a/reference/pdo/pdostatement/bindparam.xml
+++ b/reference/pdo/pdostatement/bindparam.xml
@@ -68,7 +68,7 @@
        Type explicite de données pour le paramètre utilisant les constantes
        <link linkend="pdo.constants"><literal>PDO::PARAM_*</literal></link>.
        Pour retourner un paramètre INOUT depuis une procédure
-       stockée, utilisez l'opérateur OR pour définir l'octet <constant>PDO::PARAM_INPUT_OUTPUT</constant>
+       stockée, utiliser l'opérateur OR pour définir l'octet <constant>PDO::PARAM_INPUT_OUTPUT</constant>
        pour le paramètre <parameter>type</parameter>.
       </para>
      </listitem>

--- a/reference/pdo/pdostatement/columncount.xml
+++ b/reference/pdo/pdostatement/columncount.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
 
   <para>
-   Utilisez la fonction <methodname>PDOStatement::columnCount</methodname>
+   Utiliser la fonction <methodname>PDOStatement::columnCount</methodname>
    pour retourner le nombre de colonnes dans le jeu de résultats représenté
    par l'objet PDOStatement.
   </para>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -57,17 +57,17 @@
       <para>
        Pour indexer le tableau résultant par la valeur d'une certaine colonne (plutôt que par des nombres
        consécutifs), placez le nom de cette colonne en premier dans la liste des colonnes en SQL, et
-       utilisez <constant>PDO::FETCH_UNIQUE</constant>. Cette colonne doit contenir uniquement des
+       utiliser <constant>PDO::FETCH_UNIQUE</constant>. Cette colonne doit contenir uniquement des
        valeurs uniques, sinon certaines données seront perdues.
       </para>
       <para>
        Pour regrouper les résultats sous la forme d'un tableau à trois dimensions indexé par les valeurs
        d'une colonne spécifiée, placez le nom de cette colonne en premier dans la liste des colonnes
-       en SQL et utilisez <constant>PDO::FETCH_GROUP</constant>.
+       en SQL et utiliser <constant>PDO::FETCH_GROUP</constant>.
       </para>
       <para>
        Pour regrouper les résultats sous la forme d'un tableau à deux dimensions,
-       utilisez un OU bit-à-bit avec <constant>PDO::FETCH_GROUP</constant> et
+       utiliser un OU bit-à-bit avec <constant>PDO::FETCH_GROUP</constant> et
        <constant>PDO::FETCH_COLUMN</constant>.
        Les résultats seront regroupés par la première colonne, la valeur de l'élément du tableau
        étant une liste d'entrées correspondantes de la seconde colonne.
@@ -131,8 +131,8 @@
    L'utilisation de cette méthode pour récupérer de gros jeux de résultats
    peut entraîner une charge importante sur les ressources du système et du réseau.
    Plutôt que de récupérer toutes les données et des manipuler avec PHP,
-   utilisez le serveur de base de données pour manipuler les jeux de résultats.
-   Par exemple, utilisez les clauses <literal>WHERE</literal> et 
+   utiliser le serveur de base de données pour manipuler les jeux de résultats.
+   Par exemple, utiliser les clauses <literal>WHERE</literal> et 
    <literal>ORDER BY</literal> dans les requêtes SQL pour restreindre les résultats
    avant des récupérer et des traiter avec PHP.
   </para>

--- a/reference/pdo/pdostatement/fetchcolumn.xml
+++ b/reference/pdo/pdostatement/fetchcolumn.xml
@@ -26,7 +26,7 @@
     <methodname>PDOStatement::fetchColumn</methodname> ne doit pas être utilisé pour 
     récupérer des colonnes contenant des booléens, car il n'est pas possible de 
     distinguer une valeur &false; d'un retour avec aucune ligne à récupérer. 
-    Utilisez <methodname>PDOStatement::fetch</methodname> à la place.
+    Utiliser <methodname>PDOStatement::fetch</methodname> à la place.
    </para>
   </note>
  </refsect1>

--- a/reference/pdo/pdostatement/rowcount.xml
+++ b/reference/pdo/pdostatement/rowcount.xml
@@ -92,8 +92,8 @@ Effacement de 9 lignes.
      <para>
       Pour la plupart des bases de données, <methodname>PDOStatement::rowCount</methodname>
       ne retourne pas le nombre de lignes affectées par une requête SELECT.
-      À la place, utilisez <methodname>PDO::query</methodname> pour faire une requête
-      SELECT COUNT(*), puis utilisez <methodname>PDOStatement::fetchColumn</methodname>
+      À la place, utiliser <methodname>PDO::query</methodname> pour faire une requête
+      SELECT COUNT(*), puis utiliser <methodname>PDOStatement::fetchColumn</methodname>
       pour récupérer le nombre de lignes correspondantes.
      </para>
      <programlisting role="php">

--- a/reference/pdo_firebird/configure.xml
+++ b/reference/pdo_firebird/configure.xml
@@ -6,7 +6,7 @@
 <section xml:id="ref.pdo-firebird.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
  <para>
-  Utilisez l'option de compilation
+  Utiliser l'option de compilation
   <option role="configure">--with-pdo-firebird[=DIR]</option>
   pour installer l'extension PDO Firebird, où <literal>[=DIR]</literal>
   (optionnel) représente le chemin vers le dossier d'installation

--- a/reference/pdo_ibm/ini.xml
+++ b/reference/pdo_ibm/ini.xml
@@ -80,7 +80,7 @@
       le CCSID de travail ASCII par défaut.
      </para>
      <para>
-      Pour en savoir plus sur les CCSID sur IBM i, consultez la
+      Pour en savoir plus sur les CCSID sur IBM i, consulter la
       <link xlink:href="&url.ibm.ccsid;">documentation IBM</link>.
      </para>
     </listitem>

--- a/reference/pdo_mysql/configure.xml
+++ b/reference/pdo_mysql/configure.xml
@@ -7,7 +7,7 @@
   Les distributions Linux incluent des versions binaires de PHP qui peuvent
   être installées. Même si ces binaires sont construits avec les extensions
   MySQL, les bibliothèques clientes doivent souvent être installées au
-  moyen d'un paquet additionnel. Voyez si c'est le cas pour le distribution.
+  moyen d'un paquet additionnel. Voir si c'est le cas pour le distribution.
  </para>
 
  <para>

--- a/reference/pdo_oci/configure.xml
+++ b/reference/pdo_oci/configure.xml
@@ -8,9 +8,9 @@
  <para>
   Si la base de données Oracle est sur la même machine que PHP, le logiciel de base
   de données contient déjà les bibliothèques nécessaires. Quand PHP est sur
-  une machine différente, utilisez les bibliothèques gratuites
+  une machine différente, utiliser les bibliothèques gratuites
   <link xlink:href="&url.oracle.instant.client;">Oracle Instant Client</link>.
-  Pour plus de détails consultez la section sur
+  Pour plus de détails consulter la section sur
   <link linkend="oci8.requirements">Prérequis OCI8</link>.
  </para>
  <section xml:id="pdo-oci.installation.php84">
@@ -27,13 +27,13 @@
 <section xml:id="pdo-oci.installation.phplt84">
   <title>PHP &lt; 8.4</title>
   <para>
-   Utilisez <option role="configure">--with-pdo-oci[=DIR]</option> pour installer
+   Utiliser <option role="configure">--with-pdo-oci[=DIR]</option> pour installer
    l'extension PDO Oracle OCI, où l'optionnel <literal>[=DIR]</literal>
    est le répertoire Oracle Home. <literal>[=DIR]</literal> correspond par défaut
    à la variable d'environnement <varname>$ORACLE_HOME</varname>.
   </para>
   <para>
-   Utilisez <option role="configure">--with-pdo-oci=instantclient,prefix,version</option>
+   Utiliser <option role="configure">--with-pdo-oci=instantclient,prefix,version</option>
    pour un <acronym>SDK</acronym> Oracle Instant Client, où prefix et
    version sont configurés.
   </para>

--- a/reference/pdo_oci/reference.xml
+++ b/reference/pdo_oci/reference.xml
@@ -41,7 +41,7 @@
          Le URI de la connexion Oracle Instant Client prend la forme de
          <code>dbname=//<varname>hostname</varname>:<varname>port-number</varname>/<varname>database</varname></code>.
          Si l'on l'on se connecte sur une base de données définies dans
-         <filename>tnsnames.ora</filename>, utilisez seulement le nom de la
+         <filename>tnsnames.ora</filename>, utiliser seulement le nom de la
          base de données :
          <code>dbname=<varname>database</varname></code>.
         </para>

--- a/reference/pdo_pgsql/configure.xml
+++ b/reference/pdo_pgsql/configure.xml
@@ -6,7 +6,7 @@
 <section xml:id="ref.pdo-pgsql.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
  <para>
-  Utilisez l'option de compilation
+  Utiliser l'option de compilation
   <option role="configure">--with-pdo-pgsql[=DIR]</option>
   pour installer l'extension PDO PostgreSQL, où <literal>[=DIR]</literal>
   (optionnel) représente le chemin vers le dossier d'installation

--- a/reference/pdo_pgsql/pdo/pgsql/setnoticecallback.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/setnoticecallback.xml
@@ -17,7 +17,7 @@
    Définit une fonction de rappel pour gérer les messages d'avis et d'avertissement générés par le serveur.
    Cela inclut les messages émis par PostgreSQL lui-même,
    ainsi que ceux générés par les fonctions SQL définies par l'utilisateur utilisant <literal>RAISE</literal>.
-   Veuillez noter que la réception effective de ces messages
+   Il est à noter que la réception effective de ces messages
    dépend du paramètre du serveur <literal>client_min_messages</literal>.
   </simpara>
  </refsect1>

--- a/reference/pdo_sqlite/configure.xml
+++ b/reference/pdo_sqlite/configure.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
  <para>
   Le driver PDO PDO_SQLITE est actif par défaut. Pour le désactiver,
-  utilisez l'option de compilation
+  utiliser l'option de compilation
   <option role="configure">--without-pdo-sqlite[=DIR]</option>, où
   <literal>[=DIR]</literal> (optionnel) représente le chemin vers le
   dossier d'installation de base de sqlite.

--- a/reference/pdo_sqlsrv/configure.xml
+++ b/reference/pdo_sqlsrv/configure.xml
@@ -10,7 +10,7 @@
   Les sources du pilote sont hébergées dans un <link xlink:href="&url.sqlsrv.repo;">dépôt public</link>.
  </simpara>
  <simpara>
-  Pour plus d'information à propos des exigences système, consultez le
+  Pour plus d'information à propos des exigences système, consulter le
   chapitre sur les
   <link xlink:href="&url.sqlsrv.system.requirements;">exisgences systèmes SQLSRV</link>.
  </simpara>

--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -788,7 +788,7 @@
      <function>pg_update</function> et <function>pg_delete</function>.
      Tous les paramètres passés tel que. Un échappement manuel est nécessaire
      si les paramètres contiennent des données fournies par l'utilisateur.
-     Utilisez la fonction <function>pg_escape_string</function> pour cela.
+     Utiliser la fonction <function>pg_escape_string</function> pour cela.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pgsql/functions/pg-connect.xml
+++ b/reference/pgsql/functions/pg-connect.xml
@@ -64,7 +64,7 @@
        <parameter>connect_timeout</parameter>,
        <parameter>options</parameter>, <parameter>tty</parameter> (ignoré),
        <parameter>sslmode</parameter>,
-       <parameter>requiressl</parameter> (obsolète, utilisez
+       <parameter>requiressl</parameter> (obsolète, utiliser
        <parameter>sslmode</parameter>) et
        <parameter>service</parameter>. La liste de ces arguments dépend de
        la version du serveur PostgreSQL.

--- a/reference/pgsql/functions/pg-fetch-assoc.xml
+++ b/reference/pgsql/functions/pg-fetch-assoc.xml
@@ -24,7 +24,7 @@
    <function>pg_fetch_assoc</function> est équivalent d'appeler
    <function>pg_fetch_row</function> avec <constant>PGSQL_ASSOC</constant>
    comme troisième paramètre (qui est optionnel). Cela retournera seulement un
-   tableau associatif. En cas de besoin d'indices numériques, utilisez
+   tableau associatif. En cas de besoin d'indices numériques, utiliser
    <function>pg_fetch_row</function>.
   </para>
   &database.fetch-null;

--- a/reference/pgsql/functions/pg-get-notify.xml
+++ b/reference/pgsql/functions/pg-get-notify.xml
@@ -19,7 +19,7 @@
   <para>
    <function>pg_get_notify</function> reçoit le message de NOTIFY envoyé
    par une commande SQL <literal>NOTIFY</literal>. Pour lire le message
-   associé, utilisez la commande <literal>LISTEN</literal>.
+   associé, utiliser la commande <literal>LISTEN</literal>.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-get-pid.xml
+++ b/reference/pgsql/functions/pg-get-pid.xml
@@ -75,7 +75,7 @@ if (!$conn) {
   exit;
 }
 
-// PID du serveur. Utilisez alors le PID avec pg_get_notify()
+// PID du serveur. Utiliser alors le PID avec pg_get_notify()
 $pid = pg_get_pid($conn);
 ?>
 ]]>

--- a/reference/pgsql/functions/pg-last-error.xml
+++ b/reference/pgsql/functions/pg-last-error.xml
@@ -25,7 +25,7 @@
    approprié, notamment si plusieurs erreurs ont eu lieu dans le module.
   </para>
   <para>
-   Utilisez <function>pg_result_error</function>,
+   Utiliser <function>pg_result_error</function>,
    <function>pg_result_error_field</function>,
    <function>pg_result_status</function> et
    <function>pg_connection_status</function> pour améliorer la gestion

--- a/reference/pgsql/functions/pg-pconnect.xml
+++ b/reference/pgsql/functions/pg-pconnect.xml
@@ -73,7 +73,7 @@
        <parameter>connect_timeout</parameter>,
        <parameter>options</parameter>, <parameter>tty</parameter> (ignoré),
        <parameter>sslmode</parameter>,
-       <parameter>requiressl</parameter> (obsolète, utilisez
+       <parameter>requiressl</parameter> (obsolète, utiliser
        <parameter>sslmode</parameter>) et
        <parameter>service</parameter>.
        La liste de ces arguments dépend de la version du serveur PostgreSQL.

--- a/reference/pgsql/functions/pg-query-params.xml
+++ b/reference/pgsql/functions/pg-query-params.xml
@@ -91,8 +91,8 @@
       </para>
       <para>
        Les valeurs attendues pour les champs <literal>bytea</literal> ne sont
-       pas supportées comme paramètres. Utilisez plutôt la fonction
-       <function>pg_escape_bytea</function> ou utilisez les fonctions sur les
+       pas supportées comme paramètres. Utiliser plutôt la fonction
+       <function>pg_escape_bytea</function> ou utiliser les fonctions sur les
        objets larges.
       </para>
      </listitem>

--- a/reference/pgsql/functions/pg-result-error-field.xml
+++ b/reference/pgsql/functions/pg-result-error-field.xml
@@ -31,7 +31,7 @@
   </para>
   <para>
    En cas de besoin d'obtenir plus d'informations sur l'erreur lors de
-   l'échec des requêtes avec <function>pg_query</function>, utilisez
+   l'échec des requêtes avec <function>pg_query</function>, utiliser
    <function>pg_set_error_verbosity</function> et
    <function>pg_last_error</function> et analyser ensuite le résultat.
   </para>

--- a/reference/pgsql/functions/pg-send-execute.xml
+++ b/reference/pgsql/functions/pg-send-execute.xml
@@ -72,7 +72,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne &true; en cas de succès, &false; ou <literal>0</literal> en cas d'échec.
-   Utilisez <function>pg_get_result</function> pour déterminer le résultat
+   Utiliser <function>pg_get_result</function> pour déterminer le résultat
    de la requête.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-send-prepare.xml
+++ b/reference/pgsql/functions/pg-send-prepare.xml
@@ -73,7 +73,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne &true; en cas de succès, &false; ou <literal>0</literal> en cas d'échec.
-   Utilisez <function>pg_get_result</function> pour déterminer le résultat
+   Utiliser <function>pg_get_result</function> pour déterminer le résultat
    de la requête.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-send-query-params.xml
+++ b/reference/pgsql/functions/pg-send-query-params.xml
@@ -72,7 +72,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne &true; en cas de succès, &false; ou <literal>0</literal> en cas d'échec.
-   Utilisez <function>pg_get_result</function> pour déterminer le résultat
+   Utiliser <function>pg_get_result</function> pour déterminer le résultat
    de la requête.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-send-query.xml
+++ b/reference/pgsql/functions/pg-send-query.xml
@@ -24,7 +24,7 @@
    en utilisant <function>pg_get_result</function>.
   </para>
   <para> 
-   L'exécution du script n'est pas bloquée durant l'exécution des requêtes. Utilisez 
+   L'exécution du script n'est pas bloquée durant l'exécution des requêtes. Utiliser 
    <function>pg_connection_busy</function> pour vérifier si la connexion est
    occupée (c'est-à-dire la requête est en train d'être exécutée). Les requêtes
    peuvent être annulées avec <function>pg_cancel_query</function>.
@@ -70,7 +70,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne &true; en cas de succès, &false; ou <literal>0</literal> en cas d'échec.
-   Utilisez <function>pg_get_result</function> pour déterminer le résultat
+   Utiliser <function>pg_get_result</function> pour déterminer le résultat
    de la requête.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-version.xml
+++ b/reference/pgsql/functions/pg-version.xml
@@ -21,7 +21,7 @@
    ne sont disponibles que si PHP a été compilé avec PostgreSQL 7.4 ou supérieur.
   </para>
   <para>
-   Pour plus d'informations sur le serveur, utilisez
+   Pour plus d'informations sur le serveur, utiliser
    <function>pg_parameter_status</function>.
   </para>
  </refsect1>

--- a/reference/pgsql/reference.xml
+++ b/reference/pgsql/reference.xml
@@ -42,7 +42,7 @@
      À la place, il y a un schéma standard nommé
      <literal>information_schema</literal> dans PostgreSQL 7.4 et supérieure
      contenant les vues du système avec toutes les informations nécessaires, dans
-     un format de requête facile. Voyez la
+     un format de requête facile. Voir la
      <link xlink:href="&url.pgsql.manual;">Documentation PostgreSQL</link> pour tous
      les détails.
     </para>

--- a/reference/phar/Phar/addFromString.xml
+++ b/reference/phar/Phar/addFromString.xml
@@ -67,7 +67,7 @@ try {
     $a->addFromString('chemin/vers/fichier.txt', 'mon fichier simple');
     $b = $a['chemin/vers/fichier.txt']->getContent();
 
-    // pour ajouter du contenu à partir d'un descripteur de flux pour des gros fichiers, utilisez offsetSet()
+    // pour ajouter du contenu à partir d'un descripteur de flux pour des gros fichiers, utiliser offsetSet()
     $c = fopen('/chemin/vers/grosfichier.bin');
     $a['grosfichier.bin'] = $c;
     fclose($c);

--- a/reference/phar/Phar/buildFromDirectory.xml
+++ b/reference/phar/Phar/buildFromDirectory.xml
@@ -19,7 +19,7 @@
    Remplit une archive phar à partir du contenu d'un répertoire. Le second paramètre,
    optionnel, est une expression rationnelle (pcre) utilisée pour exclure des fichiers.
    Tout fichier dont le nom satisfait l'expression rationnelle sera inclus, les autres seront exclus.
-   Pour un contrôle plus fin, utilisez <function>Phar::buildFromIterator</function>.
+   Pour un contrôle plus fin, utiliser <function>Phar::buildFromIterator</function>.
   </para>
  </refsect1>
 

--- a/reference/phar/Phar/compressFiles.xml
+++ b/reference/phar/Phar/compressFiles.xml
@@ -17,7 +17,7 @@
   <para>
    Pour les archives phar basées sur tar, cette méthode lève une exception
    <classname>BadMethodCallException</classname> car la compression de fichier individuelle au sein
-   d'une archive tar n'est pas supportée par le format de fichier. Utilisez
+   d'une archive tar n'est pas supportée par le format de fichier. Utiliser
    <function>Phar::compress</function> pour compresser une archive phar basée sur tar en entier.
   </para>
   <para>

--- a/reference/phar/Phar/decompress.xml
+++ b/reference/phar/Phar/decompress.xml
@@ -46,7 +46,7 @@
       <para>
        Pour décompresser, les extensions de fichier par défaut
        sont <literal>.phar</literal> et <literal>.phar.tar</literal>.
-       Utilisez ce paramètre pour spécifier une autre extension de fichier.
+       Utiliser ce paramètre pour spécifier une autre extension de fichier.
        À noter que toutes les archives phar exécutables doivent contenir <literal>.phar</literal>
        dans leur nom de fichier.
       </para>

--- a/reference/phar/Phar/decompressFiles.xml
+++ b/reference/phar/Phar/decompressFiles.xml
@@ -18,7 +18,7 @@
   <para>
    Pour les archives phar basées sur tar, cette méthode lève une exception
    <classname>BadMethodCallException</classname>, car la compression individuelle des fichiers
-   au sein d'une archive tar n'est pas supportée par le format de fichier. Utilisez
+   au sein d'une archive tar n'est pas supportée par le format de fichier. Utiliser
    <function>Phar::compress</function> pour compresser en archive phar basée sur tar en entier.
   </para>
   <para>

--- a/reference/phar/Phar/mapPhar.xml
+++ b/reference/phar/Phar/mapPhar.xml
@@ -68,7 +68,7 @@
    <example>
     <title>Exemple avec <function>Phar::mapPhar</function></title>
     <para>
-     mapPhar ne doit être utilisé qu'au sein du conteneur de chargement d'un phar. Utilisez
+     mapPhar ne doit être utilisé qu'au sein du conteneur de chargement d'un phar. Utiliser
      loadPhar pour charger un phar externe en mémoire.
     </para>
     <para>

--- a/reference/phar/Phar/running.xml
+++ b/reference/phar/Phar/running.xml
@@ -21,7 +21,7 @@
   </para>
   <para>
    Dans le conteneur de chargement d'une archive, <function>Phar::running</function> retourne
-   <literal>&quot;&quot;</literal>. Utilisez simplement <constant>__FILE__</constant>
+   <literal>&quot;&quot;</literal>. Utiliser simplement <constant>__FILE__</constant>
    pour accéder au phar courant au sein d'un conteneur de chargement.
   </para>
  </refsect1>

--- a/reference/phar/PharData/addFromString.xml
+++ b/reference/phar/PharData/addFromString.xml
@@ -65,7 +65,7 @@ try {
     $a->addFromString('chemin/vers/fichier.txt', 'mon fichier simple');
     $b = $a['chemin/vers/fichier.txt']->getContent();
 
-    // pour ajouter du contenu à partir d'un gestionnaire de flux pour des gros fichier, utilisez offsetSet()
+    // pour ajouter du contenu à partir d'un gestionnaire de flux pour des gros fichier, utiliser offsetSet()
     $c = fopen('/chemin/vers/grosfichier.bin');
     $a['grosfichier.bin'] = $c;
     fclose($c);

--- a/reference/phar/PharData/buildFromDirectory.xml
+++ b/reference/phar/PharData/buildFromDirectory.xml
@@ -19,7 +19,7 @@
    Remplit une archive tar/zip à partir du contenu d'un répertoire. Le second paramètre optionnel
    est une expression rationnelle (pcre) utilisée pour exclure des fichiers.
    N'importe quel fichier dont le nom satisfait sera inclus, tous les autres seront exclus. Pour un
-   contrôle plus fin, utilisez <function>PharData::buildFromIterator</function>.
+   contrôle plus fin, utiliser <function>PharData::buildFromIterator</function>.
   </para>
  </refsect1>
 

--- a/reference/phar/PharData/compressFiles.xml
+++ b/reference/phar/PharData/compressFiles.xml
@@ -17,7 +17,7 @@
   <para>
    Pour les archives basées sur tar, cette méthode soulève une exception
    <classname>BadMethodCallException</classname> car la compression individuelle des fichiers
-   d'une archive tar n'est pas supportée par ce format de fichiers. Utilisez
+   d'une archive tar n'est pas supportée par ce format de fichiers. Utiliser
    <function>PharData::compress</function> pour compresser une archive basée sur tar complète.
   </para>
   <para>

--- a/reference/phar/PharData/decompress.xml
+++ b/reference/phar/PharData/decompress.xml
@@ -40,7 +40,7 @@
      <listitem>
       <para>
        Pour décompresser, l'extension par défaut est 
-       <literal>.tar</literal>. Utilisez ce paramètre 
+       <literal>.tar</literal>. Utiliser ce paramètre 
        pour spécifier une autre extension de fichier. Gardez
        à l'esprit que seul les archives exécutables peuvent
        contenir <literal>.phar</literal> dans leur nom de fichier.

--- a/reference/phar/PharData/decompressFiles.xml
+++ b/reference/phar/PharData/decompressFiles.xml
@@ -18,7 +18,7 @@
   <para>
    Pour les archives basées sur tar, cette méthode soulève une exception
    <classname>BadMethodCallException</classname>, car la compression individuelle des fichiers
-   au sein d'une archive tar n'est pas supportée par le format de fichier. Utilisez
+   au sein d'une archive tar n'est pas supportée par le format de fichier. Utiliser
    <function>PharData::compress</function> pour compresser une archive basée sur tar complète.
   </para>
   <para>

--- a/reference/phar/fileformat.xml
+++ b/reference/phar/fileformat.xml
@@ -217,8 +217,8 @@ __HALT_COMPILER();
    actuellement, les en-têtes <literal>././@LongLink</literal> sont résolus.
   </para>
   <para>
-   Pour compresser une archive entière, utilisez <function>Phar::compress</function>.
-   Pour décompresser une archive entière, utilisez <function>Phar::decompress</function>.
+   Pour compresser une archive entière, utiliser <function>Phar::compress</function>.
+   Pour décompresser une archive entière, utiliser <function>Phar::decompress</function>.
   </para>
  </section>
  <section xml:id="phar.fileformat.zip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -250,7 +250,7 @@ __HALT_COMPILER();
   </para>
   <para>
    Tous les drapeaux non utilisés sont réservés pour un usage futur et ne doivent pas être utilisés
-   pour stocker des informations personnalisées. Utilisez les métadonnées par fichier pour stocker
+   pour stocker des informations personnalisées. Utiliser les métadonnées par fichier pour stocker
    des métadonnées personnalisées sur des fichiers particuliers.
   </para>
   <para>

--- a/reference/phar/installation.xml
+++ b/reference/phar/installation.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
  <para>
   L'extension Phar est intégrée dans PHP, et activée par défaut.
-  Pour désactiver le support de Phar, utilisez l'option de configuration
+  Pour désactiver le support de Phar, utiliser l'option de configuration
   <option role="configure">--disable-phar</option>.
  </para>
  <para>

--- a/reference/posix/functions/posix-get-last-error.xml
+++ b/reference/posix/functions/posix-get-last-error.xml
@@ -18,7 +18,7 @@
   <para>
    Retourne le numéro d'erreur retourné par la dernière fonction
    POSIX qui a échoué. Si l'on le message d'erreur associé au
-   numéro d'erreur, utilisez <function>posix_strerror</function>.
+   numéro d'erreur, utiliser <function>posix_strerror</function>.
   </para>
  </refsect1>
 

--- a/reference/posix/functions/posix-getpwnam.xml
+++ b/reference/posix/functions/posix-getpwnam.xml
@@ -78,7 +78,7 @@
       <row>
        <entry>gid</entry>
        <entry>
-        L'ID du groupe de l'utilisateur. Utilisez la fonction
+        L'ID du groupe de l'utilisateur. Utiliser la fonction
         <function>posix_getgrgid</function> pour connaître le nom du groupe,
         et ses membres.
        </entry>

--- a/reference/posix/functions/posix-getpwuid.xml
+++ b/reference/posix/functions/posix-getpwuid.xml
@@ -76,7 +76,7 @@
       <row>
        <entry>gid</entry>
        <entry>
-        L'ID du groupe de l'utilisateur. Utilisez la fonction
+        L'ID du groupe de l'utilisateur. Utiliser la fonction
         <function>posix_getgrgid</function> pour connaître le nom du groupe,
         et ses membres.
        </entry>

--- a/reference/ps/functions/ps-arc.xml
+++ b/reference/ps/functions/ps-arc.xml
@@ -25,7 +25,7 @@
    (<parameter>x</parameter>, <parameter>y</parameter>). L'arc débute à un
    angle de <parameter>alpha</parameter> et termine avec un angle de
    <parameter>beta</parameter>. Il est tracé dans le sens contraire des
-   aiguilles d'une montre (utilisez <function>ps_arcn</function> pour dessiner
+   aiguilles d'une montre (utiliser <function>ps_arcn</function> pour dessiner
    dans le sens des aiguilles d'une montre). La sous trajectoire ajoutée à la trajectoire
    courante débute sur l'arc à l'angle <parameter>alpha</parameter> et termine
    sur l'arc à l'angle <parameter>beta</parameter>.

--- a/reference/ps/functions/ps-arcn.xml
+++ b/reference/ps/functions/ps-arcn.xml
@@ -25,7 +25,7 @@
    (<parameter>x</parameter>, <parameter>y</parameter>). L'arc débute à un
    angle de <parameter>alpha</parameter> et termine avec un angle de
    <parameter>beta</parameter>. Il est tracé dans le sens des aiguilles d'une
-   montre (utilisez <function>ps_arc</function> pour dessiner dans le sens
+   montre (utiliser <function>ps_arc</function> pour dessiner dans le sens
    contraire des aiguilles d'une montre). La sous trajectoire ajoutée à la
    trajectoire courante débute sur l'arc à l'angle <parameter>beta</parameter>
    et termine sur l'arc à l'angle <parameter>alpha</parameter>.

--- a/reference/ps/functions/ps-lineto.xml
+++ b/reference/ps/functions/ps-lineto.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    Ajoute une ligne droite à partir du point courant aux coordonnées données au
-   chemin courant. Utilisez <function>ps_moveto</function> pour fixer le point
+   chemin courant. Utiliser <function>ps_moveto</function> pour fixer le point
    de départ de la ligne.
   </para>
  </refsect1>

--- a/reference/ps/functions/ps-shading.xml
+++ b/reference/ps/functions/ps-shading.xml
@@ -75,7 +75,7 @@
      <term><parameter>c1, c2, c3, c4</parameter></term>
      <listitem>
       <para>
-       Voyez <function>ps_setcolor</function> pour leur signification.
+       Voir <function>ps_setcolor</function> pour leur signification.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/quickhash/quickhashinthash.xml
+++ b/reference/quickhash/quickhashinthash.xml
@@ -86,7 +86,7 @@
      <listitem>
       <simpara>Si activé, l'ajout d'éléments dupliqués à un hachage (via <methodname>QuickHashIntHash::add</methodname> ou
       <methodname>QuickHashIntHash::loadFromFile</methodname>) entraînera la suppression de ces éléments du
-      hachage. Cela prendra plus de temps, donc n'utilisez-le que si c'est nécessaire.</simpara>
+      hachage. Cela prendra plus de temps, donc n'utiliser-le que si c'est nécessaire.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/quickhash/quickhashinthash/set.xml
+++ b/reference/quickhash/quickhashinthash/set.xml
@@ -19,7 +19,7 @@
    Cette méthode tente de mettre à jour une entrée avec une nouvelle valeur. Si l'entrée
    n'existait pas, elle ajoutera une nouvelle entrée. Elle retourne si l'entrée a été
    ajoutée ou mise à jour. Si des clés en double sont présentes, seul le premier
-   élément trouvé sera mis à jour. Utilisez
+   élément trouvé sera mis à jour. Utiliser
    <constant>QuickHashIntHash::CHECK_FOR_DUPES</constant> lors de la création du hachage pour empêcher les clés en double
    de faire partie du hachage.
   </simpara>

--- a/reference/quickhash/quickhashinthash/update.xml
+++ b/reference/quickhash/quickhashinthash/update.xml
@@ -17,7 +17,7 @@
   <simpara>
    Cette méthode met à jour une entrée avec une nouvelle valeur, et retourne si
    l'entrée a été mise à jour. Si des clés en double sont présentes, seul le premier
-   élément trouvé sera mis à jour. Utilisez <constant>QuickHashIntHash::CHECK_FOR_DUPES</constant> lors de la création du hachage
+   élément trouvé sera mis à jour. Utiliser <constant>QuickHashIntHash::CHECK_FOR_DUPES</constant> lors de la création du hachage
    pour empêcher les clés en double de faire partie du hachage.
   </simpara>
  </refsect1>

--- a/reference/quickhash/quickhashintset.xml
+++ b/reference/quickhash/quickhashintset.xml
@@ -84,7 +84,7 @@
      <listitem>
       <simpara>Si activé, l'ajout d'éléments dupliqués à un ensemble (via <methodname>QuickHashIntSet::add</methodname> ou
       <methodname>QuickHashIntSet::loadFromFile</methodname>) entraînera la suppression de ces éléments de l'ensemble.
-      Cela prendra plus de temps, donc n'utilisez cette option que si nécessaire.</simpara>
+      Cela prendra plus de temps, donc n'utiliser cette option que si nécessaire.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/quickhash/quickhashintstringhash.xml
+++ b/reference/quickhash/quickhashintstringhash.xml
@@ -86,7 +86,7 @@
      <listitem>
       <simpara>Si activé, ajouter des éléments dupliqués à un ensemble (via <methodname>QuickHashIntStringHash::add</methodname> ou
       <methodname>QuickHashIntStringHash::loadFromFile</methodname>) entraînera la suppression de ces éléments de l'ensemble.
-      Cela prendra plus de temps, donc n'utilisez-le que si nécessaire.</simpara>
+      Cela prendra plus de temps, donc n'utiliser-le que si nécessaire.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/quickhash/quickhashintstringhash/set.xml
+++ b/reference/quickhash/quickhashintstringhash/set.xml
@@ -19,7 +19,7 @@
    Cette méthode essaie de mettre à jour une entrée avec une nouvelle valeur. Si
    l'entrée n'existait pas, elle ajoutera une nouvelle entrée. Elle renvoie si
    l'entrée a été ajoutée ou mise à jour. Si des clés en double sont présentes,
-   seul le premier élément trouvé sera mis à jour. Utilisez
+   seul le premier élément trouvé sera mis à jour. Utiliser
    QuickHashIntStringHash::CHECK_FOR_DUPES lors de la création du hachage pour empêcher les clés en double
    de faire partie du hachage.
   </simpara>

--- a/reference/quickhash/quickhashintstringhash/update.xml
+++ b/reference/quickhash/quickhashintstringhash/update.xml
@@ -17,7 +17,7 @@
   <simpara>
    Cette méthode met à jour une entrée avec une nouvelle valeur, et renvoie si
    l'entrée a été mise à jour. Si des clés en double sont présentes, seul le
-   premier élément trouvé sera mis à jour. Utilisez QuickHashIntStringHash::CHECK_FOR_DUPES
+   premier élément trouvé sera mis à jour. Utiliser QuickHashIntStringHash::CHECK_FOR_DUPES
    lors de la création du hachage pour empêcher les clés en double de faire partie du hachage.
   </simpara>
  </refsect1>

--- a/reference/quickhash/quickhashstringinthash.xml
+++ b/reference/quickhash/quickhashstringinthash.xml
@@ -68,7 +68,7 @@
      <listitem>
       <simpara>Si activé, l'ajout d'éléments dupliqués à un hachage (via <methodname>QuickHashStringIntHash::add</methodname> ou
       <methodname>QuickHashStringIntHash::loadFromFile</methodname>) entraînera la suppression de ces éléments du
-      hachage. Cela prendra du temps supplémentaire, alors n'utilisez cette option que si nécessaire.</simpara>
+      hachage. Cela prendra du temps supplémentaire, alors n'utiliser cette option que si nécessaire.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/quickhash/quickhashstringinthash/set.xml
+++ b/reference/quickhash/quickhashstringinthash/set.xml
@@ -19,7 +19,7 @@
    Cette méthode met à jour une entrée avec une nouvelle valeur. Si l'entrée
    n'existait pas, elle ajoutera une nouvelle entrée. Elle retourne si l'entrée
    a été ajoutée ou mise à jour. Si des clés en double sont présentes, seul le
-   premier élément trouvé sera mis à jour. Utilisez
+   premier élément trouvé sera mis à jour. Utiliser
    QuickHashStringIntHash::CHECK_FOR_DUPES lors de la création du hachage pour empêcher les clés en double
    de faire partie du hachage.
   </simpara>

--- a/reference/quickhash/quickhashstringinthash/update.xml
+++ b/reference/quickhash/quickhashstringinthash/update.xml
@@ -17,7 +17,7 @@
   <simpara>
    Cette méthode met à jour une entrée avec une nouvelle valeur, et retourne si
    l'entrée a été mise à jour. Si des clés en double sont présentes, seul le
-   premier élément trouvé sera mis à jour. Utilisez QuickHashStringIntHash::CHECK_FOR_DUPES lors de
+   premier élément trouvé sera mis à jour. Utiliser QuickHashStringIntHash::CHECK_FOR_DUPES lors de
    la création du hachage pour empêcher les clés en double de faire partie du hachage.
   </simpara>
  </refsect1>

--- a/reference/random/functions/lcg-value.xml
+++ b/reference/random/functions/lcg-value.xml
@@ -39,8 +39,8 @@
     de l'intervalle demandé.
    </para>
    <para>
-    Utilisez <methodname>Random\Randomizer::getFloat</methodname> pour générer un
-    nombre flottant aléatoire dans un intervalle arbitraire. Utilisez <methodname>Random\Randomizer::getInt</methodname>
+    Utiliser <methodname>Random\Randomizer::getFloat</methodname> pour générer un
+    nombre flottant aléatoire dans un intervalle arbitraire. Utiliser <methodname>Random\Randomizer::getInt</methodname>
     pour générer un entier aléatoire dans un intervalle arbitraire.
    </para>
   </caution>

--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -116,7 +116,7 @@
         <function>mt_rand</function>
         <link linkend="migration71.incompatible.fixes-to-mt_rand-algorithm">a été mis à jour</link>
         pour utiliser la version corrigée, correcte, de l'algorithme Twister
-        Mersenne. Pour revenir à l'ancien comportement, utilisez
+        Mersenne. Pour revenir à l'ancien comportement, utiliser
         <function>mt_srand</function> avec <constant>MT_RAND_PHP</constant>
         comme deuxième paramètre.
        </entry>

--- a/reference/random/functions/mt-srand.xml
+++ b/reference/random/functions/mt-srand.xml
@@ -49,7 +49,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       Utilisez une des constantes suivantes pour spécifier l'implémentation de l'algorithme à utiliser.
+       Utiliser une des constantes suivantes pour spécifier l'implémentation de l'algorithme à utiliser.
        <simplelist>
         <member>
          <constant>MT_RAND_MT19937</constant>:
@@ -105,7 +105,7 @@
        <entry>
         <function>mt_rand</function> <link linkend="migration71.incompatible.fixes-to-mt_rand-algorithm">a été mis à jour</link> pour utiliser la version corrigée, correcte 
         de l'algorithme de Mersenne Twister. Pour retourner à l'ancien comportement,
-        utilisez <function>mt_srand</function> avec <constant>MT_RAND_PHP</constant> comme deuxième paramètre.
+        utiliser <function>mt_srand</function> avec <constant>MT_RAND_PHP</constant> comme deuxième paramètre.
        </entry>
       </row>
      </tbody>

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -24,7 +24,7 @@
    <parameter>max</parameter>, <function>rand</function> retourne un
    nombre pseudoaléatoire entre 0 et <function>getrandmax</function>.
    Pour un nombre aléatoire entre 5 et 15
-   (inclus), par exemple, utilisez <literal>rand (5, 15)</literal>.
+   (inclus), par exemple, utiliser <literal>rand (5, 15)</literal>.
   </simpara>
   &caution.cryptographically-insecure;
   <note>
@@ -33,7 +33,7 @@
     (comme Windows). En cas de besoin d’une plage supérieure à 32767, il est recommandé de spécifier
     une valeur limite supérieure à 32767, en spécifiant <parameter>min</parameter> et
     <parameter>max</parameter>, l'on sera autorisés à utiliser un intervalle
-    plus grand que <function>mt_getrandmax</function>, ou bien, utilisez la fonction
+    plus grand que <function>mt_getrandmax</function>, ou bien, utiliser la fonction
     <function>mt_rand</function> à la place.
    </simpara>
   </note>

--- a/reference/rar/constants.xml
+++ b/reference/rar/constants.xml
@@ -14,7 +14,7 @@
    </term>
    <listitem>
     <simpara>
-     Utilisez la constante <link linkend="rarentry.constants.host-msdos"><constant>RarEntry::HOST_MSDOS</constant></link> à la place.
+     Utiliser la constante <link linkend="rarentry.constants.host-msdos"><constant>RarEntry::HOST_MSDOS</constant></link> à la place.
     </simpara>
    </listitem>
   </varlistentry>
@@ -25,7 +25,7 @@
    </term>
    <listitem>
     <simpara>
-     Utilisez la constante <link linkend="rarentry.constants.host-os2"><constant>RarEntry::HOST_OS2</constant></link> à la place.
+     Utiliser la constante <link linkend="rarentry.constants.host-os2"><constant>RarEntry::HOST_OS2</constant></link> à la place.
     </simpara>
    </listitem>
   </varlistentry>
@@ -36,7 +36,7 @@
    </term>
    <listitem>
     <simpara>
-     Utilisez la constante <link linkend="rarentry.constants.host-win32"><constant>RarEntry::HOST_WIN32</constant></link> à la place.
+     Utiliser la constante <link linkend="rarentry.constants.host-win32"><constant>RarEntry::HOST_WIN32</constant></link> à la place.
     </simpara>
    </listitem>
   </varlistentry>
@@ -47,7 +47,7 @@
    </term>
    <listitem>
     <simpara>
-     Utilisez la constante <link linkend="rarentry.constants.host-unix"><constant>RarEntry::HOST_UNIX</constant></link> à la place.
+     Utiliser la constante <link linkend="rarentry.constants.host-unix"><constant>RarEntry::HOST_UNIX</constant></link> à la place.
     </simpara>
    </listitem>
   </varlistentry>
@@ -58,7 +58,7 @@
    </term>
    <listitem>
     <simpara>
-     Utilisez la constante <link linkend="rarentry.constants.host-beos"><constant>RarEntry::HOST_BEOS</constant></link> à la place.
+     Utiliser la constante <link linkend="rarentry.constants.host-beos"><constant>RarEntry::HOST_BEOS</constant></link> à la place.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/rar/examples.xml
+++ b/reference/rar/examples.xml
@@ -66,8 +66,8 @@ function detectUserAgent() {
 
 /*
  * Nous avons 3 options :
- * - Pour FF et Opera, qui supportent RFC 2231, utilisez ce format.
- * - Pour IE et Chrome, utilisez attwithfnrawpctenclong
+ * - Pour FF et Opera, qui supportent RFC 2231, utiliser ce format.
+ * - Pour IE et Chrome, utiliser attwithfnrawpctenclong
  *   (http://greenbytes.de/tech/tc2231/#attwithfnrawpctenclong)
  * - Pour les autres, convertissez en ISO-8859-1, si possible
  */

--- a/reference/rar/rararchive/open.xml
+++ b/reference/rar/rararchive/open.xml
@@ -79,7 +79,7 @@
   <warning>
    <simpara>
     Avant la version 2.0.0, cette fonction ne gérait pas correctement les
-    chemins relatifs. Utilisez la fonction
+    chemins relatifs. Utiliser la fonction
     <function>realpath</function> pour corriger ce bogue.</simpara>
   </warning>
  </refsect1>

--- a/reference/rar/rarentry/extract.xml
+++ b/reference/rar/rarentry/extract.xml
@@ -84,7 +84,7 @@
   <warning>
    <simpara>
     Avant la version 2.0.0, cette fonction ne gérait pas les chemins relatifs
-    correctement. Utilisez la fonction <function>realpath</function> comme contournement.
+    correctement. Utiliser la fonction <function>realpath</function> comme contournement.
    </simpara>
   </warning>
  </refsect1>

--- a/reference/reflection/reflectionmethod/construct.xml
+++ b/reference/reflection/reflectionmethod/construct.xml
@@ -22,7 +22,7 @@
   <warning>
    <simpara>
     La signature alternative est obsolète à partir de PHP 8.4.0,
-    utilisez <methodname>ReflectionMethod::createFromMethodName</methodname>
+    utiliser <methodname>ReflectionMethod::createFromMethodName</methodname>
     à la place.
    </simpara>
   </warning>

--- a/reference/reflection/reflectionparameter.xml
+++ b/reference/reflection/reflectionparameter.xml
@@ -18,7 +18,7 @@
    <para>
     Pour faire une introspection sur les paramètres des fonctions, tout d'abord
     créez une instance de la classe <classname>ReflectionFunction</classname>
-    ou de la classe <classname>ReflectionMethod</classname> puis utilisez
+    ou de la classe <classname>ReflectionMethod</classname> puis utiliser
     la méthode <methodname>ReflectionFunctionAbstract::getParameters</methodname>
     pour récupérer un tableau des paramètres.
    </para>

--- a/reference/reflection/reflectionproperty/getvalue.xml
+++ b/reference/reflection/reflectionproperty/getvalue.xml
@@ -27,7 +27,7 @@
      <listitem>
       <para>
        L'objet à utiliser dans le cas d'une propriété non statique.
-       Pour récupérer la valeur par défaut de la propriété, utilisez
+       Pour récupérer la valeur par défaut de la propriété, utiliser
        <methodname>ReflectionClass::getDefaultProperties</methodname> à la place.
       </para>
      </listitem>

--- a/reference/reflection/reflectionproperty/setvalue.xml
+++ b/reference/reflection/reflectionproperty/setvalue.xml
@@ -23,7 +23,7 @@
   </para>
   <note>
    <simpara>
-    Pour définir les valeurs des propriétés statiques, utilisez <literal>ReflectionProperty::setValue(null, $value)</literal>.
+    Pour définir les valeurs des propriétés statiques, utiliser <literal>ReflectionProperty::setValue(null, $value)</literal>.
    </simpara>
   </note>
  </refsect1>
@@ -75,7 +75,7 @@
       <entry>8.3.0</entry>
       <entry>
        L'appel de cette méthode avec un seul argument est obsolète,
-       utilisez plutôt <literal>ReflectionProperty::setValue(null, $value)</literal>
+       utiliser plutôt <literal>ReflectionProperty::setValue(null, $value)</literal>
        pour les propriétés statiques.
       </entry>
      </row>

--- a/reference/rrd/rrdgraph/setoptions.xml
+++ b/reference/rrd/rrdgraph/setoptions.xml
@@ -84,7 +84,7 @@ $graphObj->setOptions(array(
 ]]>
     </programlisting>
     <simpara>
-     N'utilisez pas la syntaxe clé/valeur pour une même option rrd.
+     N'utiliser pas la syntaxe clé/valeur pour une même option rrd.
      C'est plus lisible certes, mais ça ne fonctionne pas.
     </simpara>
     <programlisting role="php">

--- a/reference/rrd/setup.xml
+++ b/reference/rrd/setup.xml
@@ -9,7 +9,7 @@
   &reftitle.required;
   <simpara>
    Il faut installer d'abord la bibliothèque librrd afin
-   d'utiliser l'extension PECL/rrd. Vérifiez si le distribution
+   d'utiliser l'extension PECL/rrd. Vérifier si la distribution
    favorite Linux propose le paquet librrd-dev.
    PECL/rrd est testé avec librrd 1.4.3, les anciennes versions ou les plus récentes
    peuvent ou non fonctionner.

--- a/reference/scoutapm/setup.xml
+++ b/reference/scoutapm/setup.xml
@@ -19,7 +19,7 @@
  <section xml:id="scoutapm.installation">
   &reftitle.install;
   <para>
-   Cette extension est disponible sur PECL. Exécutez :
+   Cette extension est disponible sur PECL. Exécuter :
    <programlisting>
     <![CDATA[
 $ sudo pecl install scoutapm

--- a/reference/seaslog/ini.xml
+++ b/reference/seaslog/ini.xml
@@ -302,7 +302,7 @@ The log style finally formatted such as:
        <emphasis>seaslog.disting_folder = 1</emphasis> Le commutateur utilise Logger DisTing par dossier.
        Cela signifie que SeasLog créera le fichier deistic par dossier,
        et lorsque cette configuration est désactivée, SeasLog créera le fichier
-       utilisez le connecteur de soulignement Logger et Time comme default_20180211.log.
+       utiliser le connecteur de soulignement Logger et Time comme default_20180211.log.
        </simpara>
      </note>
     </listitem>

--- a/reference/seaslog/seaslog/getdatetimeformat.xml
+++ b/reference/seaslog/seaslog/getdatetimeformat.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
     Renvoie le format de date et d'heure de SeasLog.
-    Utilisez la fonction <methodname>SeasLog::getDatetimeFormat</methodname> pour obtenir la valeur de
+    Utiliser la fonction <methodname>SeasLog::getDatetimeFormat</methodname> pour obtenir la valeur de
     <link linkend="ini.seaslog.default-datetime-format">seaslog.default_datetime_format</link>
     configurée dans php.ini (seaslog.ini).
   </simpara>
@@ -32,7 +32,7 @@
   <simpara>
     Renvoie le format de date et d'heure de SeasLog
     <link linkend="ini.seaslog.default-datetime-format">seaslog.default_datetime_format</link>.
-    Utilisez la fonction <methodname>SeasLog::setDatetimeFormat</methodname>
+    Utiliser la fonction <methodname>SeasLog::setDatetimeFormat</methodname>
     pour modifier cette valeur.
   </simpara>
  </refsect1>

--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -79,7 +79,7 @@ unset($_SESSION['count']);
   <para>
    <caution>
     <para>
-     N'utilisez PAS la fonction <function>unset</function>
+     N'utiliser PAS la fonction <function>unset</function>
      avec <varname>$_SESSION</varname> sous la forme
      <literal>unset($_SESSION)</literal> sinon, cela rendra impossible
      l'enregistrement de données dans la session en utilisant la super-globale

--- a/reference/session/functions/session-create-id.xml
+++ b/reference/session/functions/session-create-id.xml
@@ -86,7 +86,7 @@ function my_session_regenerate_id() {
     if (session_status() != PHP_SESSION_ACTIVE) {
         session_start();
     }
-    // AVERTISSEMENT: N'utilisez jamais des chaînes confidentielles comme préfixe !
+    // AVERTISSEMENT: N'utiliser jamais des chaînes confidentielles comme préfixe !
     $newid = session_create_id('myprefix-');
     // Définit l'horodatage de suppression.
     // Les données de session ne doivent pas être supprimées immédiatement pour certaines raisons.

--- a/reference/session/functions/session-id.xml
+++ b/reference/session/functions/session-id.xml
@@ -21,7 +21,7 @@
   <para>
    La constante <constant>SID</constant> peut également être utilisée pour
    lire le nom de la session courante et l'identifiant de session à fournir
-   dans les URL. Voyez aussi <link linkend="ref.session">Gestion de session</link>.
+   dans les URL. Voir aussi <link linkend="ref.session">Gestion de session</link>.
   </para>
  </refsect1>
 

--- a/reference/session/functions/session-set-cookie-params.xml
+++ b/reference/session/functions/session-set-cookie-params.xml
@@ -66,7 +66,7 @@
      <term><parameter>path</parameter></term>
      <listitem>
       <para>
-       Le chemin dans le domaine où le cookie sera accessible. Utilisez
+       Le chemin dans le domaine où le cookie sera accessible. Utiliser
        un simple slash ('/') pour tous les chemins du domaine.
        Voir la directive <link linkend="ini.session.cookie-path">path</link>.
       </para>

--- a/reference/session/functions/session-start.xml
+++ b/reference/session/functions/session-start.xml
@@ -137,7 +137,7 @@ echo '<br /><a href="page2.php?' . SID . '">page 2</a>';
   <para>
    Après avoir vu la page <filename>page1.php</filename> avec un navigateur,
    la seconde page <filename>page2.php</filename> (dont le code suit) va magiquement afficher
-   les données de session. Lisez la référence sur
+   les données de session. Consulter la référence sur
    les <link linkend="ref.session">sessions</link> pour des informations
    sur la <link linkend="session.idpassing">propagation des identifiants de session</link>,
    et l'utilisation de la constante <constant>SID</constant>.
@@ -220,7 +220,7 @@ session_start([
   <note>
    <para>
     Cette fonction va émettre plusieurs entêtes HTTP, en fonction
-    de la configuration. Voyez <function>session_cache_limiter</function> pour
+    de la configuration. Voir <function>session_cache_limiter</function> pour
     personnaliser ces entêtes.
    </para>
   </note>  

--- a/reference/session/functions/session-unset.xml
+++ b/reference/session/functions/session-unset.xml
@@ -61,7 +61,7 @@
   <note>
    <para>
     Lors de l'utilisation de <varname>$_SESSION</varname>
-    utilisez <function>unset</function> pour détruire une variable de
+    utiliser <function>unset</function> pour détruire une variable de
     session, c.-à-d. <code>unset($_SESSION['nomvariable']);</code>.
    </para>
   </note>
@@ -75,7 +75,7 @@
   </caution>
   <note>
    <para>
-    Utilisez seulement <function>session_unset</function> pour du vieux code obsolète
+    Utiliser seulement <function>session_unset</function> pour du vieux code obsolète
     qui n'utilise pas <varname>$_SESSION</varname>.
    </para>
   </note>
@@ -83,7 +83,7 @@
    <para>
     Cette fonction ne fonctionne que si une session est active. Elle ne videra pas le
     tableau <varname>$_SESSION</varname> si la session n'a pas encore été démarrée
-    ou si elle a déjà été détruite. Utilisez <code>$_SESSION = []</code> pour supprimer
+    ou si elle a déjà été détruite. Utiliser <code>$_SESSION = []</code> pour supprimer
     toutes les variables de session même si la session n'est pas active.
    </para>
   </caution>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -322,7 +322,7 @@
        grand nombre d'espaces et d'inodes gaspillés.
       </para>
       <para>
-       N'utilisez une valeur de <literal>N</literal> supérieure à 2 uniquement
+       N'utiliser une valeur de <literal>N</literal> supérieure à 2 uniquement
        si l'on est certain que c'est nécessaire pour le site.
       </para>
      </caution>
@@ -379,7 +379,7 @@
       ont. Les anciens gestionnaires de sérialisation ne peuvent pas stocker
       d'index numérique, ni d'index sous forme de chaînes qui contiennent
       des caractères spéciaux (<literal>|</literal> et <literal>!</literal>) en
-      $_SESSION. Utilisez <literal>php_serialize</literal> pour éviter ce
+      $_SESSION. Utiliser <literal>php_serialize</literal> pour éviter ce
       genre d'erreur en fin de script. Par défaut, c'est <literal>php</literal>.
      </simpara>
     </listitem>
@@ -441,7 +441,7 @@
        Si des scripts différents ont des valeurs différentes de
        <literal>session.gc_maxlifetime</literal> mais partagent le même
        endroit pour y stocker les données de session, alors, le script dont la valeur
-       est la plus petite effacera la donnée. Dans ce cas, utilisez cette directive
+       est la plus petite effacera la donnée. Dans ce cas, utiliser cette directive
        conjointement avec <link linkend="ini.session.save-path">session.save_path</link>.
       </simpara>
      </note>

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -330,8 +330,8 @@
     </para>
     
     <para>
-     Définissez et gérez l'expiration du timestamp dans la variable
-     globale $_SESSION. Interdisez l'accès aux données de sessions
+     Définir et gérer l'expiration du timestamp dans la variable
+     globale $_SESSION. Interdire l'accès aux données de sessions
      périmées. Lorsqu'un accès à des données de session obsolète est détecté,
      il convient de supprimer toutes les statuts authentifiés des sessions
      utilisateurs et forcer les utilisateurs à s'authentifier de nouveau.
@@ -377,8 +377,8 @@
      Cependant, le verrouillage de session peut être utilisé par les attaquants
      pour réaliser des attaques DoS. Pour minimiser le risque d'une attaque DoS
      par verrouillage de session, il convient de minimiser les verrous.
-     Utilisez des données en lecture seule lorsque les données de session
-     n'ont pas besoin d'être mises à jour. Utilisez l'option 'read_and_close'
+     Utiliser des données en lecture seule lorsque les données de session
+     n'ont pas besoin d'être mises à jour. Utiliser l'option 'read_and_close'
      avec la fonction <function>session_start</function>.
      <code>session_start(['read_and_close'=>1]);</code> va clôre
      la session aussi vite que possible après la mise à jour de la variable
@@ -425,7 +425,7 @@
     
     <warning>
      <simpara>
-      N'utilisez jamais de données confidentielles comme préfixe.
+      N'utiliser jamais de données confidentielles comme préfixe.
       Si l'identifiant utilisateur est confidentiel, il est recommandé d'utiliser
       la fonction <function>hash_hmac</function>.
      </simpara>
@@ -463,9 +463,9 @@
     </para>
     
     <para>
-     Utilisez une clé de hachage sécurisé à usage unique comme clé
+     Utiliser une clé de hachage sécurisé à usage unique comme clé
      d'auto-identification en utilisant la fonction
-     <function>setcookie</function>. Utilisez un hachage sécurisé
+     <function>setcookie</function>. Utiliser un hachage sécurisé
      plus fort que SHA-2. c.-à-d. SHA-256 ou supérieur avec des données
      aléatoires depuis la fonction <function>random_bytes</function>
      ou via <filename>/dev/urandom</filename>.
@@ -475,14 +475,14 @@
      Si l'utilisateur est non authentifié, vérifiez si la clé d'auto-identification
      à usage unique est valide ou non. Dans ce cas où elle est valide, authentifiez
      l'utilisateur et définissez une nouvelle clé de hachage sécurisée à usage unique.
-     Une clé d'auto-identification ne doit être utilisée qu'une seule fois, c.-à-d. n'utilisez
+     Une clé d'auto-identification ne doit être utilisée qu'une seule fois, c.-à-d. n'utiliser
      jamais une clé d'auto-identification, et régénérez-la toujours.
     </para>
     
     <para>
      Une clé d'auto-identification est une clé d'authentification avec une
      longue durée, elle doit être protégée autant que possible.
-     Utilisez les attributs de cookie path/httponly/secure/SameSite pour la sécurité.
+     Utiliser les attributs de cookie path/httponly/secure/SameSite pour la sécurité.
      c.-à-d. ne transmettez jamais la clé d'auto-identification tant que cela
      n'est pas nécessaire.
     </para>
@@ -560,7 +560,7 @@
     <para>
      Si une fonctionnalité d'auto-identification est désirée, les développeurs
      doivent implémenter leur propre système d'auto-identification sécurité.
-     N'utilisez pas des identifiants de session à longue durée pour cela.
+     N'utiliser pas des identifiants de session à longue durée pour cela.
      Pour plus d'informations, se rapporter à la bonne section
      de cette documentation.
     </para>
@@ -576,7 +576,7 @@
     <para>
      Bien que les cookies HTTP souffrent de soucis techniques, ils
      restent la façon préférée de gérer les identifiants de sessions.
-     N'utilisez que les cookies pour la gestion des identifiants de sessions
+     N'utiliser que les cookies pour la gestion des identifiants de sessions
      lorsque cela est possible. La plupart des applications doivent utiliser
      un cookie pour l'identifiant de session.
     </para>
@@ -709,7 +709,7 @@
      les sessions obsolètes soient supprimées à fréquence appropriée.
      Si la fonctionnalité d'auto-identification est nécessaire, les développeurs
      doivent implémenter leur propre fonctionnalité d'auto-identification sécurisée ;
-     voir ci-dessous pour plus d'informations. N'utilisez jamais l'identifiant
+     voir ci-dessous pour plus d'informations. N'utiliser jamais l'identifiant
      de session de longue durée pour réaliser ce genre de fonctionnalité.
     </para>
     <note>
@@ -750,7 +750,7 @@
      (PHP 7.1.0 &gt;=) Les développers ne doivent pas réécrire de drapeaux HTML
      non nécessaires. La valeur par défaut doit être suffisante pour la
      plupart des utilisations. Pour les versions de PHP plus anciennes,
-     utilisez plutôt
+     utiliser plutôt
      <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link>.
     </para>
    </listitem>

--- a/reference/session/sessionhandlerinterface.xml
+++ b/reference/session/sessionhandlerinterface.xml
@@ -67,7 +67,7 @@
       les paramètres <literal>$id</literal> sont en fait des valeurs fournies 
       par l'utilisateur qui nécessitent une validation/assainissement appropriée 
       pour éviter les vulnérabilités, telles que les problèmes de parcours de 
-      chemin. <emphasis>N'utilisez donc pas cet exemple sans modification dans 
+      chemin. <emphasis>N'utiliser donc pas cet exemple sans modification dans 
       les environnements de production.</emphasis>
       
      </para>

--- a/reference/shmop/functions/shmop-open.xml
+++ b/reference/shmop/functions/shmop-open.xml
@@ -44,21 +44,21 @@
         <listitem>
          <simpara>
           <literal>"a"</literal> pour accès (utilise <literal>SHM_RDONLY</literal> pour shmat)
-          utilisez cette option pour ouvrir un bloc déjà existant en lecture
+          utiliser cette option pour ouvrir un bloc déjà existant en lecture
           seule.
          </simpara>
         </listitem>
         <listitem>
          <simpara>
           <literal>"c"</literal> pour création (utilise <literal>IPC_CREATE</literal>)
-          utilisez cette option pour créer un nouveau bloc, ou, si un
+          utiliser cette option pour créer un nouveau bloc, ou, si un
           segment avec le même identifiant existe, essayer d'y accéder en
           lecture et écriture.
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          <literal>"w"</literal> pour accès en lecture et écriture. Utilisez
+          <literal>"w"</literal> pour accès en lecture et écriture. Utiliser
           cette option lorsque l'on doit accéder en lecture et
           écriture à un segment de mémoire partagée.
           C'est le cas le plus courant.
@@ -67,7 +67,7 @@
         <listitem>
          <simpara>
           <literal>"n"</literal> crée un nouveau segment de mémoire partagée
-          (utilise <literal>IPC_CREATE|IPC_EXCL</literal>). Utilisez cette option
+          (utilise <literal>IPC_CREATE|IPC_EXCL</literal>). Utiliser cette option
           lorsque l'on veut créer un nouveau segment de mémoire
           partagée. Si un segment existe déjà avec la même clé,
           la fonction échouera. Ceci est très pratique pour des raisons

--- a/reference/simplexml/functions/simplexml-load-file.xml
+++ b/reference/simplexml/functions/simplexml-load-file.xml
@@ -89,7 +89,7 @@
   </para>
   <tip>
    <para>
-    Utilisez la fonction <function>libxml_use_internal_errors</function>
+    Utiliser la fonction <function>libxml_use_internal_errors</function>
     pour supprimer toutes les erreurs XML, et la fonction
     <function>libxml_get_errors</function> pour les parcourir.
    </para>

--- a/reference/simplexml/functions/simplexml-load-string.xml
+++ b/reference/simplexml/functions/simplexml-load-string.xml
@@ -90,7 +90,7 @@
   </para>
   <tip>
    <para>
-    Utilisez la fonction <function>libxml_use_internal_errors</function>
+    Utiliser la fonction <function>libxml_use_internal_errors</function>
     pour supprimer toutes les erreurs XML, et la fonction
     <function>libxml_get_errors</function> pour les parcourir.
    </para>

--- a/reference/simplexml/simplexmlelement/construct.xml
+++ b/reference/simplexml/simplexmlelement/construct.xml
@@ -59,7 +59,7 @@
      <term><parameter>dataIsURL</parameter></term>
      <listitem>
       <para>
-       Par défaut, <parameter>dataIsURL</parameter> vaut &false;. Utilisez
+       Par défaut, <parameter>dataIsURL</parameter> vaut &false;. Utiliser
        &true; pour spécifier que le paramètre <parameter>data</parameter> est
        un chemin d'accès ou un URL pointant à un document XML au lieu d'une
        chaîne de caractères de données.
@@ -97,7 +97,7 @@
   </para>
   <tip>
    <para>
-    Utilisez la fonction <function>libxml_use_internal_errors</function>
+    Utiliser la fonction <function>libxml_use_internal_errors</function>
     pour supprimer toutes les erreurs XML et la fonction
     <function>libxml_get_errors</function> pour les parcourir.
    </para>

--- a/reference/snmp/functions/snmpwalkoid.xml
+++ b/reference/snmp/functions/snmpwalkoid.xml
@@ -27,7 +27,7 @@
    L'existence de <function>snmpwalkoid</function> et
    <function>snmpwalk</function> a des raisons historiques.
    Les deux fonctions fournissent des compatibilités ascendantes.
-   Utilisez plutôt la fonction <function>snmprealwalk</function>.
+   Utiliser plutôt la fonction <function>snmprealwalk</function>.
   </simpara>
  </refsect1>
 

--- a/reference/soap/soapclient/call.xml
+++ b/reference/soap/soapclient/call.xml
@@ -19,7 +19,7 @@
    L'appel direct à cette méthode est obsolète. Habituellement, les
    fonctions SOAP peuvent être appelées comme méthodes de l'objet
    <classname>SoapClient</classname> ; dans les cas où ce n'est pas
-   possible, ou bien qu'il est nécessaire de passer plus d'options, utilisez
+   possible, ou bien qu'il est nécessaire de passer plus d'options, utiliser
    la méthode <methodname>SoapClient::__soapCall</methodname>.
    </para>
  </refsect1>

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -34,7 +34,7 @@
       <note>
        <para>
         Par défaut, le fichier WSDL sera mis en cache pour des raisons de performance. Pour désactiver
-        ou configurer cette mise en cache, consultez la section
+        ou configurer cette mise en cache, consulter la section
         <link linkend="soap.configuration.list">SOAP &ConfigureOptions;</link>
         et l'option <link linkend="soapclient.construct.options.cache-wsdl">
         <literal>cache_wsdl</literal></link>
@@ -306,7 +306,7 @@
            l'algorithme de compression à utiliser ; et un nombre entre 1 et 9
            pour indiquer le niveau de compression à utiliser dans la requête.
            Par exemple, pour activer la compression gzip bidirectionnelle avec le niveau
-           de compression maximal, utilisez
+           de compression maximal, utiliser
            <literal>SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP | 9</literal>.
           </para>
          </listitem>
@@ -527,7 +527,7 @@
                Si la fonctionnalité <constant>SOAP_SINGLE_ELEMENT_ARRAYS</constant> est activée,
                les éléments qui n'apparaissent qu'une seule fois sont placés dans un tableau à un seul élément, de sorte que
                l'accès soit cohérent pour tous les éléments. Cela n'a d'effet que lors de l'utilisation d'un WSDL
-               contenant un schéma pour la réponse. Consultez la section des exemples pour une illustration.
+               contenant un schéma pour la réponse. Consulter la section des exemples pour une illustration.
               </para>
              </listitem>
             </varlistentry>

--- a/reference/soap/soapclient/dorequest.xml
+++ b/reference/soap/soapclient/dorequest.xml
@@ -69,7 +69,7 @@
      <listitem>
       <para>
        Si <parameter>oneWay</parameter> prend la valeur de &true;,
-       cette méthode ne retourne rien. Utilisez cette valeur
+       cette méthode ne retourne rien. Utiliser cette valeur
        quand une réponse n'est pas attendue.
       </para>
      </listitem>

--- a/reference/sockets/book.xml
+++ b/reference/sockets/book.xml
@@ -27,7 +27,7 @@
    Lors de l'utilisation de ces fonctions, il est important de se
    rappeler que si de nombreuses fonctions ont le même nom que leur
    équivalent en langage C, elles ont souvent des déclarations différentes.
-   Lisez attentivement les descriptions pour éviter des confusions.
+   Consulter attentivement les descriptions pour éviter des confusions.
   </para>
   <para>
    Cela dit, ceux qui ne sont pas familiers avec la programmation par socket

--- a/reference/sockets/functions/socket-last-error.xml
+++ b/reference/sockets/functions/socket-last-error.xml
@@ -106,7 +106,7 @@ if ($socket === false) {
   &reftitle.notes;
   <note>
    <para>
-    <function>socket_last_error</function> n'efface pas le code d'erreur. Utilisez
+    <function>socket_last_error</function> n'efface pas le code d'erreur. Utiliser
     plutôt la fonction <function>socket_clear_error</function> pour cela.
    </para>
   </note>

--- a/reference/sockets/functions/socket-select.xml
+++ b/reference/sockets/functions/socket-select.xml
@@ -103,7 +103,7 @@
    <para>
     À cause d'une limitation du moteur Zend actuel, il n'est pas possible
     de passer une constante comme &null; directement comme paramètre à cette
-    fonction, qui attend une valeur par référence. À la place, utilisez
+    fonction, qui attend une valeur par référence. À la place, utiliser
     un tableau temporaire ou une expression dont le membre de gauche
     est une variable temporaire :
     <example>

--- a/reference/sodium/functions/sodium-crypto-box-seed-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-box-seed-keypair.xml
@@ -18,7 +18,7 @@
   </simpara>
   <simpara>
    Les fonctions <literal>*_seed_keypair</literal> sont idéales pour générer une paire de clés à partir
-   d'un mot de passe et d'un sel. Utilisez le résultat comme <parameter>seed</parameter> pour générer les clés souhaitées.
+   d'un mot de passe et d'un sel. Utiliser le résultat comme <parameter>seed</parameter> pour générer les clés souhaitées.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/functions/sodium-crypto-pwhash.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash.xml
@@ -84,7 +84,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie la clé dérivée. La valeur de retour est une chaîne binaire du hachage, pas une représentation encodée en ASCII, et ne contient pas d'informations supplémentaires sur les paramètres utilisés pour créer le hachage, donc il faudra conserver ces informations si l'on doit jamais vérifier le mot de passe à l'avenir. Utilisez <function>sodium_crypto_pwhash_str</function> pour éviter d'avoir besoin de faire tout cela.
+   Renvoie la clé dérivée. La valeur de retour est une chaîne binaire du hachage, pas une représentation encodée en ASCII, et ne contient pas d'informations supplémentaires sur les paramètres utilisés pour créer le hachage, donc il faudra conserver ces informations si l'on doit jamais vérifier le mot de passe à l'avenir. Utiliser <function>sodium_crypto_pwhash_str</function> pour éviter d'avoir besoin de faire tout cela.
   </simpara>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/sodium/functions/sodium-crypto-sign-seed-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-sign-seed-keypair.xml
@@ -18,7 +18,7 @@
   </simpara>
   <simpara>
    Les fonctions <literal>*_seed_keypair</literal> sont idéales pour générer une paire de clés à partir
-   d'un mot de passe et d'un sel. Utilisez le résultat comme <parameter>seed</parameter> pour générer les clés souhaitées.
+   d'un mot de passe et d'un sel. Utiliser le résultat comme <parameter>seed</parameter> pour générer les clés souhaitées.
   </simpara>
 
  </refsect1>

--- a/reference/solr/solrquery/setfacetsort.xml
+++ b/reference/solr/solrquery/setfacetsort.xml
@@ -30,7 +30,7 @@
      <term><parameter>facetSort</parameter></term>
      <listitem>
       <para>
-       Utilisez SolrQuery::FACET_SORT_INDEX pour trier sur l'index,
+       Utiliser SolrQuery::FACET_SORT_INDEX pour trier sur l'index,
        ou SolrQuery::FACET_SORT_COUNT pour trier sur le total.
       </para>
      </listitem>

--- a/reference/solr/solrutils/digestxmlresponse.xml
+++ b/reference/solr/solrutils/digestxmlresponse.xml
@@ -39,7 +39,7 @@
      <term><parameter>parse_mode</parameter></term>
      <listitem>
       <para>
-       Utilisez SolrResponse::PARSE_SOLR_OBJ ou SolrResponse::PARSE_SOLR_DOC
+       Utiliser SolrResponse::PARSE_SOLR_OBJ ou SolrResponse::PARSE_SOLR_DOC
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/arrayobject/append.xml
+++ b/reference/spl/arrayobject/append.xml
@@ -21,7 +21,7 @@
    <para>
     Cette méthode ne peut pas être appelée lorsque l'objet
     <classname>ArrayObject</classname> a été construit à partir
-    d'un autre objet. Utilisez alors la méthode
+    d'un autre objet. Utiliser alors la méthode
     <methodname>ArrayObject::offsetSet</methodname>.
    </para>
   </note>

--- a/reference/spl/arrayobject/getflags.xml
+++ b/reference/spl/arrayobject/getflags.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Lit les options de comportement de l'objet <classname>ArrayObject</classname>.
-   Voyez la méthode <link linkend="arrayobject.setflags">ArrayObject::setFlags</link>
+   Voir la méthode <link linkend="arrayobject.setflags">ArrayObject::setFlags</link>
    pour obtenir une liste d'options disponibles.
   </para>
  </refsect1>

--- a/reference/spl/filesystemiterator/current.xml
+++ b/reference/spl/filesystemiterator/current.xml
@@ -30,7 +30,7 @@
   <para>
    Le nom du fichier, les informations du fichier, ou bien
    <literal>$this</literal>, en fonction des options utilisées.
-   Voyez la <link linkend="filesystemiterator.constants">liste des constantes <classname>FilesystemIterator</classname></link>.
+   Voir la <link linkend="filesystemiterator.constants">liste des constantes <classname>FilesystemIterator</classname></link>.
   </para>
  </refsect1>
 

--- a/reference/spl/filesystemiterator/key.xml
+++ b/reference/spl/filesystemiterator/key.xml
@@ -26,7 +26,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne le chemin ou le nom du fichier, suivant les options
-   activées. Voyez les 
+   activées. Voir les 
    <link linkend="filesystemiterator.constants">Constantes de <classname>FilesystemIterator</classname></link>.
   </para>
  </refsect1>

--- a/reference/spl/recursivecachingiterator/construct.xml
+++ b/reference/spl/recursivecachingiterator/construct.xml
@@ -39,7 +39,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Le drapeau. Utilisez la constante <constant>CALL_TOSTRING</constant> pour appeler
+       Le drapeau. Utiliser la constante <constant>CALL_TOSTRING</constant> pour appeler
        <methodname>RecursiveCachingIterator::__toString</methodname> sur tous les éléments
        (par défaut), et/ou la constante <constant>CATCH_GET_CHILD</constant>
        pour attraper toutes les exceptions émises lorsque l'on tente de récupérer des fils.

--- a/reference/spl/splfileinfo/getlinktarget.xml
+++ b/reference/spl/splfileinfo/getlinktarget.xml
@@ -20,7 +20,7 @@
   <note>
    <para>
     Le chemin indiqué n'est pas toujours le chemin réel sur le système de fichiers.
-    Utilisez <methodname>SplFileInfo::getRealPath</methodname> pour déterminer le
+    Utiliser <methodname>SplFileInfo::getRealPath</methodname> pour déterminer le
     véritable chemin.
    </para>
   </note>

--- a/reference/spl/splfileinfo/setfileclass.xml
+++ b/reference/spl/splfileinfo/setfileclass.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>string</type><parameter>class</parameter><initializer><constant>SplFileObject::class</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   Utilisez cette méthode pour définir une classe personnalisée qui sera 
+   Utiliser cette méthode pour définir une classe personnalisée qui sera 
    utilisée lorsque <methodname>SplFileInfo::openFile</methodname> est appelé. 
    Le nom de la classe passé à cette méthode doit être 
    <classname>SplFileObject</classname> ou une classe dérivé de 

--- a/reference/spl/splfileinfo/setinfoclass.xml
+++ b/reference/spl/splfileinfo/setinfoclass.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>string</type><parameter>class</parameter><initializer><constant>SplFileInfo::class</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   Utilisez cette méthode pour configurer une classe personnalisée
+   Utiliser cette méthode pour configurer une classe personnalisée
    à utiliser avec les méthodes <methodname>SplFileInfo::getFileInfo</methodname>
    et <methodname>SplFileInfo::getPathInfo</methodname>. La classe utilisée doit hériter de <classname>SplFileInfo</classname>.
   </para>

--- a/reference/spl/splfileobject/fread.xml
+++ b/reference/spl/splfileobject/fread.xml
@@ -64,7 +64,7 @@ $contents = $file->fread($file->getSize());
   <note>
    <para>
     Il est à noter que <methodname>SplFileObject::fread</methodname> lit depuis la
-    position courante du pointeur de fichier. Utilisez la méthode
+    position courante du pointeur de fichier. Utiliser la méthode
     <methodname>SplFileObject::ftell</methodname> pour trouver la position
     courante du pointeur, et la méthode <methodname>SplFileObject::rewind</methodname>
     (ou <methodname>SplFileObject::fseek</methodname>) pour réinitialiser la

--- a/reference/spl/splfixedarray/wakeup.xml
+++ b/reference/spl/splfixedarray/wakeup.xml
@@ -49,7 +49,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Cette méthode est désormais obsolète, utilisez
+       Cette méthode est désormais obsolète, utiliser
        <methodname>SplFixedArray::__unserialize</methodname>
        à la place.
       </entry>

--- a/reference/sqlite3/sqlite3/escapestring.xml
+++ b/reference/sqlite3/sqlite3/escapestring.xml
@@ -20,7 +20,7 @@
   &note.not-bin-safe;
   <para>
    Pour correctement gérer les champs BLOB qui contiennent des caractères NUL,
-   utilisez plutôt la fonction <function>SQLite3Stmt::bindParam</function>.
+   utiliser plutôt la fonction <function>SQLite3Stmt::bindParam</function>.
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/query.xml
+++ b/reference/sqlite3/sqlite3/query.xml
@@ -17,7 +17,7 @@
    Exécute une requête SQL, et retourne un objet <classname>SQLite3Result</classname>.
    Si la requête ne génère pas de résultat (comme les instructions DML), l'objet 
    <classname>SQLite3Result</classname> retourné n'est pas vraiment utilisable.   
-   Utilisez <methodname>SQLite3::exec</methodname> pour ces requêtes à la place.
+   Utiliser <methodname>SQLite3::exec</methodname> pour ces requêtes à la place.
   </para>
  </refsect1>
 

--- a/reference/sqlsrv/functions/sqlsrv-fetch-array.xml
+++ b/reference/sqlsrv/functions/sqlsrv-fetch-array.xml
@@ -157,7 +157,7 @@ sqlsrv_free_stmt( $stmt);
   <simpara>
    Si plus d'une colonne est retournée avec le même nom, la dernière colonne
    prendra le dessus. Pour éviter d'avoir des problèmes avec les noms des
-   colonnes, utilisez des alias.
+   colonnes, utiliser des alias.
   </simpara>
   <simpara>
    Si une colonne ne possédant aucun nom est retournée, la clé associative de l'élément

--- a/reference/sqlsrv/functions/sqlsrv-fetch.xml
+++ b/reference/sqlsrv/functions/sqlsrv-fetch.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    Rend la prochaine ligne d'un jeu de résultats disponible pour lecture.
-   Utilisez la fonction <function>sqlsrv_get_field</function> pour llire les
+   Utiliser la fonction <function>sqlsrv_get_field</function> pour llire les
    champs de la ligne.
   </simpara>
  </refsect1>

--- a/reference/sqlsrv/functions/sqlsrv-prepare.xml
+++ b/reference/sqlsrv/functions/sqlsrv-prepare.xml
@@ -208,7 +208,7 @@ foreach( $orders as $id => $qty) {
    les variables sont liées à la requête. Cela signifie que si l'on met à jour
    les valeurs de ces variables, la prochaine exécution de la requête prendra
    en compte ces nouvelles valeurs. Pour les requêtes que l'on ne prévoit
-   exécuter qu'une seule fois, utilisez la fonction
+   exécuter qu'une seule fois, utiliser la fonction
    <function>sqlsrv_query</function>.
   </simpara>
  </refsect1>

--- a/reference/sqlsrv/functions/sqlsrv-query.xml
+++ b/reference/sqlsrv/functions/sqlsrv-query.xml
@@ -181,7 +181,7 @@ if( $stmt === false ) {
    Pour les requêtes que l'on ne prévoit d'exécuter qu'une seule fois,
    il est recommandé d'utiliser la fonction <function>sqlsrv_query</function>.
    Pour ré-exécuter une requête avec des valeurs différentes pour ses
-   paramètres, utilisez la combinaison de la fonction
+   paramètres, utiliser la combinaison de la fonction
    <function>sqlsrv_prepare</function> et de la fonction <function>sqlsrv_execute</function>.
   </simpara>
  </refsect1>

--- a/reference/stream/book.xml
+++ b/reference/stream/book.xml
@@ -30,7 +30,7 @@
     ou bien directement par une autre extension.
     Grâce à la souplesse des gestionnaires qui peuvent être ajoutés à PHP,
     il n'y a pas de limites aux possibilités offertes. Pour connaître la liste
-    des gestionnaires actuellement enregistrés, utilisez la fonction
+    des gestionnaires actuellement enregistrés, utiliser la fonction
     <function>stream_get_wrappers</function>.
    </simpara>
    <para>

--- a/reference/stream/constants.xml
+++ b/reference/stream/constants.xml
@@ -700,7 +700,7 @@
        ou la résolution a échoué.
       </simpara>
       <simpara>
-       Consultez <parameter>severity</parameter> pour savoir ce qui s'est produit.
+       Consulter <parameter>severity</parameter> pour savoir ce qui s'est produit.
       </simpara>
       <warning>
        <simpara>
@@ -745,7 +745,7 @@
        Le <literal>type MIME</literal> de la ressource a été identifié.
       </simpara>
       <simpara>
-       Consultez <parameter>message</parameter> pour une description du type découvert.
+       Consulter <parameter>message</parameter> pour une description du type découvert.
       </simpara>
      </listitem>
     </varlistentry>
@@ -770,7 +770,7 @@
        La ressource externe a redirigé le flux vers un autre emplacement.
       </simpara>
       <simpara>
-       Consultez <parameter>message</parameter>.
+       Consulter <parameter>message</parameter>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -809,7 +809,7 @@
        Une erreur générique est survenue sur le flux.
       </simpara>
       <simpara>
-       Consultez <parameter>message</parameter> et
+       Consulter <parameter>message</parameter> et
        <parameter>message_code</parameter> pour plus de détails.
       </simpara>
      </listitem>

--- a/reference/stream/errors.xml
+++ b/reference/stream/errors.xml
@@ -10,7 +10,7 @@
   peuvent échouer pour une grande variété de raisons (par exemple : impossible
   de se connecter au serveur distant, fichier introuvable, etc.). Un flux peut aussi
   échouer parce que le gestionnaire n'est pas configuré sur le système en
-  cours. Voyez le tableau retourné par la fonction
+  cours. Voir le tableau retourné par la fonction
   <function>stream_get_wrappers</function> pour connaître la liste des gestionnaires
   configurés sur l'installation de PHP. Comme avec la plupart des fonctions
   internes de PHP, si une erreur survient, un message de type

--- a/reference/stream/filters.xml
+++ b/reference/stream/filters.xml
@@ -11,7 +11,7 @@
   filtres peuvent être ajoutés sur un flux. Des filtres personnalisés peuvent aussi
   être ajoutés avec la fonction <function>stream_register_filter</function>, ou bien
   dans une extension. Pour
-  connaître la liste des filtres actuellement enregistrés, utilisez la fonction
+  connaître la liste des filtres actuellement enregistrés, utiliser la fonction
   <function>stream_get_filters</function>.
  </simpara>
 </chapter>

--- a/reference/stream/functions/stream-context-set-option.xml
+++ b/reference/stream/functions/stream-context-set-option.xml
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    La signature alternative suivante est obsolète à partir de PHP 8.4.0,
-   utilisez <function>stream_context_set_options</function> à la place.
+   utiliser <function>stream_context_set_options</function> à la place.
    <methodsynopsis>
     <type>bool</type><methodname>stream_context_set_option</methodname>
     <methodparam><type>resource</type><parameter>stream_or_context</parameter></methodparam>
@@ -118,7 +118,7 @@
       <entry>8.4.0</entry>
       <entry>
        La signature alternative à 2 paramètres est désormais obsolète.
-       Utilisez <function>stream_context_set_options</function> à la place.
+       Utiliser <function>stream_context_set_options</function> à la place.
       </entry>
      </row>
     </tbody>

--- a/reference/stream/functions/stream-filter-append.xml
+++ b/reference/stream/functions/stream-filter-append.xml
@@ -70,7 +70,7 @@
        <parameter>params</parameter> à la <emphasis>fin</emphasis> de
        la liste des filtres, et sera ainsi appelé à la fin des 
        opérations de filtres. Pour ajouter un filtre au début
-       de la liste, utilisez la fonction 
+       de la liste, utiliser la fonction 
        <function>stream_filter_prepend</function>.
       </para>
      </listitem>

--- a/reference/stream/functions/stream-filter-prepend.xml
+++ b/reference/stream/functions/stream-filter-prepend.xml
@@ -59,7 +59,7 @@
        <constant>STREAM_FILTER_WRITE</constant>, et/ou
        <constant>STREAM_FILTER_ALL</constant> peuvent aussi être passés dans le
        paramètre <parameter>read_write</parameter> pour imposer le comportement
-       désiré. Voyez <function>stream_filter_append</function> pour un exemple
+       désiré. Voir <function>stream_filter_append</function> pour un exemple
        d'utilisation de ce paramètre.
       </para>
      </listitem>
@@ -71,7 +71,7 @@
        Le filtre sera ajouté avec les paramètres spécifiés dans <parameter>params</parameter>,
        au <emphasis>début</emphasis> de la liste, et sera ainsi appelé en premier
        dans les opérations du flux. Pour ajouter un filtre à la fin de la liste,
-       utilisez <function>stream_filter_append</function>.
+       utiliser <function>stream_filter_append</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/stream/functions/stream-get-meta-data.xml
+++ b/reference/stream/functions/stream-get-meta-data.xml
@@ -60,7 +60,7 @@
      <literal>eof</literal> (&boolean;) : &true; si le flux a atteint la
      fin du fichier. Il est à noter que pour les sockets, cette valeur peut être
      &true; même si <literal>unread_bytes</literal> est non nul. Pour
-     déterminer s'il reste des données à lire, utilisez plutôt la
+     déterminer s'il reste des données à lire, utiliser plutôt la
      fonction <function>feof</function>.
     </para>
    </listitem>
@@ -84,7 +84,7 @@
    <listitem>
     <para>
      <literal>wrapper_type</literal> (&string;) : un nom qui décrit
-     le gestionnaire de protocole pour ce flux. Voyez
+     le gestionnaire de protocole pour ce flux. Voir
      <xref linkend="wrappers"/> pour plus d'informations sur les
      gestionnaires.
     </para>
@@ -92,7 +92,7 @@
    <listitem>
     <para>
      <literal>wrapper_data</literal> (mixed) : des données spécifiques
-     au gestionnaire liées à ce flux. Voyez <xref linkend="wrappers"/> pour
+     au gestionnaire liées à ce flux. Voir <xref linkend="wrappers"/> pour
      plus d'informations sur les gestionnaires et leurs données.
     </para>
    </listitem>

--- a/reference/stream/functions/stream-set-timeout.xml
+++ b/reference/stream/functions/stream-set-timeout.xml
@@ -107,7 +107,7 @@ if (!$fp) {
   <note>
    <para>
     Cette fonction ne fonctionne pas avec les opérations avancées comme
-    <function>stream_socket_recvfrom</function>, utilisez plutôt
+    <function>stream_socket_recvfrom</function>, utiliser plutôt
     <function>stream_select</function> avec une durée d'expiration en
     paramètre.
    </para>

--- a/reference/stream/functions/stream-socket-accept.xml
+++ b/reference/stream/functions/stream-socket-accept.xml
@@ -95,7 +95,7 @@
   <warning>
    <para>
     Cette fonction ne doit pas être utilisée avec les sockets serveur UDP.
-    À la place, utilisez les fonctions
+    À la place, utiliser les fonctions
     <function>stream_socket_recvfrom</function> et
     <function>stream_socket_sendto</function>.
    </para>

--- a/reference/stream/functions/stream-socket-client.xml
+++ b/reference/stream/functions/stream-socket-client.xml
@@ -81,7 +81,7 @@
        <note>
         <para>
          Pour définir un délai d'expiration lors de la lecture/écriture de
-         données via un socket, utilisez la fonction
+         données via un socket, utiliser la fonction
          <function>stream_set_timeout</function>, vu que le paramètre
          <parameter>timeout</parameter> n'est appliqué que lors de la connexion
          au socket.
@@ -229,7 +229,7 @@ if (!$fp) {
     Suivant l'environnement, les sockets Unix ou le délai d'expiration
     peuvent ne pas être disponibles. Une liste des transports disponibles
     sur le système est accessible via <function>stream_get_transports</function>.
-    Voyez <xref linkend="transports"/> pour une liste de transports natifs.
+    Voir <xref linkend="transports"/> pour une liste de transports natifs.
    </para>
   </note>
  </refsect1><!-- }}} -->

--- a/reference/stream/functions/stream-socket-pair.xml
+++ b/reference/stream/functions/stream-socket-pair.xml
@@ -68,7 +68,7 @@
   </para>
   <note>
    <simpara>
-    Consultez la <link linkend="stream.constants">liste des constantes de flux</link> 
+    Consulter la <link linkend="stream.constants">liste des constantes de flux</link> 
     pour plus de détails sur chaque constante.
    </simpara>
   </note>

--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -50,7 +50,7 @@
       <para>
        En fonction de l'environnement, les sockets de domaine Unix
        peuvent être indisponibles. Une liste des transports disponibles
-       est accessible via <function>stream_get_transports</function>. Voyez
+       est accessible via <function>stream_get_transports</function>. Voir
        <xref linkend="transports"/> pour connaître la liste des transports
        natifs.
       </para>
@@ -78,7 +78,7 @@
      <term><parameter>error_message</parameter></term>
      <listitem>
       <para>
-       Voyez la description de <parameter>error_code</parameter>.
+       Voir la description de <parameter>error_code</parameter>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/stream/php_user_filter/oncreate.xml
+++ b/reference/stream/php_user_filter/oncreate.xml
@@ -41,7 +41,7 @@
        <entry>
         Une chaîne contenant le nom utilisé pour instancier le filtre.
         Les filtres peuvent être enregistrés sous plusieurs noms
-        ou avec des jokers. Utilisez cette propriété pour déterminer
+        ou avec des jokers. Utiliser cette propriété pour déterminer
         quel est le nom qui a été utilisé.
        </entry>
       </row>

--- a/reference/stream/setup.xml
+++ b/reference/stream/setup.xml
@@ -15,7 +15,7 @@
   </simpara>
   <simpara>
    La classe <classname>php_user_filter</classname> est prédéfinie. C'est une classe abstraite
-   à utiliser avec les filtres personnalisés. Voyez le manuel de la fonction
+   à utiliser avec les filtres personnalisés. Voir le manuel de la fonction
    <function>stream_register_filter</function> pour plus de détails sur les
    implémentations de filtres utilisateurs.
   </simpara>

--- a/reference/stream/streamwrapper.xml
+++ b/reference/stream/streamwrapper.xml
@@ -82,7 +82,7 @@
        si aucun contexte n'a été passé à la fonction.
       </para>
       <para>
-       Utilisez la fonction <function>stream_context_get_options</function>
+       Utiliser la fonction <function>stream_context_get_options</function>
        pour analyser le contexte.
       </para>
       <note>

--- a/reference/strings/functions/addcslashes.xml
+++ b/reference/strings/functions/addcslashes.xml
@@ -66,7 +66,7 @@ echo addcslashes('foo[ ]', 'A..z');
        De plus, si le premier caractère d'un intervalle a un code ASCII
        plus grand que le second, l'intervalle ne sera pas créé.
        Seules les bornes de l'intervalle et le caractère point (.) seront
-       échappés. Utilisez la fonction <function>ord</function> pour
+       échappés. Utiliser la fonction <function>ord</function> pour
        trouver la valeur ASCII d'un caractère.
       <example>
        <title><function>addcslashes</function> avec des caractères dans le mauvais ordre</title>

--- a/reference/strings/functions/fprintf.xml
+++ b/reference/strings/functions/fprintf.xml
@@ -100,7 +100,7 @@ $len = fprintf($fp, '%01.2f', $money);
 // écrira "123.10" dans le fichier currency.txt
 
 echo "écriture de $len octets dans le fichier currency.txt";
-// utilisez la valeur retournée par fprintf pour déterminer le nombre d'octets écrits
+// utiliser la valeur retournée par fprintf pour déterminer le nombre d'octets écrits
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/htmlspecialchars.xml
+++ b/reference/strings/functions/htmlspecialchars.xml
@@ -22,7 +22,7 @@
    leurs significations. Cette fonction retourne une chaîne de caractères
    avec ces modifications. En cas de besoin que toutes
    les sous-chaînes en entrée qui sont associées à des entités
-   nommées soient transformées, utilisez la fonction
+   nommées soient transformées, utiliser la fonction
    <function>htmlentities</function>.
   </para>
   <para>

--- a/reference/strings/functions/money-format.xml
+++ b/reference/strings/functions/money-format.xml
@@ -340,7 +340,7 @@ echo money_format($fmt, 1234.56) . "\n";
   <note>
    <para>
     La catégorie <constant>LC_MONETARY</constant> de la configuration locale
-    affecte le comportement de cette fonction. Utilisez
+    affecte le comportement de cette fonction. Utiliser
     <function>setlocale</function> pour configurer correctement PHP avant
     d'utiliser cette fonction.
    </para>

--- a/reference/strings/functions/str-ireplace.xml
+++ b/reference/strings/functions/str-ireplace.xml
@@ -25,7 +25,7 @@
   </para>
   <para>
    Pour remplacer un texte en fonction d'un modèle plutôt qu'une chaîne fixe,
-   utilisez <function>preg_replace</function> avec le modificateur de modèle
+   utiliser <function>preg_replace</function> avec le modificateur de modèle
    <literal>i</literal> <link linkend="reference.pcre.pattern.modifiers">.</link>.
   </para>
  </refsect1>

--- a/reference/strings/functions/str-replace.xml
+++ b/reference/strings/functions/str-replace.xml
@@ -24,7 +24,7 @@
   </para>
   <para>
    Pour remplacer un texte en fonction d'un modèle plutôt qu'une chaîne fixe,
-   utilisez <function>preg_replace</function>.
+   utiliser <function>preg_replace</function>.
   </para>
  </refsect1>
 
@@ -187,7 +187,7 @@ echo $output, PHP_EOL;
   </caution>
   <note>
    <para>
-    Cette fonction est sensible à la casse. Utilisez la fonction
+    Cette fonction est sensible à la casse. Utiliser la fonction
     <function>str_ireplace</function> pour un remplacement insensible à la
     casse.
    </para>

--- a/reference/strings/functions/strtolower.xml
+++ b/reference/strings/functions/strtolower.xml
@@ -27,7 +27,7 @@
   <para>
    Cela peut être utilisé pour convertir des caractères ASCII dans des chaînes
    encodées avec UTF-8, car les caractères UTF-8 multioctets seront ignorés.
-   Pour convertir des caractères non-ASCII multioctets, utilisez la fonction
+   Pour convertir des caractères non-ASCII multioctets, utiliser la fonction
    <function>mb_strtolower</function>.
   </para>
  </refsect1>

--- a/reference/strings/functions/strtoupper.xml
+++ b/reference/strings/functions/strtoupper.xml
@@ -27,7 +27,7 @@
   <para>
    Cela peut être utilisé pour convertir des caractères ASCII dans des chaînes encodées
    avec UTF-8, car les caractères UTF-8 multioctets seront ignorés. Pour convertir des
-   caractères non-ASCII multioctets, utilisez la fonction <function>mb_strtoupper</function>.
+   caractères non-ASCII multioctets, utiliser la fonction <function>mb_strtoupper</function>.
   </para>
  </refsect1>
 

--- a/reference/strings/functions/substr-count.xml
+++ b/reference/strings/functions/substr-count.xml
@@ -25,7 +25,7 @@
   <note>
    <para>
     Cette fonction ne compte pas les chaînes de caractères qui se recouvrent.
-    Voyez l'exemple ci-dessous !
+    Voir l'exemple ci-dessous !
    </para>
   </note>
  </refsect1>

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -27,7 +27,7 @@
    un retour à la ligne, un saut de page, une tabulation horizontale et une tabulation verticale.
   </para>
   <para>
-   Pour faire une conversion similaire sur les chaînes multioctet, utilisez
+   Pour faire une conversion similaire sur les chaînes multioctet, utiliser
    <function>mb_convert_case</function> avec le mode
    <constant>MB_CASE_TITLE</constant>.
   </para>

--- a/reference/strings/functions/utf8-decode.xml
+++ b/reference/strings/functions/utf8-decode.xml
@@ -43,7 +43,7 @@
     (<literal>“</literal> <literal>”</literal>), à la place de certains
     caractères de contrôle de l'<literal>ISO-8859-1</literal>. Cette fonction
     ne convertira pas ces caractères <literal>Windows-1252</literal>
-    correctement. Utilisez une fonction différente si une conversion
+    correctement. Utiliser une fonction différente si une conversion
     <literal>Windows-1252</literal> est nécessaire.
    </para>
   </note>

--- a/reference/strings/functions/utf8-encode.xml
+++ b/reference/strings/functions/utf8-encode.xml
@@ -43,7 +43,7 @@
     (<literal>“</literal> <literal>”</literal>), à la place de certains
     caractères de contrôle de l'<literal>ISO-8859-1</literal>. Cette fonction
     ne convertira pas ces caractères <literal>Windows-1252</literal>
-    correctement. Utilisez une fonction différente si une conversion
+    correctement. Utiliser une fonction différente si une conversion
     <literal>Windows-1252</literal> est nécessaire.
    </para>
   </note>

--- a/reference/svn/configure.xml
+++ b/reference/svn/configure.xml
@@ -11,7 +11,7 @@
  <simpara>
    Si <filename>./configure</filename> n'arrive pas à trouver les fichiers
    SVN (par exemple, Subversion a été installé avec un préfixe de dossier
-   personnalisé), utilisez la commande
+   personnalisé), utiliser la commande
    <userinput>./configure --with-svn=$USR_PATH</userinput>
    pour spécifier le dossier où
    <filename>include/subversion-1/</filename> se trouve.

--- a/reference/svn/functions/svn-auth-get-parameter.xml
+++ b/reference/svn/functions/svn-auth-get-parameter.xml
@@ -17,7 +17,7 @@
   <simpara>
    Récupère le paramètre d'identification dont la clé est
    <parameter>key</parameter>.
-   Pour une list de clés valides ainsi que leurs significations, consultez
+   Pour une list de clés valides ainsi que leurs significations, consulter
    la <link linkend="svn.constants.auth">liste des constantes d'identification</link>.
   </simpara>
  </refsect1>
@@ -29,7 +29,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
-      Nom de la clé. Utilisez une <link linkend="svn.constants.auth">constante d'identification</link> définie
+      Nom de la clé. Utiliser une <link linkend="svn.constants.auth">constante d'identification</link> définie
       par cette extension pour spécifier une clé..
      </simpara>
     </listitem>

--- a/reference/svn/functions/svn-auth-set-parameter.xml
+++ b/reference/svn/functions/svn-auth-set-parameter.xml
@@ -31,7 +31,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
-      Nom de la clé. Utilisez une <link linkend="svn.constants.auth">constante d'identification</link>
+      Nom de la clé. Utiliser une <link linkend="svn.constants.auth">constante d'identification</link>
       définie par cette extension pour spécifier la clé.
      </simpara>
     </listitem>

--- a/reference/svn/functions/svn-diff.xml
+++ b/reference/svn/functions/svn-diff.xml
@@ -44,7 +44,7 @@
      <warning>
       <simpara>
        Si un chemin vers un fichier local n'a que des antislashs et aucun
-       slashs, cette extension échouera. Remplacez toujours tous les
+       slashs, cette extension échouera. Remplacer toujours tous les
        antislashs avec des slashs lors de l'utilisation de cette fonction.
       </simpara>
      </warning>
@@ -54,7 +54,7 @@
     <term><parameter>rev1</parameter></term>
     <listitem>
      <simpara>
-      Numéro de révision du premier chemin. Utilisez la constante
+      Numéro de révision du premier chemin. Utiliser la constante
       <constant>SVN_REVISON_HEAD</constant> pour spécifier la révision
       la plus récente.
      </simpara>

--- a/reference/svn/functions/svn-import.xml
+++ b/reference/svn/functions/svn-import.xml
@@ -69,7 +69,7 @@
    <simpara>
     Cet exemple monte un usage classique de cette fonction. Pour importer
     un dossier nommé <literal>"new-files"</literal> dans le référentiel à l'URL
-    <literal>"http://www.example.com/svnroot/incoming/abc"</literal>, utilisez :
+    <literal>"http://www.example.com/svnroot/incoming/abc"</literal>, utiliser :
    </simpara>
    <programlisting role="php">
 <![CDATA[

--- a/reference/svn/functions/svn-log.xml
+++ b/reference/svn/functions/svn-log.xml
@@ -41,7 +41,7 @@
     <term><parameter>start_revision</parameter></term>
     <listitem>
      <simpara>
-      Numéro de révision de la première historisation à récupérer. Utilisez
+      Numéro de révision de la première historisation à récupérer. Utiliser
       la constante <constant>SVN_REVISION_HEAD</constant> pour récupérer
       l'historisation de la révision la plus récente.
      </simpara>

--- a/reference/svn/functions/svn-ls.xml
+++ b/reference/svn/functions/svn-ls.xml
@@ -39,7 +39,7 @@
      <simpara>
       URL du référentiel, e.g. <userinput>http://www.example.com/svnroot</userinput>.
       Pour accéder à un référentiel local Subversion via le système de fichiers,
-      utilisez l'URI suivant : <userinput>file:///home/user/svn-repos</userinput>
+      utiliser l'URI suivant : <userinput>file:///home/user/svn-repos</userinput>
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/swoole/constants.xml
+++ b/reference/swoole/constants.xml
@@ -3193,7 +3193,7 @@
     <listitem>
      <simpara>
       Échec de l'envoi au client (cette constante est disponible dans Swoole version >= v4.5.9, 
-      auparavant, utilisez le code d'état).
+      auparavant, utiliser le code d'état).
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/tcpwrap/functions/tcpwrap-check.xml
+++ b/reference/tcpwrap/functions/tcpwrap-check.xml
@@ -100,7 +100,7 @@ if (!tcpwrap_check('php', $_SERVER['REMOTE_ADDR'])) {
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
-   Pour plus de détails, consultez la page man de hosts_access(3).
+   Pour plus de détails, consulter la page man de hosts_access(3).
   </para>
  </refsect1>
 </refentry>

--- a/reference/tidy/tidy/repairstring.xml
+++ b/reference/tidy/tidy/repairstring.xml
@@ -52,7 +52,7 @@
        et sinon, elle est interprétée comme les options elles-mêmes.
       </para>
       <para>
-       Lisez <link xlink:href="&url.tidy.conf;">&url.tidy.conf;</link> 
+       Consulter <link xlink:href="&url.tidy.conf;">&url.tidy.conf;</link> 
        pour une explication sur chaque option.
       </para>
      </listitem>

--- a/reference/tokenizer/functions/token-get-all.xml
+++ b/reference/tokenizer/functions/token-get-all.xml
@@ -19,7 +19,7 @@
    donnée en utilisant l'analyseur lexical du moteur Zend.
   </para>
   <para>
-   Pour une liste des tokens, voir <xref linkend="tokens"/>, ou utilisez la fonction
+   Pour une liste des tokens, voir <xref linkend="tokens"/>, ou utiliser la fonction
    <function>token_name</function> pour traduire une valeur token dans une
    représentation sous forme de chaîne de caractères.
   </para>

--- a/reference/ui/setup.xml
+++ b/reference/ui/setup.xml
@@ -13,7 +13,7 @@
   </para>
   <para>
    Cette extension nécessite l'installation de <link xlink:href="&url.ui.libui;">la bibliothèque libui</link> 
-   version 0.1.0 ou une version plus récente. Consultez la documentation libui pour obtenir une liste des prérequis.
+   version 0.1.0 ou une version plus récente. Consulter la documentation libui pour obtenir une liste des prérequis.
   </para>
  </section>
 

--- a/reference/uodbc/functions/odbc-data-source.xml
+++ b/reference/uodbc/functions/odbc-data-source.xml
@@ -36,7 +36,7 @@
        Le paramètre <parameter>connection_id</parameter> est une connexion
        ODBC valide. Le paramètre <parameter>fetch_type</parameter> peut être l'une des
        deux constantes suivantes : <constant>SQL_FETCH_FIRST</constant> ou
-       <constant>SQL_FETCH_NEXT</constant>. Utilisez <constant>SQL_FETCH_FIRST</constant>
+       <constant>SQL_FETCH_NEXT</constant>. Utiliser <constant>SQL_FETCH_FIRST</constant>
        la première fois que la fonction est appelée, puis <constant>SQL_FETCH_NEXT</constant>.
       </para>
      </listitem>

--- a/reference/uopz/configure.xml
+++ b/reference/uopz/configure.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
 
  <para>
-  Utilisez <option role="configure">--enable-uopz[=DIR]</option>
+  Utiliser <option role="configure">--enable-uopz[=DIR]</option>
   lors de la compilation de PHP.
  </para>
 

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -44,7 +44,7 @@
      <listitem>
       <para>
        Pour obtenir le résultat de <function>print_r</function> dans une chaîne,
-       utilisez le paramètre <parameter>return</parameter>. Lorsque ce paramètre vaut
+       utiliser le paramètre <parameter>return</parameter>. Lorsque ce paramètre vaut
        &true;, <function>print_r</function> retournera l'information plutôt que de l'afficher.
       </para>
      </listitem>

--- a/reference/var/functions/serialize.xml
+++ b/reference/var/functions/serialize.xml
@@ -23,7 +23,7 @@
   </para>
   <para>
    Pour récupérer une variable sérialisée et retrouver une
-   valeur PHP, utilisez <function>unserialize</function>.
+   valeur PHP, utiliser <function>unserialize</function>.
   </para>
  </refsect1>
 

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -26,7 +26,7 @@
     La désérialisation peut résulter
     en une exécution de code chargé et exécuté lors de l'instanciation
     et l'autochargement d'objet, et ainsi, un utilisateur mal intentionné
-    peut être capable d'exploiter ce comportement. Utilisez un standard d'échange
+    peut être capable d'exploiter ce comportement. Utiliser un standard d'échange
     sûr, comme JSON (via les fonctions <function>json_decode</function> 
     et <function>json_encode</function>) s'il faut passer des données sérialisées
     à l'utilisateur.

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -250,7 +250,7 @@ object(A)#2 (2) {
     <function>var_export</function> ne gère pas les références circulaires car il
     serait impossible de générer un code PHP analysable pour ce type de données.
     Pour faire quelque chose avec la représentation complète d'un tableau
-    ou d'un objet, utilisez la fonction <function>serialize</function>.
+    ou d'un objet, utiliser la fonction <function>serialize</function>.
    </para>
   </note>
   <warning>

--- a/reference/wddx/book.xml
+++ b/reference/wddx/book.xml
@@ -27,7 +27,7 @@
     <function>wddx_deserialize</function>. La désérialisation peut conduire au chargement
     et à l'exécution des données lors de l'instanciation de l'objet et de son autochargement,
     aussi, un utilisateur malicieux peut être capable d'exploiter ce comportement.
-    Utilisez donc un format sécurisé et standardisé d'échange de données tel que JSON
+    Utiliser donc un format sécurisé et standardisé d'échange de données tel que JSON
     (via la fonction <function>json_decode</function> et la fonction
     <function>json_encode</function>) s'il faut passer les données sérialisées à l'utilisateur.
    </para>

--- a/reference/wddx/configure.xml
+++ b/reference/wddx/configure.xml
@@ -21,7 +21,7 @@
   <title>PHP &lt; 7.4</title>
   <para>
    Après avoir installé Expat, compilez PHP avec
-   <option role="configure">--enable-wddx</option> et utilisez
+   <option role="configure">--enable-wddx</option> et utiliser
    <option role="configure">--with-libexpat-dir</option> pour Expat.
   </para>
   &windows.builtin;

--- a/reference/wddx/functions/wddx-deserialize.xml
+++ b/reference/wddx/functions/wddx-deserialize.xml
@@ -28,7 +28,7 @@
     La désérialisation peut faire que le code soit chargé, et exécuté lors
     de l'instanciation et l'autochargement de l'objet, et un utilisateur mal
     intentionné peut être capable d'y loger un exploit.
-    Utilisez un format, sûr, d'échange de données standardisé comme JSON (à l'aide de
+    Utiliser un format, sûr, d'échange de données standardisé comme JSON (à l'aide de
     <function>json_decode</function> et <function>json_encode</function>) s'il faut
     passer des données sérialisées à l'utilisateur.
    </para>

--- a/reference/win32service/setup.xml
+++ b/reference/win32service/setup.xml
@@ -51,7 +51,7 @@
   </para>
   <para>
    Il est recommandé de mettre à jour vers Win32Service 1.1.0.
-   Pour des instructions supplémentaires sur la gestion des droits sans l'extension (ou avec une version antérieure à 1.1.0), consultez la
+   Pour des instructions supplémentaires sur la gestion des droits sans l'extension (ou avec une version antérieure à 1.1.0), consulter la
    <link xlink:href="&url.win32service.kb914392;">Base de connaissances Microsoft</link>.
   </para>
  </section>

--- a/reference/wincache/functions/wincache-lock.xml
+++ b/reference/wincache/functions/wincache-lock.xml
@@ -25,7 +25,7 @@
    <simpara>
     L'utilisation de la fonction <function>wincache_lock</function> et de la fonction
     <function>wincache_unlock</function> peut conduire à des verrous morts lors de l'exécution
-    de scripts PHP sur des environnements multiprocessus, comme FastCGI. N'utilisez pas ces fonctions
+    de scripts PHP sur des environnements multiprocessus, comme FastCGI. N'utiliser pas ces fonctions
     à moins d'être absolument certain d'en avoir besoin. Pour la majorité des opérations sur
     le cache utilisateur, il n'est pas nécessaire de les utiliser.
    </simpara>

--- a/reference/wincache/functions/wincache-ucache-add.xml
+++ b/reference/wincache/functions/wincache-ucache-add.xml
@@ -43,7 +43,7 @@
        correspondant à la même clé est déjà présente dans le cache, la fonction
        échouera et retournera &false;. Le paramètre <parameter>key</parameter> est sensible à la
        casse. Pour écraser cette valeur, si <parameter>key</parameter> est présent,
-       utilisez plutôt la fonction <function>wincache_ucache_set</function>.
+       utiliser plutôt la fonction <function>wincache_ucache_set</function>.
        <parameter>key</parameter> peut également être un tableau de paires nom => valeur où
        les noms seront utilisés comme clés. Ce format peut être utilisé pour ajouter
        de multiples valeurs dans le cache en une seule opération.

--- a/reference/wincache/setup.xml
+++ b/reference/wincache/setup.xml
@@ -87,7 +87,7 @@
    </step>
    <step>
     <simpara>
-     Ajoutez la ligne suivante à la fin du fichier php.ini : 
+     Ajouter la ligne suivante à la fin du fichier php.ini :
      <literal>extension = php_wincache.dll</literal>.
     </simpara>
    </step>
@@ -207,7 +207,7 @@ $user_allowed = array('DOMAIN\user1', 'DOMAIN\user2', 'DOMAIN\user3');
    <link linkend="ini.session.save-handler">session.save_handler</link> du fichier 
    <filename>php.ini</filename> à <emphasis>wincache</emphasis>.
    Par défaut, l'endroit où sont stockés les fichiers temporaires sous Windows est utilisé
-   pour stocker les données de session. Pour changer cet endroit, utilisez la directive
+   pour stocker les données de session. Pour changer cet endroit, utiliser la directive
    <link linkend="ini.session.save-path">session.save_path</link>.
    <example>
     <title>Activer le gestionnaire de session WinCache</title>
@@ -280,7 +280,7 @@ session.save_path = C:\inetpub\temp\session\
    </listitem>
   </itemizedlist>
   <para>
-   Pour configurer le re routage de fonctions avec Wincache, utilisez le fichier
+   Pour configurer le re routage de fonctions avec Wincache, utiliser le fichier
    <filename>reroute.ini</filename> inclus dans le paquet. Copiez-le dans le dossier
    où se trouve <filename>php.ini</filename>. Après, ajoutez wincache.rerouteini dans
    <filename>php.ini</filename> et précisez le chemin absolu ou relatif vers

--- a/reference/wincache/win32build.xml
+++ b/reference/wincache/win32build.xml
@@ -75,7 +75,7 @@ configure.js [all options used to build PHP] --enable-wincache
       <literal>--enable-wincache</literal> est la seule option supplémentaire requise
       pour s'assurer que l'extension WinCache se compile correctement.
       Cette option permet de construire WinCache et le lier statiquement avec la
-      DLL de PHP. Pour construire l'extension comme une DLL externe, utilisez 
+      DLL de PHP. Pour construire l'extension comme une DLL externe, utiliser 
       l'option <literal>--enable-wincache=shared</literal>.
      </para>
     </step>

--- a/reference/xattr/functions/xattr-supported.xml
+++ b/reference/xattr/functions/xattr-supported.xml
@@ -79,7 +79,7 @@
 $file = 'un_fichier';
 
 if (xattr_supported($file)) {
-    /* ... utilisez les fonctions xattr_* ... */
+    /* ... utiliser les fonctions xattr_* ... */
 }
 
 ?>

--- a/reference/xdiff/functions/xdiff-file-diff.xml
+++ b/reference/xdiff/functions/xdiff-file-diff.xml
@@ -72,7 +72,7 @@
      <term><parameter>minimal</parameter></term>
      <listitem>
       <para>
-       Configurez <parameter>minimal</parameter> à &true; pour
+       Configurer <parameter>minimal</parameter> à &true; pour
        minimaliser la taille du fichier des différences (peut prendre beaucoup
        de temps).
       </para>
@@ -117,7 +117,7 @@ xdiff_file_diff($old_version, $new_version, 'my_script.diff', 2);
   <note>
    <para>
     Cette fonction ne fonctionne pas correctement avec les fichiers binaires.
-    Pour effectuer un diff sur des fichiers binaires, utilisez la fonction
+    Pour effectuer un diff sur des fichiers binaires, utiliser la fonction
     <function>xdiff_file_bdiff</function>/<function>xdiff_file_rabdiff</function>.
    </para>
   </note>

--- a/reference/xdiff/functions/xdiff-string-diff.xml
+++ b/reference/xdiff/functions/xdiff-string-diff.xml
@@ -62,7 +62,7 @@
      <term><parameter>minimal</parameter></term>
      <listitem>
       <para>
-       Configurez <parameter>minimal</parameter> à &true; pour
+       Configurer <parameter>minimal</parameter> à &true; pour
        minimaliser la taille du diff (peut prendre beaucoup de temps).
       </para>
      </listitem>
@@ -111,7 +111,7 @@ if (is_string($diff)) {
   <note>
    <para>
     Cette fonction ne fonctionne pas correctement avec des chaînes binaires.
-    Pour effectuer un diff de chaînes binaires, utilisez la fonction
+    Pour effectuer un diff de chaînes binaires, utiliser la fonction
     <function>xdiff_string_bdiff</function>/<function>xdiff_string_rabdiff</function>.
    </para>
   </note>

--- a/reference/xml/functions/xml-set-notation-decl-handler.xml
+++ b/reference/xml/functions/xml-set-notation-decl-handler.xml
@@ -26,7 +26,7 @@
 { <parameter>systemId</parameter> | <parameter>publicId</parameter>?>
 ]]>
    </programlisting>
-   Consultez la
+   Consulter la
    <link xlink:href="&url.rec-xml;#Notations">section 4.7 des spécifications XML 1.0</link>
    pour la définition des déclarations de notation.
   </para>

--- a/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
+++ b/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
@@ -30,7 +30,7 @@
    </programlisting>
   </para>
   <para>
-   Consultez la
+   Consulter la
    <link xlink:href="&url.rec-xml;#sec-external-ent">section 4.2.2 des spécifications XML 1.0</link>
    pour la définition des entités externes avec notation déclarée.
   </para> 

--- a/reference/xmldiff/configure.xml
+++ b/reference/xmldiff/configure.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
  
  <para>
-  Utilisez l'option <option role="configure">--with-xmldiff[=DIR]</option>
+  Utiliser l'option <option role="configure">--with-xmldiff[=DIR]</option>
   lors de la compilation de PHP.
  </para>
  

--- a/reference/xmldiff/xmldiff-base/construct.xml
+++ b/reference/xmldiff/xmldiff-base/construct.xml
@@ -30,7 +30,7 @@
       Espace de noms personnalisé pour le document de différence.
       L'espace de noms par défaut est http://www.locus.cz/diffmark
       et est suffisant pour éviter les conflits d'espaces de noms.
-      Utilisez ce paramètre pour changer d'espace de noms.
+      Utiliser ce paramètre pour changer d'espace de noms.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xsl/xsltprocessor/registerphpfunctions.xml
+++ b/reference/xsl/xsltprocessor/registerphpfunctions.xml
@@ -25,7 +25,7 @@
      <term><parameter>functions</parameter></term>
      <listitem>
       <para>
-       Utilisez ce paramètre pour restreindre les fonctions PHP accessibles
+       Utiliser ce paramètre pour restreindre les fonctions PHP accessibles
        depuis XSLT.
       </para>
       <para>

--- a/reference/yaf/ini.xml
+++ b/reference/yaf/ini.xml
@@ -228,7 +228,7 @@
       <warning>
        <para>
         Yaf utilise le chemin vers le fichier ini comme clé de l'entrée du cache,
-        aussi, n'utilisez pas un chemin absolu pour le chemin vers le fichier ini,
+        aussi, n'utiliser pas un chemin absolu pour le chemin vers le fichier ini,
         sinon, il se pourrait qu'il y ait des conflit si deux applications
         utilisent le même chemin relatif pour le chemin vers le fichier de configuration ini.
        </para>

--- a/reference/yaf/yaf-loader.xml
+++ b/reference/yaf/yaf-loader.xml
@@ -34,7 +34,7 @@
     pas à se charger).
     <note>
      <para>
-      Veuillez conserver yaf.use_spl_autoload à Off à moins qu'il y a d'autres
+      Il convient de conserver yaf.use_spl_autoload à Off à moins qu'il y ait d'autres
       bibliothèques qui possèdent son propre système de chargement
       et puissent ré-écrire ce comportement.
      </para>

--- a/reference/yaf/yaf-route-static.xml
+++ b/reference/yaf/yaf-route-static.xml
@@ -22,7 +22,7 @@
     besoins.
    </para>
    <para>
-    Veuillez noter qu'il n'est pas nécessaire d'instancier la classe
+    Il est à noter qu'il n'est pas nécessaire d'instancier la classe
     <classname>Yaf_Route_Static</classname>, et qu'il n'est pas nécessaire
     de l'ajouter dans la pile des routes de la classe
     <classname>Yaf_Router</classname> vu qu'elle sera toujours présente

--- a/reference/yaz/functions/yaz-ccl-conf.xml
+++ b/reference/yaz/functions/yaz-ccl-conf.xml
@@ -22,7 +22,7 @@
    équivalent en RPN.
   </para>
   <para>
-   Pour faire correspondre une requête CCL spécifique à RPN, utilisez la
+   Pour faire correspondre une requête CCL spécifique à RPN, utiliser la
    fonction <function>yaz_ccl_parse</function>.
   </para>
  </refsect1>

--- a/reference/yaz/functions/yaz-ccl-parse.xml
+++ b/reference/yaz/functions/yaz-ccl-parse.xml
@@ -22,7 +22,7 @@
    <function>yaz_search</function> pour effectuer une recherche.
   </para>
   <para>
-   Pour définir un champ CCL valide, utilisez la fonction
+   Pour définir un champ CCL valide, utiliser la fonction
    <function>yaz_ccl_conf</function> avant d'utiliser cette fonction.
   </para>
  </refsect1>

--- a/reference/yaz/functions/yaz-connect.xml
+++ b/reference/yaz/functions/yaz-connect.xml
@@ -140,7 +140,7 @@
           <para>
            Une chaîne de caractères qui spécifie le jeu de caractères qui sera
            utilisé dans le langage Z39.50 et le jeu de caractères pour les
-           négociations. Utilisez une chaîne de caractères comme :
+           négociations. Utiliser une chaîne de caractères comme :
            <literal>ISO-8859-1</literal>, <literal>UTF-8</literal>,
            <literal>UTF-16</literal>.
           </para>
@@ -160,7 +160,7 @@
           <para>
            Un entier qui spécifie la taille maximale en octets pour toutes les
            entrées qui seront retournées par la cible durant la récupération.
-           Voyez le <link xlink:href="&url.yaz.z3950.4;">standard Z39.50</link>
+           Voir le <link xlink:href="&url.yaz.z3950.4;">standard Z39.50</link>
            pour plus d'informations.
           </para>
           <note>

--- a/reference/yaz/functions/yaz-es.xml
+++ b/reference/yaz/functions/yaz-es.xml
@@ -36,7 +36,7 @@
   <para>
    La fonction <function>yaz_es</function> crée des paquets d'une Requête de
    Service Étendu et les place dans une file d'attente d'opérations.
-   Utilisez <function>yaz_wait</function> pour envoyer la/les requête(s) au
+   Utiliser <function>yaz_wait</function> pour envoyer la/les requête(s) au
    serveur.
    À la fin de <function>yaz_wait</function>, le résultat de l'opération de
    Service Étendu devrait être obtenu avec un appel à

--- a/reference/yaz/functions/yaz-set-option.xml
+++ b/reference/yaz/functions/yaz-set-option.xml
@@ -129,7 +129,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       La nouvelle valeur de l'option. Utilisez cet argument seulement si
+       La nouvelle valeur de l'option. Utiliser cet argument seulement si
        l'argument précédent est une chaîne de caractères.
       </para>
      </listitem>

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -26,7 +26,7 @@
    </para>
    <para>
     Pour des raisons de sécurité, les permissions d'origine ne sont pas restaurées.
-    Pour un exemple de comment les restaurer, consultez l'échantillon de code sur la
+    Pour un exemple de comment les restaurer, consulter l'échantillon de code sur la
     <link linkend="ziparchive.getexternalattributesindex.examples.perms">page d'exemple</link>
     de la méthode <methodname>ZipArchive::getExternalAttributesIndex</methodname>.
    </para>

--- a/reference/zlib/functions/deflate_add.xml
+++ b/reference/zlib/functions/deflate_add.xml
@@ -50,7 +50,7 @@
       <constant>ZLIB_FULL_FLUSH</constant>, <constant>ZLIB_FINISH</constant>.
       Normalement, on voudra définir <constant>ZLIB_NO_FLUSH</constant> pour
       maximiser la compression, et <constant>ZLIB_FINISH</constant> pour terminer
-      avec le dernier morceau de données. Consultez le <link
+      avec le dernier morceau de données. Consulter le <link
       xlink:href="&url.zlib.manual;">manuel de zlib</link> pour une
       description détaillée de ces constantes.
      </para>

--- a/reference/zlib/functions/gzcompress.xml
+++ b/reference/zlib/functions/gzcompress.xml
@@ -20,7 +20,7 @@
    le format de données <literal>ZLIB</literal>.
   </para>
   <para>
-   Pour plus de détails sur l'algorithme, lisez le document
+   Pour plus de détails sur l'algorithme, consulter le document
    "<link xlink:href="&url.rfc;1950">ZLIB Compressed Data Format
    Specification version 3.3</link>" (RFC 1950).
   </para>

--- a/reference/zlib/functions/gzdeflate.xml
+++ b/reference/zlib/functions/gzdeflate.xml
@@ -20,7 +20,7 @@
    le format de données <literal>DEFLATE</literal>.
   </para>
   <para>
-   Pour plus de détails sur l'algorithme, lisez le document
+   Pour plus de détails sur l'algorithme, consulter le document
    "<link xlink:href="&url.rfc;1951">ZLIB Compressed Data Format
    Specification version 1.3</link>" (RFC 1951).
   </para>

--- a/reference/zlib/functions/gzencode.xml
+++ b/reference/zlib/functions/gzencode.xml
@@ -22,7 +22,7 @@
    <command>gzip</command>.
   </para>
   <para>
-   Pour plus de détails sur l'algorithme, lisez le document
+   Pour plus de détails sur l'algorithme, consulter le document
    "<link xlink:href="&url.rfc;1952">GZIP file format specification
    version 4.3</link>" (RFC 1952).
   </para>

--- a/reference/zlib/functions/gzopen.xml
+++ b/reference/zlib/functions/gzopen.xml
@@ -46,7 +46,7 @@
        (<literal>wb9</literal>) ou une stratégie : <literal>f</literal> pour
        les données filtrées comme <literal>wb6f</literal>, <literal>h</literal> pour
        <literal>Huffman only compression</literal> comme <literal>wb1h</literal>.
-       (Lisez la description de <literal>deflateInit2</literal> dans le fichier
+       (Consulter la description de <literal>deflateInit2</literal> dans le fichier
        <filename>zlib.h</filename> pour plus d'informations sur la stratégie
        des paramètres.)
       </para>

--- a/reference/zlib/functions/inflate_add.xml
+++ b/reference/zlib/functions/inflate_add.xml
@@ -54,7 +54,7 @@
       <constant>ZLIB_FULL_FLUSH</constant>, <constant>ZLIB_FINISH</constant>.
       Normalement on voudra définir <constant>ZLIB_NO_FLUSH</constant> pour
       maximiser la compression, et <constant>ZLIB_FINISH</constant> pour terminer
-      avec le dernier morceau de données. Consultez le <link
+      avec le dernier morceau de données. Consulter le <link
       xlink:href="&url.zlib.manual;">manuel de zlib</link> pour une
       description détaillée de ces constantes.
      </para>

--- a/reference/zmq/zmq.xml
+++ b/reference/zmq/zmq.xml
@@ -756,7 +756,7 @@
      <varlistentry xml:id="zmq.constants.mode-noblock">
       <term><constant>ZMQ::MODE_NOBLOCK</constant></term>
       <listitem>
-       <para>Opération non-bloquante. Obsolète : utilisez plutôt ZMQ::MODE_DONTWAIT</para>
+       <para>Opération non-bloquante. Obsolète : utiliser plutôt ZMQ::MODE_DONTWAIT</para>
       </listitem>
      </varlistentry>
      

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -668,7 +668,7 @@
      <varlistentry xml:id="zookeeper.constants.reconfiginprogress">
       <term><constant>Zookeeper::RECONFIGINPROGRESS</constant></term>
       <listitem>
-       <para>Reconfiguration demandée alors qu'une autre reconfiguration est en cours. Ceci n'est actuellement pas supporté. Veuillez réessayer.</para>
+       <para>Reconfiguration demandée alors qu'une autre reconfiguration est en cours. Ceci n'est actuellement pas supporté. Il convient de réessayer.</para>
         <para>Disponible à partir de ZooKeeper 3.5.0</para>
       </listitem>
      </varlistentry>

--- a/security/database.xml
+++ b/security/database.xml
@@ -100,7 +100,7 @@
    <link linkend="book.openssl">OpenSSL</link> et
    <link linkend="book.sodium">Sodium</link>, qui connaissent un large éventail
    de méthodes de chiffrement. Le script PHP va chiffrer les données qui
-   seront stockées, et les déchiffrer lorsqu'elles seront relues. Voyez la
+   seront stockées, et les déchiffrer lorsqu'elles seront relues. Voir la
    suite pour des exemples d'utilisation de ce chiffrement.
   </simpara>
   


### PR DESCRIPTION
## Summary

- Remplacement systématique des formes impératives à la 2e personne du pluriel par des tournures impersonnelles, conformément aux conventions de `TRADUCTIONS.txt`
- 500 fichiers concernés, ~800 corrections
- Exemples de remplacements :
  - `lisez` → `se reporter à` / `consulter`
  - `utilisez` → `utiliser`
  - `consultez` → `consulter`
  - `Notez que` → `Il est à noter que`
  - `vérifiez` → `il faut vérifier` / `s'assurer`
  - `Préférez` → `Il est préférable de`

## Contexte

Extraction de la catégorie la plus importante de la PR #84 (`review/full-review`) pour faciliter la revue.

## Test plan

- [ ] Vérifier que le build XML passe
- [ ] Vérifier qu'aucun terme interdit TRADUCTIONS.txt ne subsiste dans les fichiers modifiés