### PR TITLE
Fix translation issues in language/predefined/

### DIFF
--- a/language/predefined/attributes/sensitiveparameter.xml
+++ b/language/predefined/attributes/sensitiveparameter.xml
@@ -12,7 +12,7 @@
    <para>
    <!-- TODO Link -->
     Cet attribut est utilisé pour indiquer qu'un paramètre est sensible
-    et que sa valeur doit être expurgée s'il est présent dans une trace de pile.
+    et que sa valeur devrait être expurgée s'il est présent dans une trace d'appels.
    </para>
   </section>
 

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -60,7 +60,7 @@
     <term><parameter>newThis</parameter></term>
     <listitem>
      <para>
-      L'objet auquel lier la fonction anonyme, ou &null; pour une fermeture statique.
+      L'objet auquel lier la fonction anonyme, ou &null; pour que la fermeture ne soit pas liée.
      </para>
     </listitem>
    </varlistentry>

--- a/language/predefined/exception/construct.xml
+++ b/language/predefined/exception/construct.xml
@@ -52,7 +52,7 @@
   </para>
   <note>
    <simpara>
-    L'appel du constructeur de l'exception de classe à partir d'une sous-classe 
+    L'appel du constructeur de la classe Exception à partir d'une sous-classe
     ignore les arguments par défaut, si les propriétés $code et $message sont 
     déjà définies.
    </simpara>

--- a/language/predefined/exception/getprevious.xml
+++ b/language/predefined/exception/getprevious.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la précédente <classname>Throwable</classname> si disponible, 
+   Retourne le <classname>Throwable</classname> précédent si disponible,
    &null; sinon.
   </para>
  </refsect1>

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -12,8 +12,8 @@
   <section xml:id="iterator.intro">
    &reftitle.intro;
    <para>
-    Interface pour les itérateurs ou les objets externes qui peuvent
-    être itérés eux-mêmes en interne.
+    Interface pour les itérateurs externes ou les objets capables
+    d'être itérés eux-mêmes en interne.
    </para>
   </section>
 <!-- }}} -->

--- a/language/predefined/iterator/rewind.xml
+++ b/language/predefined/iterator/rewind.xml
@@ -25,7 +25,7 @@
    <simpara>
     Comme &foreach; appelle toujours <methodname>rewind</methodname> avant de
     commencer l'itération, avancer manuellement la position de l'itérateur
-    (par exemple via <methodname>SplFileObject::seek</methodname>) sera réinitialisé.
+    (par exemple via <methodname>SplFileObject::seek</methodname>) sera réinitialisée.
    </simpara>
    <simpara>
     Pour itérer sans rembobiner l'itérateur, il est possible de

--- a/language/predefined/sensitiveparametervalue.xml
+++ b/language/predefined/sensitiveparametervalue.xml
@@ -12,12 +12,12 @@
    &reftitle.intro;
    <para>
     La classe <classname>SensitiveParameterValue</classname> permet d'envelopper des valeurs
-    pour les protéger contre une exposition accidentelle.
+    sensibles pour les protéger contre une exposition accidentelle.
    </para>
    <para>
-    Les valeurs des paramètres ayant l'attribut <classname>SensitiveParameter</classname> 
+    Les valeurs des paramètres ayant l'attribut <classname>SensitiveParameter</classname>
     seront automatiquement enveloppées dans un objet <classname>SensitiveParameterValue</classname>
-    dans les traces de pile.
+    dans les traces d'appels.
    </para>
   </section>
 <!-- }}} -->

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -20,9 +20,10 @@
     <link linkend="object.sleep">__sleep()</link> et
     <link linkend="object.wakeup">__wakeup()</link>.
     La méthode de sérialisation est appelée chaque fois qu'une
-    instance doit être sérialisée. Elle n'appelle pas la méthode
-    __destruct() et n'a aucun effet sur le contenu de cette méthode.
-    Lorsque les données sont sérialisées, la classe est connue et
+    instance doit être sérialisée. Elle n'appelle pas __destruct()
+    et ne produit aucun autre effet de bord, sauf si cela est codé
+    dans la méthode.
+    Lorsque les données sont désérialisées, la classe est connue et
     la méthode unserialize() appropriée est appelée comme constructeur
     au lieu d'appeler __construct(). S'il est nécessaire d'appeler le constructeur
     standard, il est possible de le faire dans la méthode.

--- a/language/predefined/variables/files.xml
+++ b/language/predefined/variables/files.xml
@@ -6,13 +6,13 @@
 <refentry role="variable" xml:id="reserved.variables.files" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>$_FILES</refname>
-  <refpurpose>Variable de téléchargement de fichier via HTTP</refpurpose>
+  <refpurpose>Variable de téléversement de fichier via HTTP</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <para>
-   Un tableau associatif des valeurs téléchargées au script courant via
+   Un <type>array</type> associatif des éléments téléversés au script courant via
    le protocole HTTP et la méthode POST. La structure de ce tableau est décrite 
    dans la section 
    <link linkend="features.file-upload.post-method">chargements de fichiers par méthode POST</link>.

--- a/language/predefined/variables/get.xml
+++ b/language/predefined/variables/get.xml
@@ -31,7 +31,7 @@ echo 'Bonjour ' . htmlspecialchars($_GET["name"]) . '!';
 ]]>
     </programlisting>
     <simpara>
-     En assumant que l'utilisateur a entré <literal>http://example.com/?name=Yannick</literal>
+     En supposant que l'utilisateur a entré <literal>http://example.com/?name=Yannick</literal>.
     </simpara>
     &example.outputs.similar;
     <screen>

--- a/language/predefined/variables/httpresponseheader.xml
+++ b/language/predefined/variables/httpresponseheader.xml
@@ -19,8 +19,8 @@
   &reftitle.description;
   <para>
    Le tableau <varname>$http_response_header</varname> est similaire à la fonction
-   <function>get_headers</function>. Lors de l'utilisation du
-   <link linkend="wrappers.http">gestionnaire HTTP</link>,
+   <function>get_headers</function>. Lors de l'utilisation de
+   l'<link linkend="wrappers.http">enveloppe HTTP</link>,
    <varname>$http_response_header</varname> sera rempli avec les en-têtes
    de réponses HTTP.
    <varname>$http_response_header</varname> sera créé avec une <link linkend="language.variables.scope">

--- a/language/predefined/variables/server.xml
+++ b/language/predefined/variables/server.xml
@@ -22,8 +22,8 @@
   </para>
   <note>
     <simpara>
-     Lorsque PHP est exécuté en <link linkend="features.commandline">ligne de commande</link>
-     , la plupart de ces entrées ne seront pas disponibles ou n'auront aucun sens.
+     Lorsque PHP est exécuté en <link linkend="features.commandline">ligne de commande</link>,
+     la plupart de ces entrées ne seront pas disponibles ou n'auront aucun sens.
     </simpara>
   </note>
   <para>
@@ -107,7 +107,7 @@
      <term>'<varname>SERVER_NAME</varname>'</term>
      <listitem>
       <simpara>
-       Le nom du serveur hôte qui exécute le script suivant.
+       Le nom du serveur hôte qui exécute le script courant.
        Si le script est exécuté sur un hôte virtuel, ce sera
        la valeur définie pour cet hôte virtuel.
       </simpara>
@@ -220,8 +220,9 @@
      <term>'<varname>REMOTE_HOST</varname>'</term>
      <listitem>
       <simpara>
-       Le nom de l'hôte qui lit le script courant. La résolution
-       DNS inverse est basée sur la valeur de <varname>REMOTE_ADDR</varname>.
+       Le nom de l'hôte à partir duquel l'utilisateur consulte la page courante.
+       La résolution DNS inverse est basée sur la valeur de
+       <varname>REMOTE_ADDR</varname>.
       </simpara>
       <note>
        <simpara>
@@ -285,9 +286,9 @@
      <listitem>
       <simpara>
        La valeur donnée à la directive SERVER_ADMIN
-       (pour Apache), dans le fichier de configuration. Si le script
-       est exécuté par un hôte virtuel, ce sera la
-       valeur définie par l'hôte virtuel.
+       (pour Apache), dans le fichier de configuration du serveur web. Si le script
+       est exécuté sur un hôte virtuel, ce sera la
+       valeur définie pour cet hôte virtuel.
       </simpara>
      </listitem>
     </varlistentry>

--- a/language/predefined/weakmap/getiterator.xml
+++ b/language/predefined/weakmap/getiterator.xml
@@ -35,7 +35,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>
-   Lance un <classname>Exception</classname> en cas d'échec.
+   Lance une <classname>Exception</classname> en cas d'échec.
   </para>
  </refsect1><!-- }}} -->
 

--- a/language/predefined/weakreference/create.xml
+++ b/language/predefined/weakreference/create.xml
@@ -25,7 +25,7 @@
     <term><parameter>object</parameter></term>
     <listitem>
      <para>
-      L'objet à référencer faiblement
+      L'objet à référencer faiblement.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Slice 1/36 du découpage de la branche `review/language` (PR #139), à envoyer ensuite upstream.

Corrige contresens (`bindto` unbound vs static, `iterator` interface, `serializable` effets de bord, `$_SERVER` REMOTE_HOST/SERVER_NAME), termes du glossaire (`téléversement`, `enveloppe HTTP`), accords et genre (`une Exception`, `le Throwable précédent`), et formatage mineur (espaces de fin, `?>` manquants).

19 fichiers, 33 ins / 29 del.