### PR TITLE
Translate nits in reference/ (componere to filter)

### DIFF
--- a/reference/componere/componere.abstract.definition.xml
+++ b/reference/componere/componere.abstract.definition.xml
@@ -12,7 +12,7 @@
   <section xml:id="componere-abstract-definition.intro">
    &reftitle.intro;
    <simpara>
-    La classe abstraite finale représente une entrée de classe, et ne doit pas être utilisée par le développeur.
+    La classe abstraite finale représente une entrée de classe, et ne devrait pas être utilisée par le développeur.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/cubrid/cubridmysql/cubrid-errno.xml
+++ b/reference/cubrid/cubridmysql/cubrid-errno.xml
@@ -58,6 +58,7 @@
 <![CDATA[
 <?php
 $con = cubrid_connect('localhost', 33000, 'demodb', 'dba', '');
+$req = cubrid_execute($con, "select id, name from person");
 if ($req) {
     while (list ($id, $name) = cubrid_fetch($req))
     echo $id, $name;

--- a/reference/curl/constants_curl_error.xml
+++ b/reference/curl/constants_curl_error.xml
@@ -32,7 +32,7 @@
   </term>
   <listitem>
    <simpara>
-    Encodage de contenu non reconnu.
+    Encodage de transfert non reconnu.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -33,7 +33,7 @@
   </term>
   <listitem>
    <simpara>
-    Chemin natif du certificat CA.
+    Chemin par défaut intégré du certificat CA.
     Disponible à partir de PHP 8.3.0 et cURL 7.84.0
    </simpara>
   </listitem>
@@ -45,7 +45,7 @@
   </term>
   <listitem>
    <simpara>
-    Chemin natif du CA.
+    Chemin par défaut intégré du CA.
     Disponible à partir de PHP 8.3.0 et cURL 7.84.0
    </simpara>
   </listitem>
@@ -648,7 +648,7 @@
   </term>
   <listitem>
    <simpara>
-    Le nombre total d'octets téléchargés
+    Le nombre total d'octets téléversés
    </simpara>
   </listitem>
  </varlistentry>
@@ -659,7 +659,7 @@
   </term>
   <listitem>
    <simpara>
-    Le nombre total d'octets téléchargés.
+    Le nombre total d'octets téléversés.
     Disponible à partir de PHP 7.3.0 et cURL 7.50.0
    </simpara>
   </listitem>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1263,7 +1263,7 @@
    </term>
    <listitem>
     <para>
-     Définir sur &true; pour réinitialiser la méthode de requête HTTP à <literal>GET</literal>. Comme <literal>GET</literal> est la valeur par défaut, cela n'est nécessaire que si la requête
+     Définir sur &true; pour réinitialiser la méthode de requête HTTP à <literal>GET</literal>. Comme <literal>GET</literal> est la valeur par défaut, cela n'est nécessaire que si la méthode
      de requête a été changée.
      Disponible à partir de cURL 7.8.1.
     </para>
@@ -2140,7 +2140,7 @@
      se connecter au proxy HTTP(S) spécifié dans l'option
      <constant>CURLOPT_PROXY</constant> pour la prochaine requête.
      Le préproxy ne peut être qu'un proxy SOCKS et il doit être préfixé par
-     <literal>[scheme]://</literal> pour spécifier quel type de chaussettes est utilisé.
+     <literal>[scheme]://</literal> pour spécifier quel type de SOCKS est utilisé.
      Une adresse IP numérique IPv6 doit être écrite entre [crochets].
      Définir le préproxy sur un <type>string</type> vide désactive explicitement l'utilisation d'un préproxy.
      Pour spécifier le numéro de port dans ce <type>string</type>, ajoutez <literal>:[port]</literal>

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une session cURL en cas de succès, &false; si une erreur survient.
+   Retourne un gestionnaire cURL en cas de succès, &false; si une erreur survient.
   </para>
  </refsect1>
 

--- a/reference/curl/functions/curl-multi-info-read.xml
+++ b/reference/curl/functions/curl-multi-info-read.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>int</type><parameter role="reference">queued_messages</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Appelle le gestionnaire multiple s'il y a des messages ou des informations
+   Demande au gestionnaire multi s'il y a des messages ou des informations
    issus des transferts individuels. Les messages peuvent inclure des informations
    comme un code erreur du transfert, ou juste le fait que le transfert est terminé.
   </para>

--- a/reference/curl/functions/curl-unescape.xml
+++ b/reference/curl/functions/curl-unescape.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.curl-unescape" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_unescape</refname>
-  <refpurpose>Décode l'URL fourni</refpurpose>
+  <refpurpose>Décode une chaîne encodée URL</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cette fonction décode l'URL fournie.
+   Cette fonction décode la chaîne encodée URL fournie.
   </para>
  </refsect1>
 

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -129,12 +129,12 @@
       </para>
       <para>
        Peut être configuré à <constant>DatePeriod::EXCLUDE_START_DATE</constant>
-       pour exclure la date de début du jeu de dates de récursion dans
+       pour exclure la date de début du jeu de dates de récurrence dans
        la période.
       </para>
       <para>
        Peut être configuré à <constant>DatePeriod::INCLUDE_END_DATE</constant>
-       pour inclure la date de fin du jeu de dates de récursion dans
+       pour inclure la date de fin du jeu de dates de récurrence dans
        la période.
       </para>
      </listitem>
@@ -243,7 +243,7 @@ $period = new DatePeriod($start, $interval, $end,
                          DatePeriod::EXCLUDE_START_DATE);
 
 // En parcourant l'objet DatePeriod,
-// toutes les dates de récursion pour la période sont affichées.
+// toutes les dates de récurrence pour la période sont affichées.
 // Notez que, dans ce cas, 2012-07-01 ne sera pas affiché.
 foreach ($period as $date) {
     echo $date->format('Y-m-d')."\n";
@@ -302,7 +302,7 @@ Thursday 2022-12-29
  <refsect1 role="notes">
   &reftitle.notes;
   <simpara>
-   Les nombres de répétitions non liés spécifiés dans la section 4.5 
+   Les nombres de répétitions non bornés spécifiés dans la section 4.5
    "Intervalle de temps récurrent" de la norme ISO 8601 ne sont pas 
    supportés, c'est-à-dire ni <literal>"R/..."</literal> comme 
    <parameter>isostr</parameter> ni &null; comme 

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -173,7 +173,7 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 $date = new DateTimeImmutable('2000-01-01', new DateTimeZone('Pacific/Nauru'));
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
-// date/time courant dans le fuseau horaire de votre ordinateur.
+// date/time courant dans le fuseau horaire par défaut de PHP.
 $date = new DateTimeImmutable();
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
@@ -181,7 +181,7 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 $date = new DateTimeImmutable('now', new DateTimeZone('Pacific/Nauru'));
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
-// Utilisant un horodatage UNIX. Notez que le résultat est dans le fuseau horaire UTC.
+// Utilisant un horodatage UNIX. Il est à noter que le résultat est dans le fuseau horaire UTC.
 $date = new DateTimeImmutable('@946684800');
 echo $date->format('Y-m-d H:i:sP') . "\n";
 

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -69,7 +69,7 @@ End:   2015-11-02 00:00:00 -05:00
     <title>L'ajout ou la soustraction de dates/heures peut dépasser 
      (en plus ou en moins) des dates</title>
     <simpara>
-     Comme pour 31 Janvier + 1 mois donnera comme résultat 2 Mars (année bisextile) ou
+     Comme pour 31 Janvier + 1 mois donnera comme résultat 2 Mars (année bissextile) ou
      3 Mars (année normale).
     </simpara>
     <programlisting role="php">

--- a/reference/datetime/functions/idate.xml
+++ b/reference/datetime/functions/idate.xml
@@ -98,7 +98,7 @@
           </row>
           <row>
            <entry><literal>t</literal></entry>
-           <entry>Jour du mois courant</entry>
+           <entry>Nombre de jours dans le mois courant</entry>
           </row>
           <row>
            <entry><literal>U</literal></entry>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -120,7 +120,7 @@
        L'année, peut être sur deux ou quatre chiffres, avec des valeurs
        allant de 0 à 69, correspondant aux valeurs 2000 à 2069 et 70 à 100,
        correspondant aux valeurs 1970 à 2000. Sur les systèmes où time_t
-       un entier signé sur 32bits, ce qui est le plus courant de nos jours,
+       est un entier signé sur 32bits, ce qui est le plus courant de nos jours,
        la période valide pour <parameter>year</parameter> est
        quelque part près de 1901 et 2038.
       </para>

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -177,7 +177,7 @@
           <row>
            <entry><literal>%G</literal></entry>
            <entry>La version complète à quatre chiffres de %g</entry>
-           <entry>Exemple : <literal>2009</literal> pour la semaine du 3 janvier 2009</entry>
+           <entry>Exemple : <literal>2008</literal> pour la semaine du 3 janvier 2009</entry>
           </row>
           <row>
            <entry><literal>%y</literal></entry>

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
    La fonction <function>strtotime</function> essaye de lire une
-   date au format anglais fournie par le paramètre <parameter>time</parameter>,
+   date au format anglais fournie par le paramètre <parameter>datetime</parameter>,
    et de la transformer en timestamp Unix (le nombre de secondes depuis
    le 1er Janvier 1970 à 00:00:00 UTC), relativement au timestamp
    <parameter>baseTimestamp</parameter>, ou à la date courante si ce dernier

--- a/reference/datetime/ini.xml
+++ b/reference/datetime/ini.xml
@@ -96,7 +96,7 @@
     </term>
     <listitem>
      <para>
-      L'heure de lever du soleil par défaut.
+      L'angle de zénith du lever du soleil par défaut.
      </para>
      <para>
       La valeur par défaut est 90°50'. Les 50' supplémentaires
@@ -113,7 +113,7 @@
     </term>
     <listitem>
      <para>
-      L'heure du coucher du soleil par défaut.
+      L'angle de zénith du coucher du soleil par défaut.
      </para>
     </listitem>
    </varlistentry>
@@ -125,11 +125,11 @@
     </term>
     <listitem>
      <para>
-      Le décalage horaire par défaut utilisé par toutes les fonctions date/heure.
-      L'ordre des décalages horaires utilisés si aucun n'est spécifié est
+      Le fuseau horaire par défaut utilisé par toutes les fonctions date/heure.
+      L'ordre des fuseaux horaires utilisés si aucun n'est spécifié est
       explicitement décrit dans la page de documentation sur la fonction
       <function>date_default_timezone_get</function>.
-      Voir <xref linkend="timezones"/> pour une liste complète des décalages
+      Voir <xref linkend="timezones"/> pour une liste complète des fuseaux
       horaires supportés.
      </para>
     </listitem>

--- a/reference/dba/functions/dba-open.xml
+++ b/reference/dba/functions/dba-open.xml
@@ -164,8 +164,8 @@
      <simpara>
       Le nom du <link linkend="dba.requirements">gestionnaire</link>
       qui doit être utilisé pour accéder à <parameter>path</parameter>.
-      C'est passé à tous les paramètres facultatifs donnés à
-      <function>dba_open</function> et peut agir au nom d'eux.
+      Tous les paramètres facultatifs donnés à
+      <function>dba_open</function> lui sont passés et il peut agir en leur nom.
       Si le paramètre <parameter>handler</parameter> est &null;,
       alors le gestionnaire par défaut est invoqué.
      </simpara>
@@ -185,16 +185,6 @@
       <literal>gdbm</literal>,
       <literal>ndbm</literal> et <literal>lmdb</literal> prennent en charge le
       paramètre <parameter>permission</parameter>.
-     </simpara>
-     <simpara>
-      Le pilote <literal>lmdb</literal> supporte deux paramètres additionnels.
-      Le premier permet de définir le <literal>$filemode</literal>
-      (voir description ci-dessus), et le second permet de définir la
-      <literal>$mapsize</literal>, dont la valeur devrait être un multiple de
-      la taille de page du système d'exploitation, ou zéro pour utiliser la
-      mapsize par défaut.
-      Le paramètre <literal>$mapsize</literal> est supporté à partir de
-      PHP 7.3.14 et 7.4.2, respectivement.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -125,7 +125,7 @@
         fonctions <function>dba_firstkey</function> et <function>dba_nextkey</function>
         retournent une chaîne de caractères représentant la clé, il y a une
         nouvelle fonction, <function>dba_key_split</function>,
-        qui permet de convertir les clés en tableaux sans déperdition.
+        qui permet de convertir les clés en tableaux sans perdre &false;.
        </entry>
       </row>
 

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -164,7 +164,7 @@
     <varlistentry xml:id="dom-element.props.prefix">
      <term><varname>prefix</varname></term>
      <listitem>
-      <simpara>L'espace de noms préfixé de l'élément.</simpara>
+      <simpara>Le préfixe d'espace de noms de l'élément.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.localname">

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -294,7 +294,7 @@
      <term><varname>recover</varname></term>
      <listitem>
       <para>
-       <emphasis>Propriétaire</emphasis>. Active le mode "recovery", c.-à-d.
+       <emphasis>Spécifique</emphasis>. Active le mode "recovery", c.-à-d.
        tente d'analyser un document mal formé. Cet attribut ne fait pas
        partie de la spécification DOM et est spécifique à libxml.
       </para>

--- a/reference/dom/domdocument/load.xml
+++ b/reference/dom/domdocument/load.xml
@@ -42,7 +42,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal></link>
+       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal> bit à bit</link>
        des <link linkend="libxml.constants">constantes d'options libxml</link>.
       </para>
      </listitem>

--- a/reference/dom/domdocument/loadxml.xml
+++ b/reference/dom/domdocument/loadxml.xml
@@ -35,7 +35,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal></link>
+       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal> bit à bit</link>
        des <link linkend="libxml.constants">constantes libxml</link>.
       </para>
      </listitem>

--- a/reference/dom/domdocument/savexml.xml
+++ b/reference/dom/domdocument/savexml.xml
@@ -115,10 +115,10 @@ $title = $root->appendChild($title);
 $text = $doc->createTextNode('Ceci est le titre');
 $text = $title->appendChild($text);
 
-echo "Récupération de tout le document :\n";
+echo "Sauvegarde de tout le document :\n";
 echo $doc->saveXML() . "\n";
 
-echo "Récupération du titre, uniquement :\n";
+echo "Sauvegarde du titre, uniquement :\n";
 echo $doc->saveXML($title);
 
 ?>
@@ -127,13 +127,13 @@ echo $doc->saveXML($title);
     &example.outputs;
     <screen>
 <![CDATA[
-Récupération de tout le document :
+Sauvegarde de tout le document :
 <?xml version="1.0"?>
 <book>
   <title>Ceci est le titre</title>
 </book>
 
-Récupération du titre, uniquement :
+Sauvegarde du titre, uniquement :
 <title>Ceci est le titre</title>
 ]]>
     </screen>

--- a/reference/dom/domdocument/xinclude.xml
+++ b/reference/dom/domdocument/xinclude.xml
@@ -20,7 +20,7 @@
   <note>
    <para>
     Vu que la bibliothèque libxml2 résout automatiquement les entités, cette méthode
-    peut produire des résultats non attendus si le fichier XML inclus a une DTD d'attachée.
+    peut produire des résultats non attendus si le fichier XML inclus a une DTD attachée.
    </para>
   </note>
  </refsect1>

--- a/reference/dom/domelement/construct.xml
+++ b/reference/dom/domelement/construct.xml
@@ -33,7 +33,7 @@
      <term><parameter>qualifiedName</parameter></term>
      <listitem>
       <para>
-       Le nom de l'élément. Lorsqu'il est passé dans l'URI de l'espace de noms,
+       Le nom de l'élément. Lorsque l'URI de l'espace de noms est également fournie,
        le nom de l'élément doit comporter un préfixe pour être associé à l'URI.
       </para>
      </listitem>
@@ -50,7 +50,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       Un espace de noms de l'URI pour créer l'élément dans un espace de noms spécifique.
+       Un URI d'espace de noms pour créer l'élément dans un espace de noms spécifique.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domimplementation/createdocument.xml
+++ b/reference/dom/domimplementation/createdocument.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>DOMImplementation::createDocument</refname>
   <refpurpose>
-   Crée un objet DOM Document du type spécifié avec ses éléments
+   Crée un objet DOM Document du type spécifié avec son élément
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -29,7 +29,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'URI du namespace des éléments du document à créer.
+       L'URI du namespace de l'élément du document à créer.
       </para>
      </listitem>
     </varlistentry>
@@ -37,7 +37,7 @@
      <term><parameter>qualifiedName</parameter></term>
      <listitem>
       <para>
-       Le nom qualifié des éléments du document à créer.
+       Le nom qualifié de l'élément du document à créer.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnode/c14n.xml
+++ b/reference/dom/domnode/c14n.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="domnode.c14n" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DOMNode::C14N</refname>
-  <refpurpose>Canonise des nœuds en une chaîne</refpurpose>
+  <refpurpose>Canonicalise des nœuds en une chaîne</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>nsPrefixes</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Canonise des nœuds en une chaîne de caractères.
+   Canonicalise des nœuds en une chaîne de caractères.
   </para>
  </refsect1>
 

--- a/reference/dom/domnode/clonenode.xml
+++ b/reference/dom/domnode/clonenode.xml
@@ -24,7 +24,7 @@
      <term><parameter>deep</parameter></term>
      <listitem>
       <para>
-       Indique si l'on doit copier tous les nœuds fils. Ce paramètre vaut
+       Indique si l'on doit copier tous les nœuds descendants. Ce paramètre vaut
        &false; par défaut.
       </para>
      </listitem>

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -109,7 +109,7 @@ Remove me once you perform substitutions
    &reftitle.notes;
    <note>
     <simpara>
-      Les nœuds dans la carte peuvent être accédés via la syntaxe de tableau.
+      Les nœuds dans la liste peuvent être accédés via la syntaxe de tableau.
     </simpara>
    </note>
   </section>

--- a/reference/ds/ds/deque/map.xml
+++ b/reference/ds/ds/deque/map.xml
@@ -34,7 +34,7 @@
              </methodsynopsis>
          </para>
          <para>
-            Une <type>fonction de rappel</type> à appliquer à chaque valeur de la deque.
+            Un <type>callable</type> à appliquer à chaque valeur de la deque.
          </para>
 
          <para>

--- a/reference/ds/ds/sequence/apply.xml
+++ b/reference/ds/ds/sequence/apply.xml
@@ -34,7 +34,7 @@
              </methodsynopsis>
         </para>
         <para>
-            Un <type>callable</type> à appliquer à chaque valeur de la carte.
+            Un <type>callable</type> à appliquer à chaque valeur de la séquence.
         </para>
 
         <para>

--- a/reference/ds/ds/sequence/map.xml
+++ b/reference/ds/ds/sequence/map.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
     Renvoie le résultat de l'application de <parameter>callback</parameter> à
-    chaque valeur de la deque.
+    chaque valeur de la séquence.
   </para>
  </refsect1>
 
@@ -34,7 +34,7 @@
              </methodsynopsis>
          </para>
          <para>
-            Une <type>fonction de rappel</type> à appliquer à chaque valeur de la deque.
+            Un <type>callable</type> à appliquer à chaque valeur de la séquence.
          </para>
 
          <para>
@@ -50,7 +50,7 @@
   &reftitle.returnvalues;
   <para>
     Le résultat de l'application de <parameter>callback</parameter> à chaque valeur
-    du deque.
+    de la séquence.
   </para>
   <note>
     <para>

--- a/reference/ds/ds/sequence/slice.xml
+++ b/reference/ds/ds/sequence/slice.xml
@@ -32,8 +32,8 @@
             L'index auquel commence la sous-séquence.
         </para>
         <para>
-            Si positif, le sous-deque commencera à cet index dans le deque.
-            Si négatif, le sous-deque commencera à cette distance de la fin.
+            Si positif, la sous-séquence commencera à cet index dans la séquence.
+            Si négatif, la sous-séquence commencera à cette distance de la fin.
         </para>
     </listitem>
     </varlistentry>
@@ -41,16 +41,16 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <para>
-        Si une longueur est donnée et est positive, le sous-deque résultant
+        Si une longueur est donnée et est positive, la sous-séquence résultante
         aura jusqu'à autant de valeurs.
 
         Si la longueur entraîne un dépassement, seules
-        les valeurs jusqu'à la fin du deque seront incluses.
+        les valeurs jusqu'à la fin de la séquence seront incluses.
 
-        Si une longueur est donnée et est négative, le sous-deque
+        Si une longueur est donnée et est négative, la sous-séquence
         s'arrêtera à autant de valeurs de la fin.
 
-        Si une longueur n'est pas fournie, le sous-deque
+        Si une longueur n'est pas fournie, la sous-séquence
         contiendra toutes les valeurs entre l'index et la
         fin de la séquence.
      </para>

--- a/reference/ds/ds/set/add.xml
+++ b/reference/ds/ds/set/add.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::add</refname>
-  <refpurpose>Ajoute des valeurs à la séquence</refpurpose>
+  <refpurpose>Ajoute des valeurs à l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -41,7 +41,7 @@
     <term><parameter>values</parameter></term>
     <listitem>
      <para>
-        Les valeurs à ajouter à la séquence.
+        Les valeurs à ajouter à l'ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/set/clear.xml
+++ b/reference/ds/ds/set/clear.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Supprime toutes les valeurs de la séquence.
+    Supprime toutes les valeurs de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/contains.xml
+++ b/reference/ds/ds/set/contains.xml
@@ -54,7 +54,7 @@
   &reftitle.returnvalues;
   <para>
     &false; si l'une des <parameter>valeurs</parameter> fournies n'est pas dans
-    la séquence, sinon &true;.
+    l'ensemble, sinon &true;.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/copy.xml
+++ b/reference/ds/ds/set/copy.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.copy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::copy</refname>
-  <refpurpose>Renvoie une copie superficielle de la séquence</refpurpose>
+  <refpurpose>Renvoie une copie superficielle de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie une copie superficielle de la séquence.
+    Renvoie une copie superficielle de l'ensemble.
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie une copie superficielle de la séquence.
+   Renvoie une copie superficielle de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/count.xml
+++ b/reference/ds/ds/set/count.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.count" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::count</refname>
-  <refpurpose>Renvoie le nombre de valeurs dans la séquence</refpurpose>
+  <refpurpose>Renvoie le nombre de valeurs dans l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ds/ds/set/diff.xml
+++ b/reference/ds/ds/set/diff.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.diff" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::diff</refname>
-  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs qui ne sont pas dans une autre séquence</refpurpose>
+  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs qui ne sont pas dans un autre ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>Ds\Set</type><parameter>set</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Crée un nouvel ensemble utilisant des valeurs qui ne sont pas dans une autre séquence.
+    Crée un nouvel ensemble utilisant des valeurs qui ne sont pas dans un autre ensemble.
   </para>
   <para>
     <code>A \ B = {x ∈ A | x ∉ B}</code>

--- a/reference/ds/ds/set/first.xml
+++ b/reference/ds/ds/set/first.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.first" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::first</refname>
-  <refpurpose>Renvoie la première valeur de la séquence</refpurpose>
+  <refpurpose>Renvoie la première valeur de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie la première valeur de la séquence.
+    Renvoie la première valeur de l'ensemble.
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    La première valeur de la séquence.
+    La première valeur de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/intersect.xml
+++ b/reference/ds/ds/set/intersect.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.intersect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::intersect</refname>
-  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs communes avec une autre séquence</refpurpose>
+  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs communes avec un autre ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -31,7 +31,7 @@
     <term><parameter>set</parameter></term>
     <listitem>
      <para>
-        L'autre séquence.
+        L'autre ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/set/last.xml
+++ b/reference/ds/ds/set/last.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.last" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::last</refname>
-  <refpurpose>Renvoie la dernière valeur de la séquence</refpurpose>
+  <refpurpose>Renvoie la dernière valeur de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie la dernière valeur de la séquence.
+    Renvoie la dernière valeur de l'ensemble.
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    La dernière valeur de la séquence.
+    La dernière valeur de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/merge.xml
+++ b/reference/ds/ds/set/merge.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.merge" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::merge</refname>
-  <refpurpose>Renvoie le résultat de l'ajout de toutes les valeurs de la séquence</refpurpose>
+  <refpurpose>Renvoie le résultat de l'ajout de toutes les valeurs de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Renvoie le résultat de l'ajout de toutes les valeurs de la séquence.
+    Renvoie le résultat de l'ajout de toutes les valeurs de l'ensemble.
   </para>
 
  </refsect1>
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Le résultat de l'ajout de toutes les valeurs données à la séquence,
+    Le résultat de l'ajout de toutes les valeurs données à l'ensemble,
     effectivement le même que d'ajouter les valeurs à une copie, puis de renvoyer cette copie.
   </para>
   <note>

--- a/reference/ds/ds/set/remove.xml
+++ b/reference/ds/ds/set/remove.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::remove</refname>
-  <refpurpose>Supprime toutes les valeurs données de la séquence</refpurpose>
+  <refpurpose>Supprime toutes les valeurs données de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Supprime toutes les <parameter>values</parameter> données de la séquence, en ignorant celles qui ne sont pas dans la séquence.
+    Supprime toutes les <parameter>values</parameter> données de l'ensemble, en ignorant celles qui ne sont pas dans l'ensemble.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/set/reversed.xml
+++ b/reference/ds/ds/set/reversed.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie une copie renversée de la séquence.
+    Renvoie une copie renversée de l'ensemble.
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Une copie renversée de la séquence.
+    Une copie renversée de l'ensemble.
 
     <note>
         <para>

--- a/reference/ds/ds/set/slice.xml
+++ b/reference/ds/ds/set/slice.xml
@@ -29,11 +29,11 @@
     <term><parameter>index</parameter></term>
     <listitem>
         <para>
-            L'index auquel commence la sous-séquence .
+            L'index auquel commence le sous-ensemble.
         </para>
         <para>
-            Si positif, la sous-séquence commencera à cet index dans la séquence.
-            Si négatif, la sous-séquence commencera à cette distance de la fin.
+            Si positif, le sous-ensemble commencera à cet index dans l'ensemble.
+            Si négatif, le sous-ensemble commencera à cette distance de la fin.
         </para>
     </listitem>
     </varlistentry>
@@ -41,18 +41,18 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <para>
-        Si une longueur est donnée et est positive, la sous-séquence résultante
+        Si une longueur est donnée et est positive, le sous-ensemble résultant
         aura jusqu'à autant de valeurs.
 
         Si la longueur entraîne un dépassement, seules
         les valeurs jusqu'à la fin de l'ensemble seront incluses.
 
-        Si une longueur est donnée et est négative, la sous-séquence
+        Si une longueur est donnée et est négative, le sous-ensemble
         s'arrêtera à autant de valeurs de la fin.
 
-        Si une longueur n'est pas fournie, la sous-séquence
+        Si une longueur n'est pas fournie, le sous-ensemble
         contiendra toutes les valeurs entre l'index et la
-        fin de la séquence.
+        fin de l'ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/set/sorted.xml
+++ b/reference/ds/ds/set/sorted.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Renvoie une copie triée de la séquence, en utilisant une fonction <parameter>comparator</parameter> optionnelle.
+    Renvoie une copie triée de l'ensemble, en utilisant une fonction <parameter>comparator</parameter> optionnelle.
   </para>
 
  </refsect1>
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Renvoie une copie triée de la séquence.
+    Renvoie une copie triée de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/sum.xml
+++ b/reference/ds/ds/set/sum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.sum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::sum</refname>
-  <refpurpose>Renvoie la somme de toutes les valeurs de la séquence</refpurpose>
+  <refpurpose>Renvoie la somme de toutes les valeurs de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie la somme de toutes les valeurs de la séquence.
+    Renvoie la somme de toutes les valeurs de l'ensemble.
   </para>
   <note>
     <para>
@@ -33,7 +33,7 @@
   &reftitle.returnvalues;
   <para>
     La somme de toutes les valeurs de l'ensemble en tant que <type>float</type> ou <type>int</type>
-    en fonction des valeurs de la séquence.
+    en fonction des valeurs de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/toarray.xml
+++ b/reference/ds/ds/set/toarray.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Un &array; contenant toutes les valeurs dans le même ordre que la séquence.
+    Un &array; contenant toutes les valeurs dans le même ordre que l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/xor.xml
+++ b/reference/ds/ds/set/xor.xml
@@ -29,7 +29,7 @@
     <term><parameter>set</parameter></term>
     <listitem>
      <para>
-        L'autre séquence.
+        L'autre ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/vector/apply.xml
+++ b/reference/ds/ds/vector/apply.xml
@@ -34,7 +34,7 @@
              </methodsynopsis>
         </para>
         <para>
-            Un <type>callable</type> à appliquer à chaque valeur de la carte.
+            Un <type>callable</type> à appliquer à chaque valeur du vecteur.
         </para>
 
         <para>

--- a/reference/ds/ds/vector/join.xml
+++ b/reference/ds/ds/vector/join.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Toutes les valeurs de la séquence rassemblées en une chaîne.
+    Toutes les valeurs du vecteur rassemblées en une chaîne.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/vector/map.xml
+++ b/reference/ds/ds/vector/map.xml
@@ -34,7 +34,7 @@
              </methodsynopsis>
          </para>
          <para>
-            Une <type>fonction de rappel</type> à appliquer à chaque valeur de la deque.
+            Un <type>callable</type> à appliquer à chaque valeur du vecteur.
          </para>
 
          <para>

--- a/reference/eio/book.xml
+++ b/reference/eio/book.xml
@@ -85,7 +85,7 @@ function my_symlink_done($filename, $result) {
  // Crée une demande eio_rename et l'ajoute au groupe
  $req = eio_rename($filename, "/path/to/new-name");
  eio_grp_add($grp, $req);
- // Vous pouvez vouloir d'autres actions...
+ // Il est possible d'ajouter d'autres demandes...
 }
 
 // Création d'un groupe de demandes

--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -338,7 +338,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-/* Is called when eio_readdir() finishes */
+/* Sera appelé lorsque la fonction eio_readdir() aura terminé */
 function my_readdir_callback($data, $result) {
     echo __FUNCTION__, " called\n";
     echo "donnée : "; var_dump($data);

--- a/reference/enchant/book.xml
+++ b/reference/enchant/book.xml
@@ -32,7 +32,7 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>MySpell/Hunspell (un projet orienté objet, également utilisé par Mozilla)</literal>
+      <literal>MySpell/Hunspell (un projet OpenOffice.org, également utilisé par Mozilla)</literal>
      </simpara>
     </listitem>
     <listitem>

--- a/reference/enchant/functions/enchant-dict-add-to-personal.xml
+++ b/reference/enchant/functions/enchant-dict-add-to-personal.xml
@@ -9,7 +9,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-  &warn.deprecated.function-8-0-0;
+  &warn.deprecated.alias-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/enchant/functions/enchant-dict-get-error.xml
+++ b/reference/enchant/functions/enchant-dict-get-error.xml
@@ -28,7 +28,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne le message d'erreur sous la forme d'une chaîne de caractères,
-   ou &false; si une erreur survient.
+   ou &false; si aucune erreur n'est survenue.
   </simpara>
  </refsect1>
 

--- a/reference/enchant/functions/enchant-dict-is-in-session.xml
+++ b/reference/enchant/functions/enchant-dict-is-in-session.xml
@@ -9,7 +9,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-  &warn.deprecated.function-8-0-0;
+  &warn.deprecated.alias-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -74,9 +74,7 @@ if (enchant_broker_dict_exists($r,$tag)) {
         echo "Suggestions pour 'soong' : ";
         print_r($suggs);
     }
-    enchant_broker_free_dict($d);
 }
-enchant_broker_free($r);
 ?>
 ]]>
     </programlisting>

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -255,7 +255,7 @@ function myErrorHandler($errno, $errstr, $errfile, $errline)
 function scale_by_log($vect, $scale)
 {
     if (!is_numeric($scale) || $scale <= 0) {
-        trigger_error("log(x) pour x <= 0 est indéfini, vous utiliser : scale = $scale", E_USER_ERROR);
+        trigger_error("log(x) pour x <= 0 est indéfini, valeur utilisée : scale = $scale", E_USER_ERROR);
     }
 
     if (!is_array($vect)) {
@@ -284,7 +284,7 @@ print_r($a);
 
 // Générons maintenant un second tableau
 echo "----\nvector b - a notice (b = log(PI) * a)\n";
-/* Valeur à la position $pos n'est pas un nombre, utilisation de 0 (zéro) */
+/* La valeur à la position $pos n'est pas un nombre, utilisation 0 (zéro) */
 $b = scale_by_log($a, M_PI);
 print_r($b);
 
@@ -296,7 +296,7 @@ var_dump($c); // NULL
 
 // Ceci est une erreur critique : le logarithme de zéro ou d'un nombre négatif est indéfini
 echo "----\nvector d - fatal error\n";
-/* log(x) pour x <= 0 est indéfini, vous utiliser : scale = $scale" */
+/* log(x) pour x <= 0 est indéfini, valeur utilisée : scale = $scale" */
 $d = scale_by_log($a, -2.5);
 var_dump($d); // Jamais atteint
 ?>
@@ -317,7 +317,7 @@ Array
 )
 ----
 vector b - a notice (b = log(PI) * a)
-<b>Mon AVERTISSEMENT</b> [1024] La valeur à la position 2 n'est pas un nombre, utilisation de 0 (zéro)<br />
+<b>Mon AVERTISSEMENT</b> [1024] La valeur à la position 2 n'est pas un nombre, utilisation 0 (zéro)<br />
 Array
 (
     [0] => 2.2894597716988
@@ -333,7 +333,7 @@ vector c - a warning
 NULL
 ----
 vector d - fatal error
-<b>Mon ERREUR</b> [256] log(x) pour x <= 0 est indéfini, vous utiliser : scale = -2.5<br />
+<b>Mon ERREUR</b> [256] log(x) pour x <= 0 est indéfini, valeur utilisée : scale = -2.5<br />
   Erreur fatale sur la ligne 36 dans le fichier trigger_error.php, PHP 5.2.1 (Linux)<br />
 Arrêt...<br />
 ]]>

--- a/reference/ev/configure.xml
+++ b/reference/ev/configure.xml
@@ -11,7 +11,7 @@
  </simpara>
  <simpara>
   Pour plus d'informations concernant l'installation manuelle,
-  veuillez lire le fichier <filename>INSTALL.md</filename> inclus
+  se reporter au fichier <filename>INSTALL.md</filename> inclus
   dans les sources du paquet.
  </simpara>
 </section>

--- a/reference/ev/ev.xml
+++ b/reference/ev/ev.xml
@@ -323,7 +323,7 @@
         <link xlink:href="&url.ev.signal;">ev_signal</link>
         (et
         <link xlink:href="&url.ev.child;">ev_child</link>).
-        Cette API délivre les signaux de façon asynchrone, ce qui
+        Cette API délivre les signaux de façon synchrone, ce qui
         la rend plus rapide, et peut permettre la récupération des données
         des signaux en attente. Elle peut également simplifier la gestion
         des signaux avec les threads, sachant que les signaux sont des

--- a/reference/ev/watchers.xml
+++ b/reference/ev/watchers.xml
@@ -25,12 +25,12 @@ Ev::run(Ev::RUN_ONCE);
   <methodname>EvIo::createStopped</methodname>).
  </simpara>
  <simpara>
-  Notez qu'un watcher sera automatiquement stoppé lorsque l'objet watcher est
+  Il est à noter qu'un watcher sera automatiquement stoppé lorsque l'objet watcher est
   détruit. Toutefois, les objets watchers retournés par les constructeurs
-  ou les méthodes factorielles seront conservés.
+  ou les méthodes fabriques seront conservés.
  </simpara>
  <simpara>
-  Notez également que toutes les méthodes qui modifient les propriétés
+  Il est également à noter que toutes les méthodes qui modifient les propriétés
   d'un watcher (<emphasis>set</emphasis>, <varname>priority</varname> etc.)
   stoppent et redémarrent automatiquement le watcher s'il est actif, ce qui
   signifie que les événements en attente seront perdus.

--- a/reference/event/eventbase.xml
+++ b/reference/event/eventbase.xml
@@ -170,8 +170,8 @@
       </para>
       <para>
        Le fait de définir ce drapeau rend le code plus rapide, mais il peut
-       se confronter à un bogue Linux : il n'est pas sécurisé d'utiliser ce drapeau
-       en la présence d'un fds clôné par dup() ou une de ces variantes.
+       déclencher un bogue Linux : il n'est pas sécurisé d'utiliser ce drapeau
+       en la présence d'un fds cloné par dup() ou une de ces variantes.
        Ceci produirait un comportement étrange et très difficile à diagnostiquer.
       </para>
       <para>

--- a/reference/event/eventbase/getfeatures.xml
+++ b/reference/event/eventbase/getfeatures.xml
@@ -49,9 +49,9 @@ $base = new EventBase($cfg);
 
 echo "fonctionnalités :\n";
 $features = $base->getFeatures();
-($features & EventConfig::FEATURE_ET) and print "ET - edge-triggered IO\n";
-($features & EventConfig::FEATURE_O1) and print "O1 - O(1) operation for adding/deleting events\n";
-($features & EventConfig::FEATURE_FDS) and print "FDS - arbitrary file descriptor types, and not just sockets\n";
+($features & EventConfig::FEATURE_ET) and print "ET - E/S déclenchées par front\n";
+($features & EventConfig::FEATURE_O1) and print "O1 - opération O(1) pour l'ajout/suppression d'événements\n";
+($features & EventConfig::FEATURE_FDS) and print "FDS - type de descripteur de fichiers arbitraire, et non uniquement les sockets\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/event/eventbuffer.xml
+++ b/reference/event/eventbuffer.xml
@@ -194,8 +194,8 @@
        Identique à <constant>EventBuffer::PTR_SET</constant>,
        sauf que ce drapeau fait que la méthode
        <methodname>EventBuffer::setPosition</methodname>
-       se déplace à une position en arrière par rapport au numéro
-       d'octets spécifié (au lieu de définir une position absolue).
+       se déplace en avant jusqu'au nombre d'octets spécifié
+       (au lieu de définir une position absolue).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/eventbufferevent/sslerror.xml
+++ b/reference/event/eventbufferevent/sslerror.xml
@@ -51,7 +51,7 @@ function ssl_event_cb($bev, $events, $ctx) {
     if ($events & EventBufferEvent::ERROR) {
         // Récupère les erreurs depuis la pile des erreurs SSL
         while ($err = $bev->sslError()) {
-            fprintf(STDERR, "Bufferevent error %s.\n", $err);
+            fprintf(STDERR, "Erreur Bufferevent %s.\n", $err);
         }
     }
 

--- a/reference/event/eventhttp/construct.xml
+++ b/reference/event/eventhttp/construct.xml
@@ -144,44 +144,44 @@ function _http_dump($req, $data) {
     static $max_requests = 2;
 
     if (++$counter >= $max_requests)  {
-        echo "Counter reached max requests $max_requests. Exiting\n";
+        echo "Le compteur a atteint le maximum de requêtes $max_requests. Sortie\n";
         exit();
     }
 
-    echo __METHOD__, " called\n";
-    echo "request:"; var_dump($req);
-    echo "data:"; var_dump($data);
+    echo __METHOD__, " appelée\n";
+    echo "requête :"; var_dump($req);
+    echo "données :"; var_dump($data);
 
     echo "\n===== DUMP =====\n";
-    echo "Command:", $req->getCommand(), PHP_EOL;
-    echo "URI:", $req->getUri(), PHP_EOL;
-    echo "Input headers:"; var_dump($req->getInputHeaders());
-    echo "Output headers:"; var_dump($req->getOutputHeaders());
+    echo "Commande :", $req->getCommand(), PHP_EOL;
+    echo "URI :", $req->getUri(), PHP_EOL;
+    echo "En-têtes d'entrée :"; var_dump($req->getInputHeaders());
+    echo "En-têtes de sortie :"; var_dump($req->getOutputHeaders());
 
-    echo "\n >> Sending reply ...";
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 
-    echo "\n >> Reading input buffer ...\n";
+    echo "\n >> Lecture du buffer d'entrée ...\n";
     $buf = $req->getInputBuffer();
     while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
         echo $s, PHP_EOL;
     }
-    echo "No more data in the buffer\n";
+    echo "Plus de données dans le buffer\n";
 }
 
 function _http_about($req) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
@@ -191,7 +191,7 @@ if ($argc > 1) {
     $port = (int) $argv[1];
 }
 if ($port <= 0 || $port > 65535) {
-    exit("Invalid port");
+    exit("Port invalide");
 }
 
 $base = new EventBase();
@@ -200,7 +200,7 @@ $http->setAllowedMethods(EventHttpRequest::CMD_GET | EventHttpRequest::CMD_POST)
 
 $http->setCallback("/dump", "_http_dump", array(4, 8));
 $http->setCallback("/about", "_http_about");
-$http->setDefaultCallback("_http_default", "custom data value");
+$http->setDefaultCallback("_http_default", "valeur de données personnalisée");
 
 $http->bind("0.0.0.0", 8010);
 $base->loop();

--- a/reference/event/eventhttp/setcallback.xml
+++ b/reference/event/eventhttp/setcallback.xml
@@ -145,44 +145,44 @@ function _http_dump($req, $data) {
     static $max_requests = 2;
 
     if (++$counter >= $max_requests)  {
-        echo "Counter reached max requests $max_requests. Exiting\n";
+        echo "Le compteur a atteint le maximum de requêtes $max_requests. Sortie\n";
         exit();
     }
 
-    echo __METHOD__, " called\n";
-    echo "request:"; var_dump($req);
-    echo "data:"; var_dump($data);
+    echo __METHOD__, " appelée\n";
+    echo "requête :"; var_dump($req);
+    echo "données :"; var_dump($data);
 
     echo "\n===== DUMP =====\n";
-    echo "Command:", $req->getCommand(), PHP_EOL;
-    echo "URI:", $req->getUri(), PHP_EOL;
-    echo "Input headers:"; var_dump($req->getInputHeaders());
-    echo "Output headers:"; var_dump($req->getOutputHeaders());
+    echo "Commande :", $req->getCommand(), PHP_EOL;
+    echo "URI :", $req->getUri(), PHP_EOL;
+    echo "En-têtes d'entrée :"; var_dump($req->getInputHeaders());
+    echo "En-têtes de sortie :"; var_dump($req->getOutputHeaders());
 
-    echo "\n >> Sending reply ...";
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 
-    echo "\n >> Reading input buffer ...\n";
+    echo "\n >> Lecture du buffer d'entrée ...\n";
     $buf = $req->getInputBuffer();
     while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
         echo $s, PHP_EOL;
     }
-    echo "No more data in the buffer\n";
+    echo "Plus de données dans le buffer\n";
 }
 
 function _http_about($req) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
@@ -192,7 +192,7 @@ if ($argc > 1) {
     $port = (int) $argv[1];
 }
 if ($port <= 0 || $port > 65535) {
-    exit("Invalid port");
+    exit("Port invalide");
 }
 
 $base = new EventBase();
@@ -201,7 +201,7 @@ $http->setAllowedMethods(EventHttpRequest::CMD_GET | EventHttpRequest::CMD_POST)
 
 $http->setCallback("/dump", "_http_dump", array(4, 8));
 $http->setCallback("/about", "_http_about");
-$http->setDefaultCallback("_http_default", "custom data value");
+$http->setDefaultCallback("_http_default", "valeur de données personnalisée");
 
 $http->bind("0.0.0.0", 8010);
 $base->loop();

--- a/reference/event/eventhttpconnection/makerequest.xml
+++ b/reference/event/eventhttpconnection/makerequest.xml
@@ -86,14 +86,14 @@ function _request_handler($req, $base) {
     echo __FUNCTION__, PHP_EOL;
 
     if (is_null($req)) {
-        echo "Timed out\n";
+        echo "Délai d'attente maximal atteint\n";
     } else {
         $response_code = $req->getResponseCode();
 
         if ($response_code == 0) {
             echo "Connexion refusée\n";
         } elseif ($response_code != 200) {
-            echo "Réponse inatendue : $response_code\n";
+            echo "Réponse inattendue : $response_code\n";
         } else {
             echo "Succès : $response_code\n";
             $buf = $req->getInputBuffer();

--- a/reference/event/eventhttpconnection/setclosecallback.xml
+++ b/reference/event/eventhttpconnection/setclosecallback.xml
@@ -72,22 +72,22 @@
 <![CDATA[
 <?php
 /*
- * Setting up close-connection callback
+ * Configuration de la fonction de rappel de fermeture de connexion
  *
- * The script handles closed connections using HTTP API.
+ * Le script gère les connexions fermées en utilisant l'API HTTP.
  *
- * Usage:
- * 1) Launch the server:
+ * Utilisation :
+ * 1) Lancez le serveur :
  * $ php examples/http_closecb.php 4242
  *
- * 2) Launch a client in another terminal. Telnet-like
- * session should look like the following:
+ * 2) Lancez un client dans un autre terminal. La session
+ * de type Telnet devrait ressembler à ceci :
  *
  * $ nc -t 127.0.0.1 4242
  * GET / HTTP/1.0
  * Connection: close
  *
- * The server will output something similar to the following:
+ * Le serveur devrait afficher quelque chose de similaire à :
  *
  * HTTP/1.0 200 OK
  * Content-Type: multipart/x-mixed-replace;boundary=boundarydonotcross
@@ -95,14 +95,14 @@
  *
  * <html>
  *
- * 3) Terminate the client connection abruptly,
- * i.e. kill the process, or just press Ctrl-C.
+ * 3) Terminez la connexion client brusquement,
+ * par exemple en tuant le processus, ou en appuyant sur Ctrl-C.
  *
- * 4) Check if the server called _close_callback.
- * The script should output "_close_callback" string to standard output.
+ * 4) Vérifiez si le serveur a appelé _close_callback.
+ * Le script devrait afficher la chaîne "_close_callback" sur la sortie standard.
  *
- * 5) Check if the server's process has no orphaned connections,
- * e.g. with `lsof` utility.
+ * 5) Vérifiez que le processus serveur n'a pas de connexions orphelines,
+ * par exemple avec l'utilitaire `lsof`.
  */
 
 function _close_callback($conn)
@@ -116,22 +116,22 @@ function _http_default($req, $dummy)
     $conn->setCloseCallback('_close_callback', NULL);
 
     /*
-    By enabling Event::READ we protect the server against unclosed conections.
-    This is a peculiarity of Libevent. The library disables Event::READ events
-     on this connection, and the server is not notified about terminated
-    connections.
+    En activant Event::READ, on protège le serveur contre les connexions non fermées.
+    C'est une particularité de Libevent. La bibliothèque désactive les événements
+    Event::READ sur cette connexion, et le serveur n'est pas notifié des connexions
+    terminées.
 
-    So each time client terminates connection abruptly, we get an orphaned
-    connection. For instance, the following is a part of `lsof -p $PID | grep TCP`
-    command after client has terminated connection:
+    Ainsi, chaque fois qu'un client termine brusquement la connexion, on obtient une
+    connexion orpheline. Par exemple, voici une partie de la commande
+    `lsof -p $PID | grep TCP` après que le client a terminé la connexion :
 
     57-php     15057 ruslan  6u  unix 0xffff8802fb59c780   0t0  125187 socket
     58:php     15057 ruslan  7u  IPv4             125189   0t0     TCP *:4242 (LISTEN)
     59:php     15057 ruslan  8u  IPv4             124342   0t0     TCP localhost:4242->localhost:37375 (CLOSE_WAIT)
 
-    where $PID is our process ID.
+    où $PID est l'identifiant du processus.
 
-    The following block of code fixes such kind of orphaned connections.
+    Le bloc de code suivant corrige ce type de connexions orphelines.
      */
     $bev = $req->getBufferEvent();
     $bev->enable(Event::READ);
@@ -159,7 +159,7 @@ if ($argc > 1) {
     $port = (int) $argv[1];
 }
 if ($port <= 0 || $port > 65535) {
-    exit("Invalid port");
+    exit("Port invalide");
 }
 
 $base = new EventBase();

--- a/reference/event/eventhttprequest/construct.xml
+++ b/reference/event/eventhttprequest/construct.xml
@@ -92,11 +92,11 @@ function _request_handler($req, $base) {
         if ($response_code == 0) {
             echo "Connexion refusée\n";
         } elseif ($response_code != 200) {
-            echo "Réponse innatendue : $response_code\n";
+            echo "Réponse inattendue : $response_code\n";
         } else {
             echo "Succès : $response_code\n";
             $buf = $req->getInputBuffer();
-            echo "Body:\n";
+            echo "Corps :\n";
             while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
                 echo $s, PHP_EOL;
             }

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -560,7 +560,7 @@ eio_mkdir($dir, 0750, EIO_PRI_DEFAULT, "my_nop_cb");
 
 $event = new Event($base, eio_get_event_stream(),
     Event::READ | Event::PERSIST, function ($fd, $events, $base) {
-    echo "step 5\n";
+    echo "étape 5\n";
 
     while (eio_nreqs()) {
         eio_poll();
@@ -605,9 +605,9 @@ echo "Méthode d'événement utilisée : ", $base->getMethod(), PHP_EOL;
 
 echo "fonctionnalités :\n";
 $features = $base->getFeatures();
-($features & EventConfig::FEATURE_ET) and print "ET - edge-triggered IO\n";
-($features & EventConfig::FEATURE_O1) and print "O1 - O(1) operation for adding/deleting events\n";
-($features & EventConfig::FEATURE_FDS) and print "FDS - arbitrary file descriptor types, and not just sockets\n";
+($features & EventConfig::FEATURE_ET) and print "ET - E/S déclenchées par front\n";
+($features & EventConfig::FEATURE_O1) and print "O1 - opération O(1) pour l'ajout/suppression d'événements\n";
+($features & EventConfig::FEATURE_FDS) and print "FDS - type de descripteur de fichiers arbitraire, et non uniquement les sockets\n";
 
 // Nécessite la fonctionnalité FDS
 if ($cfg->requireFeatures(EventConfig::FEATURE_FDS)) {
@@ -700,7 +700,7 @@ function _http_dump($req, $data) {
         exit();
     }
 
-    echo __METHOD__, " called\n";
+    echo __METHOD__, " appelée\n";
     echo "Requête :"; var_dump($req);
     echo "Données :"; var_dump($data);
 
@@ -732,7 +732,7 @@ function _http_about($req) {
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "URI : ", $req->getUri(), PHP_EOL;
     echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
@@ -831,7 +831,7 @@ function _http_about($req) {
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "URI : ", $req->getUri(), PHP_EOL;
     echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
@@ -1131,7 +1131,7 @@ class MyListener {
         $base = $this->base;
 
         fprintf(STDERR, "On reçoit une erreur %d (%s) sur l'écouteur. "
-            ."Shutting down.\n",
+            ."Arrêt.\n",
             EventUtil::getLastSocketErrno(),
             EventUtil::getLastSocketError());
 

--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -281,7 +281,7 @@ if (is_resource($process)) {
 <![CDATA[
 Array
 (
-    [some_option] => aeiou
+    [quelques_options] => aeiou
     [PWD] => /tmp
     [SHLVL] => 1
     [_] => /usr/local/bin/php

--- a/reference/exif/functions/exif-read-data.xml
+++ b/reference/exif/functions/exif-read-data.xml
@@ -37,17 +37,17 @@
    utilisée dans une balise image <acronym>HTML</acronym> classique.
   </simpara>
   <simpara>
-   Lorsqu'un en-tête EXIF contient une note de Copyright, cet en-tête
-   peut alors contenir lui-même deux valeurs. Comme cette solution est
+   Lorsqu'un en-tête EXIF contient une note de Copyright, cette note
+   peut elle-même contenir deux valeurs. Comme cette solution est
    incohérente avec les standards EXIF 2.10, la section <literal>COMPUTED</literal>
    retournera les deux en-têtes, <literal>Copyright.Photographer</literal>
    et <literal>Copyright.Editor</literal>, tandis que les sections <literal>IFD0</literal>
-   contiennent le tableau d'octets avec des caractères NULL pour séparer les deux entrées ;
+   contiennent le tableau d'octets avec le caractère NULL séparant les deux entrées ;
    ou bien, juste la première entrée si le type de données était erroné
    (comportement par défaut d'EXIF). La section <literal>COMPUTED</literal> va aussi
    contenir une entrée <literal>Copyright</literal>, qui sera soit la chaîne originale
-   de copyright, soit une liste de valeurs séparées par des virgules de
-   photos et de copyright de l'auteur.
+   de copyright, soit une liste séparée par des virgules du copyright
+   du photographe et de l'éditeur.
   </simpara>
   <simpara>
    La balise <literal>UserComment</literal> présente le même problème que la balise Copyright.
@@ -81,8 +81,8 @@
     <term><parameter>required_sections</parameter></term>
     <listitem>
      <para>
-      Liste de valeurs séparées par des virgules
-      des sections qui devront être présentées dans le tableau de résultat.
+      Liste séparée par des virgules
+      de sections devant être présentes dans le fichier pour produire un tableau de résultat.
       Si aucune des sections demandées n'est trouvée, la valeur retournée
       est &false;.
       <informaltable>
@@ -98,8 +98,8 @@
           <entry>
            Attribut HTML, largeur, hauteur, couleur ou noir et blanc et plus si disponible.
            La largeur et la hauteur sont calculées de la même façon que la fonction
-           <function>getimagesize</function>, donc, leurs valeurs ne
-           devraient jamais différer. De même, l'index
+           <function>getimagesize</function>, donc leurs valeurs ne doivent
+           pas faire partie d'aucun en-tête retourné. De même, l'index
           <literal>html</literal> est la représentation textuelle de la hauteur/largeur
           utilisée dans une balise image <acronym>HTML</acronym> classique.
           </entry>
@@ -107,7 +107,7 @@
          <row>
           <entry>ANY_TAG</entry>
           <entry>
-           Toutes les informations concernant cette balise, comme
+           Toute information ayant un Tag, comme
            <literal>IFD0</literal>, <literal>EXIF</literal>, ...
           </entry>
          </row>

--- a/reference/exif/functions/exif-tagname.xml
+++ b/reference/exif/functions/exif-tagname.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.exif-tagname">
  <refnamediv>
   <refname>exif_tagname</refname>
-  <refpurpose>Lit le nom d'en-tête EXIF d'un index</refpurpose>
+  <refpurpose>Récupère le nom d'en-tête EXIF d'un index</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/exif/ini.xml
+++ b/reference/exif/ini.xml
@@ -6,8 +6,8 @@
  &reftitle.runtime;
  &extension.runtime;
  <para>
-  EXIF supporte automatiquement la conversion depuis Unicode
-  et JIS, lorsque le module <link linkend="ref.mbstring">mbstring</link>
+  EXIF supporte automatiquement la conversion pour les encodages
+  Unicode et JIS des commentaires utilisateurs, lorsque le module <link linkend="ref.mbstring">mbstring</link>
   est compilé avec PHP. Cela se fait en décodant le commentaire avec
   le jeu de caractères spécifié. Le résultat est ensuite codé avec
   un autre jeu de caractères, compatible avec la sortie
@@ -79,7 +79,7 @@
     <literal>exif.encode_unicode</literal> définit la
     méthode de gestion des commentaires écrits en Unicode.
     La valeur par défaut est <literal>ISO-8859-15</literal>,
-    qui devrait fonctionner dans tous les pays non-asiatiques.
+    qui devrait fonctionner pour la plupart des pays non-asiatiques.
     Cette directive peut être laissée vide, ou prendre un
     des jeux de caractères supporté par mbstring. Si elle
     est vide, le jeu de caractères interne de mbstring sera

--- a/reference/fann/constants.xml
+++ b/reference/fann/constants.xml
@@ -6,7 +6,7 @@
  &extension.constants;
  <para>
   <variablelist xml:id="constants.fann-train">
-   <title>Training algorithms</title>
+   <title>Algorithmes d'entraînement</title>
    <varlistentry xml:id="constant.fann-train-incremental">
     <term>
      <constant>FANN_TRAIN_INCREMENTAL</constant>
@@ -79,7 +79,7 @@
    </varlistentry>
   </variablelist>
   <variablelist xml:id="constants.fann-activation-funcs">
-   <title>Activation functions</title>
+   <title>Fonctions d'activation</title>
    <varlistentry xml:id="constant.fann-linear">
     <term>
      <constant>FANN_LINEAR</constant>
@@ -359,7 +359,7 @@
    </varlistentry>
    </variablelist>
   <variablelist xml:id="constants.fann-e">
-   <title>Errors</title>
+   <title>Erreurs</title>
    <varlistentry xml:id="constant.fann-e-no-error">
     <term>
      <constant>FANN_E_NO_ERROR</constant>

--- a/reference/fann/examples.xml
+++ b/reference/fann/examples.xml
@@ -4,7 +4,7 @@
 <chapter xml:id="fann.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <section xml:id="fann.examples-1">
-  <title>XOR training</title>
+  <title>Entraînement XOR</title>
   <para>
    Cet exemple montre comment entraîner des données pour la fonction XOR
    <example>
@@ -62,11 +62,11 @@ if ($ann) {
 <?php
 $train_file = (dirname(__FILE__) . "/xor_float.net");
 if (!is_file($train_file))
-    die("The file xor_float.net has not been created! Please run simple_train.php to generate it");
+    die("Le fichier xor_float.net n'a pas été créé ! Veuillez exécuter simple_train.php pour le générer");
 
 $ann = fann_create_from_file($train_file);
 if (!$ann)
-    die("ANN could not be created");
+    die("Le réseau de neurones n'a pas pu être créé");
 
 $input = array(-1, 1);
 $calc_out = fann_run($ann, $input);

--- a/reference/fann/functions/fann-set-weight.xml
+++ b/reference/fann/functions/fann-set-weight.xml
@@ -52,7 +52,7 @@
     <term><parameter>weight</parameter></term>
     <listitem>
      <para>
-      Taille de la connexion
+      Poids de la connexion
      </para>
     </listitem>
    </varlistentry>

--- a/reference/fann/functions/fann-test-data.xml
+++ b/reference/fann/functions/fann-test-data.xml
@@ -22,7 +22,7 @@
    et calcule le MSE pour ces données.
   </para>
   <para>
-   Cette fonction met à jour le MSE à sa valeur la plus sûre.
+   Cette fonction met à jour le MSE et les valeurs de bits échoués.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-train-epoch.xml
+++ b/reference/fann/functions/fann-train-epoch.xml
@@ -19,7 +19,7 @@
   <para>
    Effectue un entraînement avec un jeu de données d'entraînement.
    Une époque correspond au fait que toutes les données d'entraînement
-   sont considérées comme étant exactement uniques.
+   sont considérées exactement une fois.
   </para>
   <para>
    Cette fonction retourne l'erreur MSE sachant qu'elle est calculée

--- a/reference/fdf/functions/fdf-set-value.xml
+++ b/reference/fdf/functions/fdf-set-value.xml
@@ -48,8 +48,8 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <simpara>
-      Ce paramètre devra être stocké comme une chaîne de caractères
-      même si c'est un tableau. Dans ce cas, tous les éléments du tableau
+      Ce paramètre sera stocké comme une chaîne de caractères
+      sauf si c'est un tableau. Dans ce cas, tous les éléments du tableau
       seront stockés comme un tableau de valeurs.
      </simpara>
     </listitem>

--- a/reference/ffi/ffi.cdata.xml
+++ b/reference/ffi/ffi.cdata.xml
@@ -58,8 +58,7 @@
      </listitem>
      <listitem>
       <simpara>
-       Les pointeurs C peuvent être incrémentés et décrémentés à l'aide des opérations ordinaires ( <code>+</code>/<code>-</code>/ / ).
-       <code>++</code>/<code>--</code>, par exemple <code>$cdata += 5</code>
+       Les pointeurs C peuvent être incrémentés et décrémentés à l'aide des opérations ordinaires <code>+</code>/<code>-</code>/<code>++</code>/<code>--</code>, par exemple <code>$cdata += 5</code>
       </simpara>
      </listitem>
      <listitem>

--- a/reference/ffi/ffi.exception.xml
+++ b/reference/ffi/ffi.exception.xml
@@ -5,7 +5,7 @@
 <reference xml:id="class.ffi-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Exceptions FFI</title>
- <titleabbrev>Exceptions FFI</titleabbrev>
+ <titleabbrev>FFI\Exception</titleabbrev>
 
  <partintro>
 

--- a/reference/fileinfo/functions/finfo-open.xml
+++ b/reference/fileinfo/functions/finfo-open.xml
@@ -80,7 +80,7 @@
       <entry>8.1.0</entry>
       <entry>
        Retourne désormais une instance de <classname>finfo</classname> ;
-       auparavant, une &resource; était attendue.
+       antérieurement, une &resource; était retournée.
       </entry>
      </row>
      <row>

--- a/reference/filesystem/functions/fgetss.xml
+++ b/reference/filesystem/functions/fgetss.xml
@@ -69,7 +69,7 @@
   <para>
    Retourne une chaîne de taille <parameter>length</parameter> - 1 octet
    lu depuis le fichier pointé par <parameter>handle</parameter>,
-   dont les balises HTML et PHP ont été échappées.
+   dont les balises HTML et PHP ont été supprimées.
   </para>
   <para>
    Si une erreur survient, la fonction retourne &false;.

--- a/reference/filter/examples.xml
+++ b/reference/filter/examples.xml
@@ -74,18 +74,18 @@ $options = array(
     )
 );
 if (filter_var($int_a, FILTER_VALIDATE_INT, $options) !== FALSE) {
-    echo "L'entier A 'int_a' est considéré comme valide (entre 0 et 3).\n";
+    echo "L'entier A '$int_a' est considéré comme valide (entre 0 et 3).\n";
 }
 if (filter_var($int_b, FILTER_VALIDATE_INT, $options) !== FALSE) {
-    echo "L'entier B 'int_b' est considéré comme valide (entre 0 et 3).\n";
+    echo "L'entier B '$int_b' est considéré comme valide (entre 0 et 3).\n";
 }
 if (filter_var($int_c, FILTER_VALIDATE_INT, $options) !== FALSE) {
-    echo "L'entier C 'int_c' est considéré comme valide (entre 0 et 3).\n";
+    echo "L'entier C '$int_c' est considéré comme valide (entre 0 et 3).\n";
 }
 
 $options['options']['default'] = 1;
 if (($int_c = filter_var($int_c, FILTER_VALIDATE_INT, $options)) !== FALSE) {
-    echo "L'entier C 'int_c' est considéré comme valide (entre 0 et 3).";
+    echo "L'entier C '$int_c' est considéré comme valide (entre 0 et 3).";
 }
 ?>
 ]]>

--- a/reference/filter/functions/filter-input-array.xml
+++ b/reference/filter/functions/filter-input-array.xml
@@ -66,12 +66,12 @@
    retourné si <parameter>add_empty</parameter> est &true;.
    Auquel cas, les entrées manquantes seront définies à &null;,
    sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
-   dans quel cas ce sera &false;.
+   auquel cas ce sera &false;.
   </simpara>
   <simpara>
    Une entrée dans le &array; retourné sera &false; si le filtre échoue,
    sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
-   dans ce cas ça sera &null;.
+   auquel cas il sera &null;.
   </simpara>
  </refsect1>
 

--- a/reference/filter/functions/filter-var-array.xml
+++ b/reference/filter/functions/filter-var-array.xml
@@ -40,7 +40,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Soit un <type>array</type> associatif d'option,
+      Soit un <type>array</type> associatif d'options,
       soit un filtre à appliquer à chaque entrée,
       qui peut être un filtre de validation en utilisant une des constantes
       <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>,

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -68,7 +68,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Soit un <type>array</type> associatif d'option,
+      Soit un <type>array</type> associatif d'options,
       soit un masque de bit des constantes des drapeaux de filtrage
       <constant>FILTER_FLAG_<replaceable>*</replaceable></constant>.
      </simpara>


### PR DESCRIPTION
Corrections de contresens, faux amis, accords, glossaire et terminologie sur 92 fichiers répartis dans 20 extensions (componere, cubrid, curl, datetime, dba, dom, ds, eio, enchant, errorfunc, ev, event, exec, exif, fann, fdf, ffi, fileinfo, filesystem, filter).