### PR TITLE
fix(appendices): traduire « PHP Core » → « Cœur de PHP »

### DIFF
--- a/appendices/migration73/other-changes.xml
+++ b/appendices/migration73/other-changes.xml
@@ -7,7 +7,7 @@
  <title>Autres changements</title>
 
  <sect2 xml:id="migration73.other-changes.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration73.other-changes.core.setcookie">
    <title>Set(raw)cookie accepte l'argument $option</title>

--- a/appendices/migration74/constants.xml
+++ b/appendices/migration74/constants.xml
@@ -7,7 +7,7 @@
  <title>Nouvelles constantes globales</title>
 
  <sect2 xml:id="migration74.constants.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -6,7 +6,7 @@
 
 
  <sect2 xml:id="migration74.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration74.incompatible.core.non-array-access">
    <title>Accès de type tableau des non-tableaux</title>

--- a/appendices/migration74/new-functions.xml
+++ b/appendices/migration74/new-functions.xml
@@ -5,7 +5,7 @@
  <title>Nouvelles fonctions</title>
 
  <sect2 xml:id="migration74.new-functions.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -7,7 +7,7 @@
  <title>Fonctionnalités obsolètes</title>
 
  <sect2 xml:id="migration80.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -5,7 +5,7 @@
  <title>Nouvelles fonctionnalités</title>
 
  <sect2 xml:id="migration80.new-features.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration80.new-features.core.named-arguments">
    <title>Les arguments nommés</title>

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -5,7 +5,7 @@
  <title>Fonctionnalités dépréciées</title>
 
  <sect2 xml:id="migration81.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration81.deprecated.core.serialize-interface">
    <title>

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -5,7 +5,7 @@
  <title>Les changements de rétrocompatibilités</title>
 
  <sect2 xml:id="migration81.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration81.incompatible.core.globals-access">
    <title>Restrictions d'accès $GLOBALS</title>

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -5,7 +5,7 @@
  <title>Nouvelles Fonctionnalités</title>
 
  <sect2 xml:id="migration81.new-features.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration81.new-features.core.octal-literal-prefix">
    <title>Préfixe littéral octal entier</title>

--- a/appendices/migration81/new-functions.xml
+++ b/appendices/migration81/new-functions.xml
@@ -5,7 +5,7 @@
  <title>Nouvelles fonctions</title>
 
  <sect2 xml:id="migration81.new-functions.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -5,7 +5,7 @@
  <title>Fonctionnalités obsolètes</title>
 
  <sect2 xml:id="migration82.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration82.deprecated.core.dynamic-properties">
    <title>Utilisation des propriétés dynamiques</title>

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -5,7 +5,7 @@
  <title>Fonctionnalités dépréciées</title>
 
  <sect2 xml:id="migration83.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration83.deprecated.core.saner-inc-dec-operators">
    <title>Opérateurs incrémentation/décrémentation plus sains</title>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -5,7 +5,7 @@
  <title>Changement de rétrocompatibilité</title>
 
  <sect2 xml:id="migration83.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration83.incompatible.core.overflowing-call-stack">
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -5,7 +5,7 @@
  <title>Nouvelles fonctionnalités</title>
 
  <sect2 xml:id="migration83.new-features.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration83.new-features.core.readonly-modifier-improvements">
    <title>Modification sur la lecture seule</title>

--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -5,7 +5,7 @@
  <title>Fonctionnalités dépréciées</title>
 
  <sect2 xml:id="migration84.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration84.deprecated.core.implicitly-nullable-parameter">
    <!-- RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types -->

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -13,7 +13,7 @@
  </simpara>
 
  <sect2 xml:id="migration84.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <!-- RFC: https://wiki.php.net/rfc/exit-as-function -->
   <sect3 xml:id="migration84.incompatible.core.exit">

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -6,7 +6,7 @@
 
  <!-- TODO: Core features for 8.4 -->
  <sect2 xml:id="migration84.new-features.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <!-- RFC: https://wiki.php.net/rfc/property-hooks -->
   <sect3 xml:id="migration84.new-features.core.property-hooks">

--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -5,7 +5,7 @@
  <title>Fonctionnalités dépréciées</title>
 
  <sect2 xml:id="migration85.deprecated.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration85.deprecated.core.changes-to-user-output-handler">
    <title>Changement aux gestionnaires de sortie utilisateur</title>

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -5,7 +5,7 @@
  <title>Changements non rétrocompatibles</title>
 
  <sect2 xml:id="migration85.incompatible.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration85.incompatible.core.array-callable-alias">
    <title>Les noms d'alias <literal>"array"</literal> et <literal>"callable"</literal></title>

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -5,7 +5,7 @@
  <title>Nouvelles fonctionnalités</title>
 
  <sect2 xml:id="migration85.new-features.core">
-  <title>PHP Core</title>
+  <title>Cœur de PHP</title>
 
   <sect3 xml:id="migration85.new-features.core.pipe-operator">
    <title>Opérateur pipe</title>


### PR DESCRIPTION
## Summary

- Traduction du titre `PHP Core` → `Cœur de PHP` dans 20 fichiers appendices/migration (7.3 à 8.5)
- Remplacement mécanique, aucune autre modification

## Fichiers concernés

appendices/migration{73,74,80,81,82,83,84,85}/*.xml (deprecated, incompatible, new-features, new-functions, constants, other-changes)

## Test plan

- [ ] CI check-whitespace
- [ ] CI Build (fr)
- [ ] CI TRADUCTIONS.txt