### PR TITLE
Audit FR: reference/componere -> reference/dir

### DIFF
--- a/reference/componere/componere.abstract.definition.xml
+++ b/reference/componere/componere.abstract.definition.xml
@@ -12,7 +12,7 @@
   <section xml:id="componere-abstract-definition.intro">
    &reftitle.intro;
    <simpara>
-    La classe abstraite finale représente une entrée de classe, et ne doit pas être utilisée par le développeur.
+    La classe abstraite finale représente une entrée de classe, et ne devrait pas être utilisée par le développeur.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/ctype/functions/ctype-alpha.xml
+++ b/reference/ctype/functions/ctype-alpha.xml
@@ -57,7 +57,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>ctype_alpha</function> (en utilisant les locales courantes)</title>
+    <title>Exemple avec <function>ctype_alpha</function> (en utilisant la locale par défaut)</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ctype/functions/ctype-digit.xml
+++ b/reference/ctype/functions/ctype-digit.xml
@@ -58,9 +58,9 @@
 $strings = array('1820.20', '10002', 'wsl!12');
 foreach ($strings as $testcase) {
   if (ctype_digit($testcase)) {
-    echo "La chaîne $testcase ne contient que des entiers.\n";
+    echo "La chaîne $testcase ne contient que des chiffres.\n";
   } else {
-    echo "La chaîne $testcase ne contient pas que des entiers.\n";
+    echo "La chaîne $testcase ne contient pas que des chiffres.\n";
   }
 }
 ?>
@@ -69,9 +69,9 @@ foreach ($strings as $testcase) {
     &example.outputs;
     <screen>
 <![CDATA[
-La chaîne 1820.20 ne contient pas que des entiers.
-La chaîne 10002 ne contient que des entiers.
-La chaîne wsl!12 ne contient pas que des entiers.
+La chaîne 1820.20 ne contient pas que des chiffres.
+La chaîne 10002 ne contient que des chiffres.
+La chaîne wsl!12 ne contient pas que des chiffres.
 ]]>
     </screen>
    </example>

--- a/reference/cubrid/constants.xml
+++ b/reference/cubrid/constants.xml
@@ -212,7 +212,7 @@
        <entry><constant>TRAN_COMMIT_CLASS_UNCOMMIT_INSTANCE</constant></entry>
        <entry>Le niveau d'isolation le plus faible (1).
         Une lecture de données modifiées, non-répétables, ou
-        fantômes peuvent survenir sur le tuple et, de plus, une lecture
+        fantômes peut survenir sur le tuple et, de plus, une lecture
         non-répétable peut survenir sur la table.</entry>
       </row>
       <row>

--- a/reference/cubrid/cubridmysql/cubrid-affected-rows.xml
+++ b/reference/cubrid/cubridmysql/cubrid-affected-rows.xml
@@ -30,8 +30,8 @@
   <variablelist>
    <varlistentry>
     <term><parameter>conn_identifier</parameter></term>
-    <listitem><simpara>Le résultat. S'il n'est pas spécifié,
-     le dernier résultat sera utilisé.</simpara></listitem>
+    <listitem><simpara>La connexion CUBRID. Si l'identifiant de connexion n'est pas
+     spécifié, le dernier lien ouvert par <function>cubrid_connect</function> est utilisé.</simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>req_identifier</parameter></term>

--- a/reference/cubrid/cubridmysql/cubrid-close.xml
+++ b/reference/cubrid/cubridmysql/cubrid-close.xml
@@ -17,7 +17,7 @@
   <simpara>
    La fonction <function>cubrid_close</function> met fin à la transaction courante,
    ferme le gestionnaire de connexion et déconnecte le serveur. S'il existe des gestionnaires
-   de requêtes non clos à ce moment là, ils seront tous clos.
+   de requêtes non clos à ce moment-là, ils seront tous clos.
    Cette fonction est similaire à la fonction <function>cubrid_disconnect</function>.
   </simpara>
  </refsect1>

--- a/reference/cubrid/cubridmysql/cubrid-data-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-data-seek.xml
@@ -19,7 +19,7 @@
    Cette fonction déplace le pointeur de lignes interne du résultat CUBRID
    (associé avec l'identifiant de résultat spécifié) pour pointer sur un numéro
    de ligne spécifique. Il y a des fonctions, comme la fonction
-   <function>cubrid_fetch_assoc</function>, qui utilise la valeur courante
+   <function>cubrid_fetch_assoc</function>, qui utilisent la valeur courante
    stockée de <parameter>row_number</parameter>.
   </simpara>
  </refsect1>
@@ -33,7 +33,7 @@
    </varlistentry>
    <varlistentry>
     <term><parameter>row_number</parameter></term>
-    <listitem><simpara>Numéro de ligne désirée pour le pointeur.</simpara></listitem>
+    <listitem><simpara>Numéro de ligne désiré pour le nouveau pointeur de résultat.</simpara></listitem>
    </varlistentry>
   </variablelist>
  </refsect1>

--- a/reference/cubrid/cubridmysql/cubrid-errno.xml
+++ b/reference/cubrid/cubridmysql/cubrid-errno.xml
@@ -58,6 +58,7 @@
 <![CDATA[
 <?php
 $con = cubrid_connect('localhost', 33000, 'demodb', 'dba', '');
+$req = cubrid_execute($con, "select id, name from person");
 if ($req) {
     while (list ($id, $name) = cubrid_fetch($req))
     echo $id, $name;

--- a/reference/cubrid/cubridmysql/cubrid-fetch-object.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-object.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>type</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Cette fonction retourne un objet avec les noms de la colonne
+   Cette fonction retourne un objet avec les noms des colonnes
    du jeu de résultats comme propriétés. Les valeurs de ces propriétés
    sont extraites depuis la ligne courante du jeu de résultats.
   </simpara>

--- a/reference/cubrid/cubridmysql/cubrid-field-type.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-type.xml
@@ -35,7 +35,7 @@
    </varlistentry>
    <varlistentry>
     <term><parameter>field_offset</parameter></term>
-    <listitem><simpara>Position numérique du champ. le paramètre
+    <listitem><simpara>Position numérique du champ. Le paramètre
      <parameter>field_offset</parameter> commence à zéro (0). Si
      <parameter>field_offset</parameter> n'existe pas, une erreur de niveau
      <constant>E_WARNING</constant> sera également émise.</simpara></listitem>

--- a/reference/cubrid/functions/cubrid-bind.xml
+++ b/reference/cubrid/functions/cubrid-bind.xml
@@ -174,7 +174,7 @@
     </term>
     <listitem>
      <simpara>
-      Valeur actuelle à lier.
+      Valeur effective à lier.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/cubrid/functions/cubrid-commit.xml
+++ b/reference/cubrid/functions/cubrid-commit.xml
@@ -26,7 +26,7 @@
    en utilisant la fonction <function>cubrid_set_autocommit</function>.
    Il est possible de récupérer son statut en utilisant la fonction
    <function>cubrid_get_autocommit</function>. Avant de commencer une
-   transaction, n'oubliez pas de désactiver le mode auto-commit.
+   transaction, il ne faut pas oublier de désactiver le mode auto-commit.
   </simpara>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-connect-with-url.xml
+++ b/reference/cubrid/functions/cubrid-connect-with-url.xml
@@ -83,7 +83,7 @@
     de la requête. Une fois cette valeur atteinte, un message pour annuler la requête
     envoyée au serveur est envoyé. La valeur retournée peut dépendre de la configuration
     de disconnect_on_query_timeout ; même si le message pour annuler
-    la requête a été envoyée au serveur, la requête peut réussir.
+    la requête a été envoyé au serveur, la requête peut réussir.
    </member>
    <member>
     disconnect_on_query_timeout : Configure une valeur déterminant si l'on doit retourner
@@ -157,7 +157,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Identifiant de connexion, en cas de succès,&return.falseforfailure;.
+   Identifiant de connexion, en cas de succès, &return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-error-msg.xml
+++ b/reference/cubrid/functions/cubrid-error-msg.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    La fonction <function>cubrid_error_msg</function> est utilisée pour récupérer
-   le message d'erreur survenue lors de l'utilisation de l'API CUBRID. Habituellement,
+   le message d'erreur survenu lors de l'utilisation de l'API CUBRID. Habituellement,
    elle récupère le message d'erreur lorsque l'API retourne &false;.
   </simpara>
  </refsect1>
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Le message d'erreur survenue.
+   Le message d'erreur survenu.
   </simpara>
   <simpara/>
  </refsect1>

--- a/reference/cubrid/functions/cubrid-execute.xml
+++ b/reference/cubrid/functions/cubrid-execute.xml
@@ -37,7 +37,7 @@
    récupérer l'OID après l'exécution de la requête, et si l'on doit exécuter
    la requête en mode asynchrone ou non. <constant>CUBRID_INCLUDE_OID</constant> et <constant>CUBRID_ASYNC</constant>
    (ou <constant>CUBRID_EXEC_QUERY_ALL</constant> si l'on veut exécuter plusieurs requêtes SQL)
-   peuvent être spécifiés en utilisant l'opérateur OR. Si l'opérateur n'est
+   peuvent être spécifiés en utilisant l'opérateur OR bit à bit. Si l'opérateur n'est
    pas spécifié, aucun des deux ne sera sélectionné. Si le drapeau
    <constant>CUBRID_EXEC_QUERY_ALL</constant> est défini, le mode synchrone (sync_mode) sera
    utilisé pour récupérer les résultats de la requête, et dans un tel cas,

--- a/reference/cubrid/functions/cubrid-get-db-parameter.xml
+++ b/reference/cubrid/functions/cubrid-get-db-parameter.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Cette fonction retourne les paramètres de la base de données CUBRID,&return.falseforfailure;. Elle retourne un tableau associatif
-   avec les valeurs des paramètres suivants:
+   avec les valeurs des paramètres suivants :
   </simpara>
   <simplelist>
    <member><constant>PARAM_ISOLATION_LEVEL</constant></member>

--- a/reference/cubrid/functions/cubrid-lob2-bind.xml
+++ b/reference/cubrid/functions/cubrid-lob2-bind.xml
@@ -25,7 +25,7 @@
    <parameter>bind_value_type</parameter> n'est pas fourni, la chaîne sera
    par défaut "BLOB". Mais si l'on utilise d'abord la fonction
    <function>cubrid_lob2_new</function>, le paramètre <parameter>bind_value_type</parameter>
-   deviendra consistent avec le paramètre <parameter>type</parameter> dans
+   deviendra cohérent avec le paramètre <parameter>type</parameter> dans
    la fonction <function>cubrid_lob2_new</function>.
   </simpara>
  </refsect1>
@@ -37,7 +37,7 @@
     <term><parameter>req_identifier</parameter></term>
     <listitem>
      <simpara>
-      Identifiant de la demande, résultant de la fonction <function>cubrid_prepare</function>.
+      Identifiant de la requête, résultant de la fonction <function>cubrid_prepare</function>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -45,7 +45,7 @@
     <term><parameter>bind_index</parameter></term>
     <listitem>
      <simpara>
-      Position des paramètres liés. Commence à 1.
+      Position du paramètre lié. Commence à 1.
      </simpara>
     </listitem>
    </varlistentry>
@@ -53,7 +53,7 @@
     <term><parameter>bind_value</parameter></term>
     <listitem>
      <simpara>
-      Valeur actuelle pour le liage.
+      Valeur effective pour le liage.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/cubrid/functions/cubrid-lob2-export.xml
+++ b/reference/cubrid/functions/cubrid-lob2-export.xml
@@ -20,7 +20,7 @@
    pour sauvegarder les données BLOB/CLOB dans un fichier. Pour utiliser
    cette fonction, il faut tout d'abord utiliser la fonction
    <function>cubrid_lob2_new</function> ou récupérer un objet LOB depuis la
-   base de données CUBRID. Si le fichier n'existe pas, l'opération échouera.
+   base de données CUBRID. Si le fichier existe déjà, l'opération échouera.
    Cette fonction ne modifiera pas la position du curseur de l'objet LOB.
    Elle opère sur l'objet LOB dans sa totalité.
   </simpara>

--- a/reference/cubrid/functions/cubrid-lob2-seek64.xml
+++ b/reference/cubrid/functions/cubrid-lob2-seek64.xml
@@ -95,7 +95,6 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-<?php
 // test_lob (id INT, contents CLOB)
 // La longueur des données de doc_1.txt doit être supérieure à 20101029056306120215.
 

--- a/reference/cubrid/functions/cubrid-lob2-write.xml
+++ b/reference/cubrid/functions/cubrid-lob2-write.xml
@@ -105,7 +105,7 @@ $lob2 = $row[1];
 cubrid_lob2_seek($lob2, 0, CUBRID_CURSOR_LAST);
 
 $pos = cubrid_lob2_tell($lob2);
-print "pos before write: $pos\n";
+print "Position avant écriture : $pos\n";
 
 cubrid_lob2_write($lob2, "Hello world");
 

--- a/reference/cubrid/functions/cubrid-lock-write.xml
+++ b/reference/cubrid/functions/cubrid-lock-write.xml
@@ -30,7 +30,7 @@
    </varlistentry>
    <varlistentry>
     <term><parameter>oid</parameter></term>
-    <listitem><simpara>OID de l'instance dont l'on veut placer un verrou d'écriture.</simpara></listitem>
+    <listitem><simpara>OID de l'instance sur laquelle placer un verrou d'écriture.</simpara></listitem>
    </varlistentry>
   </variablelist>
  </refsect1>

--- a/reference/cubrid/functions/cubrid-move-cursor.xml
+++ b/reference/cubrid/functions/cubrid-move-cursor.xml
@@ -20,8 +20,8 @@
    La fonction <function>cubrid_move_cursor</function> est utilisée pour déplacer le
    curseur courant suivant le paramètre <parameter>req_identifier</parameter>
    de la valeur du paramètre <parameter>offset</parameter> et dans la direction
-   définie par le paramètre <parameter>origin</parameter> argument. Pour définir
-   l'argument <parameter>origin</parameter>, il est possible d'utiliser <constant>CUBRID_CURSOR_FIRST</constant> pour
+   définie par le paramètre <parameter>origin</parameter>. Pour définir
+   le paramètre <parameter>origin</parameter>, il est possible d'utiliser <constant>CUBRID_CURSOR_FIRST</constant> pour
    la première partie du résultat, <constant>CUBRID_CURSOR_CURRENT</constant> pour la position courante du résultat,
    ou <constant>CUBRID_CURSOR_LAST</constant> pour la dernière partie du résultat. Si l'argument <parameter>origin</parameter>
    n'est pas explicitement désigné, alors la fonction utilisera <constant>CUBRID_CURSOR_CURRENT</constant> comme valeur par défaut.

--- a/reference/cubrid/functions/cubrid-pconnect-with-url.xml
+++ b/reference/cubrid/functions/cubrid-pconnect-with-url.xml
@@ -33,7 +33,7 @@
   <simpara>
    Ensuite, la connexion vers le serveur SQL ne sera pas fermée lorsque la fin
    du script sera atteinte. Au lieu de cela, la connexion restera ouverte
-   pour une utilisation future ( la fonction <function>cubrid_close</function> ou la fonction
+   pour une utilisation future (la fonction <function>cubrid_close</function> ou la fonction
    <function>cubrid_disconnect</function> ne fermera pas la connexion établie par la fonction
    <function>cubrid_pconnect_with_url</function>).
   </simpara>
@@ -96,7 +96,7 @@
     de la requête. Une fois cette valeur atteinte, un message pour annuler la requête
     envoyée au serveur est envoyé. La valeur retournée peut dépendre de la configuration
     de disconnect_on_query_timeout ; même si le message pour annuler
-    la requête a été envoyée au serveur, la requête peut réussir.
+    la requête a été envoyé au serveur, la requête peut réussir.
    </member>
    <member>
     disconnect_on_query_timeout : Configure une valeur déterminant si l'on doit retourner
@@ -178,7 +178,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?althost=10.34.63.132:33088&rctime=100";
+$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::";
 $con = cubrid_pconnect_with_url ($conn_url);
 
 if ($con) {
@@ -204,7 +204,7 @@ if ($con) {
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?autocommit=off&althost=10.34.63.132:33088&rctime=100";
+$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?althost=10.34.63.132:33088&rctime=100";
 $con = cubrid_pconnect_with_url ($conn_url);
 
 if ($con) {

--- a/reference/cubrid/functions/cubrid-pconnect.xml
+++ b/reference/cubrid/functions/cubrid-pconnect.xml
@@ -40,7 +40,7 @@
    <function>cubrid_pconnect</function>).
   </simpara>
   <simpara>
-   Ce type de lien était appelé auparavant 'persistant'.
+   Ce type de lien est donc appelé 'persistant'.
   </simpara>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-schema.xml
+++ b/reference/cubrid/functions/cubrid-schema.xml
@@ -22,7 +22,7 @@
    récupérer des informations d'un schéma depuis la base de données.
    Pour récupérer les informations d'une classe particulière,
    il faut définir <parameter>class_name</parameter>,
-   pour récupérer les informations sur un attributs particulier (seulement
+   pour récupérer les informations sur un attribut particulier (seulement
    utilisable avec <constant>CUBRID_SCH_ATTR_PRIVILEGE</constant>),
    il faut définir <parameter>attr_name</parameter>.
   </simpara>

--- a/reference/cubrid/setup.xml
+++ b/reference/cubrid/setup.xml
@@ -28,7 +28,7 @@
    Il y a 4 types de ressources utilisés dans CUBRID. La première
    est l'identifiant du lien pour une connexion à la base de données,
    la seconde est une ressource qui contient le résultat d'une requête,
-   et deux dernières, une ressource qui contient les résultats d'une
+   et les deux dernières, une ressource qui contient les résultats d'une
    requête pour les types de données BLOB/CLOB.
   </simpara>
   <section xml:id="cubrid.resources.connection-identifier">

--- a/reference/curl/book.xml
+++ b/reference/curl/book.xml
@@ -17,9 +17,9 @@
    types de serveurs, et ce, avec différents types de protocoles.
    libcurl supporte actuellement les protocoles http, https, ftp,
    gopher, telnet, DICT, file et LDAP. libcurl supporte également les
-   certificats HTTPS, HTTP POST, HTTP PUT, le téléchargement FTP
+   certificats HTTPS, HTTP POST, HTTP PUT, le téléversement FTP
    (ceci pouvant également être effectué via l'extension ftp de PHP),
-   les formulaires de téléchargement HTTP, les serveurs mandataires
+   les formulaires de téléversement HTTP, les serveurs mandataires
    (proxy), les cookies et l'identification utilisateur/mot de passe.
   </para>
  </preface>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -11,7 +11,7 @@
   <function>curl_multi_setopt</function> et <function>curl_getinfo</function>.
  </para>
  <variablelist role="constant_list">
-   <varlistentry xml:id="constant.curlaltsvc-h1">
+  <varlistentry xml:id="constant.curlaltsvc-h1">
    <term>
     <constant>CURLALTSVC_H1</constant>
     (<type>int</type>)
@@ -546,7 +546,7 @@
     </simpara>
    </listitem>
   </varlistentry>
- <varlistentry xml:id="constant.curlpipe-http1">
+  <varlistentry xml:id="constant.curlpipe-http1">
    <term>
     <constant>CURLPIPE_HTTP1</constant>
     (<type>int</type>)
@@ -1221,7 +1221,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlusessl-none">  
+  <varlistentry xml:id="constant.curlusessl-none">
    <term>
     <constant>CURLUSESSL_NONE</constant>
     (<type>int</type>)
@@ -1612,7 +1612,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-options"> 
+  <varlistentry xml:id="constant.curl-rtspreq-options">
    <term>
     <constant>CURL_RTSPREQ_OPTIONS</constant>
     (<type>int</type>)
@@ -1664,7 +1664,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-    <varlistentry xml:id="constant.curl-rtspreq-record">
+  <varlistentry xml:id="constant.curl-rtspreq-record">
    <term>
     <constant>CURL_RTSPREQ_RECORD</constant>
     (<type>int</type>)
@@ -1812,7 +1812,7 @@
     <simpara>
 
     </simpara>
-    </listitem>
+   </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curl-sslversion-tlsv1">
    <term>

--- a/reference/curl/constants_curl_error.xml
+++ b/reference/curl/constants_curl_error.xml
@@ -32,7 +32,7 @@
   </term>
   <listitem>
    <simpara>
-    Encodage de contenu non reconnu.
+    Encodage de transfert non reconnu.
    </simpara>
   </listitem>
  </varlistentry>
@@ -591,7 +591,7 @@
    <simpara>
     Erreur de connexion au proxy.
     <constant>CURLINFO_PROXY_ERROR</constant> fournit des détails supplémentaires sur le problème spécifique.
-    Disponible à partir de PHP 8.2.0 et cURL 7.73.0  
+    Disponible à partir de PHP 8.2.0 et cURL 7.73.0
    </simpara>
   </listitem>
  </varlistentry>
@@ -680,7 +680,7 @@
   </term>
   <listitem>
    <simpara>
-    Problème avec le client de certificat local.
+    Problème avec le certificat client local.
    </simpara>
   </listitem>
  </varlistentry>
@@ -702,7 +702,7 @@
   </term>
   <listitem>
    <simpara>
-    Un problème s'est produit quelque part dans la poignée SSL/TLS.
+    Un problème s'est produit quelque part dans la négociation SSL/TLS.
     La lecture du message dans le tampon d'erreur fournit plus de détails sur le problème.
     Pourrait être des certificats (formats de fichiers, chemins, autorisations), des mots de passe et d'autres.
    </simpara>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -33,7 +33,7 @@
   </term>
   <listitem>
    <simpara>
-    Chemin natif du certificat CA.
+    Chemin par défaut intégré du certificat CA.
     Disponible à partir de PHP 8.3.0 et cURL 7.84.0
    </simpara>
   </listitem>
@@ -45,7 +45,7 @@
   </term>
   <listitem>
    <simpara>
-    Chemin natif du CA.
+    Chemin par défaut intégré du CA.
     Disponible à partir de PHP 8.3.0 et cURL 7.84.0
    </simpara>
   </listitem>
@@ -238,7 +238,7 @@
   </term>
   <listitem>
    <simpara>
-    La taille totale de toutes les en-têtes reçues
+    La taille totale de tous les en-têtes reçus
    </simpara>
   </listitem>
  </varlistentry>
@@ -648,7 +648,7 @@
   </term>
   <listitem>
    <simpara>
-    Le nombre total d'octets téléchargés
+    Le nombre total d'octets téléversés
    </simpara>
   </listitem>
  </varlistentry>
@@ -659,7 +659,7 @@
   </term>
   <listitem>
    <simpara>
-    Le nombre total d'octets téléchargés.
+    Le nombre total d'octets téléversés.
     Disponible à partir de PHP 7.3.0 et cURL 7.50.0
    </simpara>
   </listitem>

--- a/reference/curl/constants_curl_multi.xml
+++ b/reference/curl/constants_curl_multi.xml
@@ -46,7 +46,7 @@
   </term>
   <listitem>
    <simpara>
-    Depuis cURL 7.20.0, cette constante n'est pas utilisée.
+    À partir de cURL 7.20.0, cette constante n'est pas utilisée.
     Avant cURL 7.20.0, ce statut pouvait être retourné par
     <function>curl_multi_exec</function> lorsque <function>curl_multi_select</function>
     ou une fonction similaire était appelée avant qu'elle ne retourne une autre constante.

--- a/reference/curl/constants_curl_multi_setopt.xml
+++ b/reference/curl/constants_curl_multi_setopt.xml
@@ -51,7 +51,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie le nombre maximal de stream simultanés pour les connexions
+     Spécifie le nombre maximal de flux simultanés pour les connexions
      que cURL devrait supporter sur les connexions utilisant HTTP/2.
      Les valeurs valides vont de <literal>1</literal>
      à <literal>2147483647</literal> (<literal>2^31 - 1</literal>).
@@ -106,7 +106,7 @@
    <listitem>
     <simpara>
      Passer 1 pour activer ou 0 pour désactiver. Activer le pipelining sur un gestionnaire multiple
-     fera qu'elle tentera de réaliser le pipelining HTTP autant que possible
+     fera qu'il tentera de réaliser le pipelining HTTP autant que possible
      pour les transferts utilisant ce gestionnaire. Cela signifie qu'ajouter
      une deuxième requête qui peut utiliser une connexion déjà existante
      "pipe" la deuxième requête sur la même connexion.
@@ -128,7 +128,7 @@
    </term>
    <listitem>
     <para>
-     Passer une <type>Closure</type> qui sera enregistrée pour gérer les poussées du serveur
+     Passer un <type>callable</type> qui sera enregistré pour gérer les poussées du serveur
      et doit avoir la signature suivante:
      <methodsynopsis>
       <type>int</type><methodname><replaceable>pushfunction</replaceable></methodname>
@@ -149,7 +149,7 @@
        <term><parameter>pushed_ch</parameter></term>
        <listitem>
         <simpara>
-         Un nouveau gestionnaire cURL pour la requête poussée. 
+         Un nouveau gestionnaire cURL pour la requête poussée.
         </simpara>
        </listitem>
       </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -102,7 +102,7 @@
    </term>
    <listitem>
     <para>
-     Mettre cette option à <literal>1</literal> fera que les téléchargements FTP
+     Mettre cette option à <literal>1</literal> fera que les téléversements FTP
      s'ajoutent au fichier distant au lieu de l'écraser.
      Par défaut à <literal>0</literal>.
      Disponible à partir de cURL 7.17.0.
@@ -685,8 +685,8 @@
       <member><literal>deflate</literal></member>
       <member><literal>gzip</literal></member>
      </simplelist>.
-     Si une chaîne vide, <type>string</type>,
-     est définie, un en-tête contenant tous les types d'encodage supportés est envoyé.
+     Si une <type>string</type> vide est définie,
+     un en-tête contenant tous les types d'encodage supportés est envoyé.
      Disponible à partir de cURL 7.10 et obsolète à partir de cURL 7.21.6.
     </para>
    </listitem>
@@ -712,7 +712,7 @@
    </term>
    <listitem>
     <para>
-     &true; pour échouer verbalement si le code HTTP retourné
+     &true; pour échouer de manière détaillée si le code HTTP retourné
      est supérieur ou égal à <literal>400</literal>. Le comportement par défaut est de retourner
      la page normalement, en ignorant le code.
      Disponible à partir de cURL 7.1.0.
@@ -1215,7 +1215,7 @@
     <para>
      Si on autorise les réponses HTTP/0.9. Par défaut à &false; à partir de cURL 7.66.0;
      avant, c'était &true;.
-     Disponible à partir de PHP 7.3.15 et 7.4.3, respectivement, et cURL 7.64.0
+     Disponible à partir de PHP 7.3.15 et 7.4.3, respectivement, et cURL 7.64.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1252,6 +1252,8 @@
      quelles méthodes il supporte et choisira la meilleure.
      <constant>CURLAUTH_ANY</constant> définit tous les bits. cURL sélectionnera automatiquement
      celle qu'il trouve la plus sécurisée.
+     <constant>CURLAUTH_ANYSAFE</constant> définit tous les bits sauf <constant>CURLAUTH_BASIC</constant>.
+     cURL sélectionnera automatiquement celle qu'il trouve la plus sécurisée.
      Disponible à partir de cURL 7.10.6.
     </para>
    </listitem>
@@ -1263,7 +1265,7 @@
    </term>
    <listitem>
     <para>
-     Définir sur &true; pour réinitialiser la méthode de requête HTTP à <literal>GET</literal>. Comme <literal>GET</literal> est la valeur par défaut, cela n'est nécessaire que si la requête
+     Définir sur &true; pour réinitialiser la méthode de requête HTTP à <literal>GET</literal>. Comme <literal>GET</literal> est la valeur par défaut, cela n'est nécessaire que si la méthode
      de requête a été changée.
      Disponible à partir de cURL 7.8.1.
     </para>
@@ -1359,7 +1361,7 @@
    </term>
    <listitem>
     <para>
-     Accepte un handle de fichier <type>resource</type> vers le fichier à partir duquel le transfert doit être lu lors du téléchargement.
+     Accepte un gestionnaire de fichier <type>resource</type> vers le fichier à partir duquel le transfert doit être lu lors du téléversement.
      Disponible à partir de cURL 7.1.0 et déprécié à partir de cURL 7.9.7.
      Utiliser <constant>CURLOPT_READDATA</constant> à la place.
     </para>
@@ -1669,7 +1671,7 @@
      Le temps maximum d'inactivité autorisé pour une connexion existante pour être considérée pour réutilisation.
      Par défaut, l'âge maximum est défini à <literal>118</literal> secondes.
      Cette option accepte toute valeur pouvant être convertie en un <type>int</type> valide.
-     Disponible à partir de PHP 8.2.0 et cURL 7.65.0
+     Disponible à partir de PHP 8.2.0 et cURL 7.65.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1741,7 +1743,7 @@
      que cette valeur, elle sera plutôt fermée une fois que tous les transferts en cours sont terminés.
      Par défaut à <literal>0</literal> secondes, ce qui signifie que l'option est désactivée et que toutes les connexions sont éligibles pour réutilisation.
      Cette option accepte toute valeur pouvant être convertie en un <type>int</type> valide.
-     Disponible à partir de PHP 8.2.0 et cURL 7.80.0
+     Disponible à partir de PHP 8.2.0 et cURL 7.80.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2140,7 +2142,7 @@
      se connecter au proxy HTTP(S) spécifié dans l'option
      <constant>CURLOPT_PROXY</constant> pour la prochaine requête.
      Le préproxy ne peut être qu'un proxy SOCKS et il doit être préfixé par
-     <literal>[scheme]://</literal> pour spécifier quel type de chaussettes est utilisé.
+     <literal>[scheme]://</literal> pour spécifier quel type de SOCKS est utilisé.
      Une adresse IP numérique IPv6 doit être écrite entre [crochets].
      Définir le préproxy sur un <type>string</type> vide désactive explicitement l'utilisation d'un préproxy.
      Pour spécifier le numéro de port dans ce <type>string</type>, ajoutez <literal>:[port]</literal>
@@ -2228,7 +2230,7 @@
        <term><parameter>bytesToUpload</parameter></term>
        <listitem>
         <simpara>
-         Le nombre total d'octets attendus à télécharger lors de ce transfert.
+         Le nombre total d'octets attendus à téléverser lors de ce transfert.
         </simpara>
        </listitem>
       </varlistentry>
@@ -2236,7 +2238,7 @@
        <term><parameter>bytesUploaded</parameter></term>
        <listitem>
         <simpara>
-         Le nombre d'octets téléchargés jusqu'à présent.
+         Le nombre d'octets téléversés jusqu'à présent.
         </simpara>
        </listitem>
       </varlistentry>
@@ -2730,7 +2732,7 @@
      <constant>CURLOPT_PROXY_CAPATH</constant>.
      Lorsque défini sur &false;, la vérification du certificat du proxy réussit indépendamment.
      &true; par défaut.
-     Disponible à partir de PHP 7.3.0 et cURL 7.52.0
+     Disponible à partir de PHP 7.3.0 et cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2878,7 +2880,7 @@
      Une <type>string</type> avec la(les) plage(s) de données à récupérer au format <literal>X-Y</literal>, où X ou Y sont optionnels. Les transferts HTTP
      supportent également plusieurs intervalles, séparés par des virgules au format
      <literal>X-Y,N-M</literal>.
-     Définir sur &null; pour désactiver la demande d'une plage de bytes.
+     Définir sur &null; pour désactiver la demande d'une plage d'octets.
      Disponible à partir de cURL 7.1.0.
     </para>
    </listitem>
@@ -2915,7 +2917,7 @@
             <term><parameter>curlHandle</parameter></term>
             <listitem>
                 <simpara>
-                    Le handle cURL.
+                    Le gestionnaire cURL.
                 </simpara>
             </listitem>
         </varlistentry>
@@ -2939,8 +2941,8 @@
      </variablelist>
      Le callback doit retourner une <type>string</type>
      d'une longueur égale ou inférieure à la quantité de données demandée,
-     typiquement en la lisant à partir du <type>stream</type> de flux passée. Elle doit
-     renvoyer un <type>string</type> vide pour signaler <literal>la fin du fichier</literal>.
+     typiquement en la lisant à partir du flux <type>resource</type> passé. Il doit
+     retourner une <type>string</type> vide pour signaler <literal>EOF</literal>.
      Disponible à partir de cURL 7.1.0.
     </para>
    </listitem>
@@ -3099,7 +3101,7 @@
    <listitem>
     <para>
      Définit un <type>int</type> avec le numéro CSEQ à émettre pour la prochaine requête RTSP.
-     Utilise si l'application reprend une connexion précédemment interrompue.
+     Utile si l'application reprend une connexion précédemment interrompue.
      Le CSEQ s'incrémente à partir de ce nouveau numéro par la suite.
      Par défaut à <literal>0</literal>.
      Disponible à partir de cURL 7.20.0.
@@ -3141,13 +3143,13 @@
    </term>
    <listitem>
     <para>
-     Définit un <type>string</type> avec la valeur de l'identifiant de la session RTSP courante pour la poignée.
+     Définit un <type>string</type> avec la valeur de l'identifiant de la session RTSP courante pour le gestionnaire.
      Une fois que cette valeur est définie sur une valeur non-&null;,
      cURL renvoie <constant>CURLE_RTSP_SESSION_ERROR</constant>
      si l'identifiant reçu du serveur ne correspond pas.
      Si défini sur &null;, cURL définit automatiquement l'identifiant
      la première fois que le serveur le définit dans une réponse.
-     Par défaut à &null;
+     Par défaut à &null;.
      Disponible à partir de cURL 7.20.0.
     </para>
    </listitem>
@@ -3353,7 +3355,7 @@
        <term><parameter>curlHandle</parameter></term>
        <listitem>
         <simpara>
-         Le handle cURL.
+         Le gestionnaire cURL.
         </simpara>
        </listitem>
       </varlistentry>
@@ -3538,6 +3540,7 @@
     <para>
      L'identifiant du moteur de cryptographie utilisé pour les opérations de
      cryptographie asymétrique.
+     Disponible à partir de cURL 7.9.3.
     </para>
    </listitem>
   </varlistentry>
@@ -4024,7 +4027,7 @@
      La différence entre cette option et <constant>CURLOPT_TIMEVALUE</constant>
      est le type de l'argument. Sur les systèmes où 'long' n'est que de 32 bits de large,
      cette option doit être utilisée pour définir des dates au-delà de l'année 2038.
-     Disponible à partir de PHP 7.3.0 et cURL 7.59.0
+     Disponible à partir de PHP 7.3.0 et cURL 7.59.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4177,7 +4180,7 @@
    </term>
    <listitem>
     <para>
-     &true; pour préparer et effectuer un téléchargement.
+     &true; pour préparer et effectuer un téléversement.
      Par défaut, c'est &false;.
      Disponible à partir de cURL 7.1.0.
     </para>
@@ -4190,8 +4193,8 @@
    </term>
    <listitem>
     <para>
-     Le tampon de taille préférée en octets pour le téléchargement cURL.
-     La taille du tampon de téléchargement par défaut est de 64 kilo-octets. La taille maximale du tampon autorisée à être définie est de 2 méga-octets.
+     Le tampon de taille préférée en octets pour le téléversement cURL.
+     La taille du tampon de téléversement par défaut est de 64 kilo-octets. La taille maximale du tampon autorisée à être définie est de 2 méga-octets.
      La taille minimale du tampon autorisée à être définie est de 16 kilo-octets.
      Disponible à partir de PHP 8.2.0 et cURL 7.62.0.
     </para>
@@ -4391,7 +4394,7 @@
        <term><parameter>bytesToDownload</parameter></term>
        <listitem>
         <simpara>
-         Le nombre total de bytes qui devraient être téléchargés lors de ce transfert.
+         Le nombre total d'octets attendus à télécharger lors de ce transfert.
         </simpara>
        </listitem>
       </varlistentry>
@@ -4399,7 +4402,7 @@
        <term><parameter>bytesDownloaded</parameter></term>
        <listitem>
         <simpara>
-         Le nombre de bytes téléchargés jusqu'à présent.
+         Le nombre d'octets téléchargés jusqu'à présent.
         </simpara>
        </listitem>
       </varlistentry>
@@ -4407,7 +4410,7 @@
        <term><parameter>bytesToUpload</parameter></term>
        <listitem>
         <simpara>
-         Le nombre total de bytes qui devraient être téléchargés lors de ce transfert.
+         Le nombre total d'octets attendus à téléverser lors de ce transfert.
         </simpara>
        </listitem>
       </varlistentry>
@@ -4415,7 +4418,7 @@
        <term><parameter>bytesUploaded</parameter></term>
        <listitem>
         <simpara>
-         Le nombre de bytes téléchargés jusqu'à présent.
+         Le nombre d'octets téléversés jusqu'à présent.
         </simpara>
        </listitem>
       </varlistentry>
@@ -4480,7 +4483,7 @@
        <term><parameter>curlHandle</parameter></term>
        <listitem>
         <simpara>
-         Le handle cURL.
+         Le gestionnaire cURL.
         </simpara>
        </listitem>
       </varlistentry>
@@ -4552,7 +4555,7 @@
        <term><parameter>curlHandle</parameter></term>
        <listitem>
         <simpara>
-         Le handle cURL.
+         Le gestionnaire cURL.
         </simpara>
        </listitem>
       </varlistentry>

--- a/reference/curl/constants_curl_share_setopt.xml
+++ b/reference/curl/constants_curl_share_setopt.xml
@@ -10,7 +10,7 @@
   </term>
   <listitem>
    <simpara>
-    Partage/départage la connexion.
+    Partage/départage le cache de connexion.
     Disponible à partir de PHP 7.3.0 et cURL 7.10.3.
    </simpara>
   </listitem>
@@ -61,7 +61,7 @@
   <listitem>
    <simpara>
     Partage/départage les identifiants de session SSL, réduisant le temps passé
-    sur la poignée SSL lors de la reconnexion au même serveur.
+    sur la poignée de main SSL lors de la reconnexion au même serveur.
     Il est à noter que les identifiants de session SSL sont réutilisés dans le même gestionnaire par défaut.
     Disponible à partir de cURL 7.10.3.
    </simpara>

--- a/reference/curl/curlfile.xml
+++ b/reference/curl/curlfile.xml
@@ -72,7 +72,7 @@
      <term><varname>name</varname></term>
      <listitem>
       <para>
-       Nom du fichier à télécharger.
+       Nom du fichier à téléverser.
       </para>
      </listitem>
     </varlistentry>
@@ -88,7 +88,7 @@
      <term><varname>postname</varname></term>
      <listitem>
       <para>
-       Le nom du fichier dans les données téléchargées (par défaut, la propriété
+       Le nom du fichier dans les données téléversées (par défaut, la propriété
        <varname>name</varname>).
       </para>
      </listitem>

--- a/reference/curl/curlfile/construct.xml
+++ b/reference/curl/curlfile/construct.xml
@@ -25,7 +25,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>posted_filename</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Crée un objet <classname>CURLFile</classname>, utilisé pour télécharger
+   Crée un objet <classname>CURLFile</classname>, utilisé pour téléverser
    un fichier avec <constant>CURLOPT_POSTFIELDS</constant>.
   </para>
  </refsect1>
@@ -37,7 +37,7 @@
     <term><parameter>filename</parameter></term>
     <listitem>
      <para>
-      Chemin vers le fichier à télécharger.
+      Chemin vers le fichier à téléverser.
      </para>
     </listitem>
    </varlistentry>
@@ -53,7 +53,7 @@
     <term><parameter>posted_filename</parameter></term>
     <listitem>
      <para>
-      Nom du fichier à utiliser dans les données téléchargées.
+      Nom du fichier à utiliser dans les données téléversées.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/curl/curlstringfile.xml
+++ b/reference/curl/curlstringfile.xml
@@ -12,9 +12,9 @@
   <section xml:id="curlstringfile.intro">
    &reftitle.intro;
    <para>
-    <classname>CURLStringFile</classname> permet de télécharger un fichier directement à partir d'une variable.
+    <classname>CURLStringFile</classname> permet de téléverser un fichier directement à partir d'une variable.
     Ceci est similaire à <classname>CURLFile</classname>, mais fonctionne avec le contenu du fichier, et non avec le nom du fichier.
-    Cette classe ou <classname>CURLFile</classname> doit être utilisée pour télécharger le contenu du fichier avec <constant>CURLOPT_POSTFIELDS</constant>.
+    Cette classe ou <classname>CURLFile</classname> doit être utilisée pour téléverser le contenu du fichier avec <constant>CURLOPT_POSTFIELDS</constant>.
    </para>
   </section>
 <!-- }}} -->
@@ -61,13 +61,13 @@
     <varlistentry xml:id="curlstringfile.props.data">
      <term><varname>data</varname></term>
      <listitem>
-      <para>Le contenu à télécharger.</para>
+      <para>Le contenu à téléverser.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="curlstringfile.props.postname">
      <term><varname>postname</varname></term>
      <listitem>
-      <para>Le nom du fichier à utiliser dans les données de téléchargement.</para>
+      <para>Le nom du fichier à utiliser dans les données de téléversement.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="curlstringfile.props.mime">

--- a/reference/curl/curlstringfile/construct.xml
+++ b/reference/curl/curlstringfile/construct.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>mime</parameter><initializer>"application/octet-stream"</initializer></methodparam>
   </constructorsynopsis>
   <para>
-   Crée un objet <classname>CURLStringFile</classname>, utilisé pour télécharger un fichier avec <constant>CURLOPT_POSTFIELDS</constant>.
+   Crée un objet <classname>CURLStringFile</classname>, utilisé pour téléverser un fichier avec <constant>CURLOPT_POSTFIELDS</constant>.
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <para>
-      Le contenu à télécharger.
+      Le contenu à téléverser.
      </para>
     </listitem>
    </varlistentry>
@@ -35,7 +35,7 @@
     <term><parameter>postname</parameter></term>
     <listitem>
      <para>
-      Le nom du fichier à utiliser dans les données à télécharger.
+      Le nom du fichier à utiliser dans les données à téléverser.
      </para>
     </listitem>
    </varlistentry>
@@ -64,7 +64,7 @@ var_dump(file_get_contents($_FILES['test_string']['tmp_name']));
 ?>
 */
 
-// Crée un handle cURL
+// Crée un gestionnaire cURL
 $ch = curl_init('http://example.com/upload.php');
 
 // Crée un objet CURLStringFile

--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -21,8 +21,8 @@
   </methodsynopsis>
   &note.resource-migration-8.0-dead-function;
   <para>
-   Ferme une session cURL et libère toutes les ressources
-   réservées. L'identifiant cURL <parameter>handle</parameter>
+   Ferme une session cURL et libère toutes les ressources.
+   Le gestionnaire cURL, <parameter>handle</parameter>,
    est aussi effacé.
   </para>
  </refsect1>

--- a/reference/curl/functions/curl-copy-handle.xml
+++ b/reference/curl/functions/curl-copy-handle.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.curl-copy-handle" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_copy_handle</refname>
-  <refpurpose>Copie une ressource cURL avec toutes ses préférences</refpurpose>
+  <refpurpose>Copie un gestionnaire cURL avec toutes ses préférences</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Copie une ressource cURL, retournant une nouvelle ressource
+   Copie un gestionnaire cURL, retournant un nouveau gestionnaire
    cURL avec les mêmes préférences.
   </para>
  </refsect1>
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une nouvelle ressource cURL, &return.falseforfailure;.
+   Retourne un nouveau gestionnaire cURL, &return.falseforfailure;.
   </para>
  </refsect1>
 
@@ -63,18 +63,18 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Copie d'une ressource cURL</title>
+    <title>Copie d'un gestionnaire cURL</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// crée une nouvelle ressource cURL
+// crée un nouveau gestionnaire cURL
 $ch = curl_init();
 
 // assigne URL et autres options appropriées
 curl_setopt($ch, CURLOPT_URL, 'http://www.example.com/');
 curl_setopt($ch, CURLOPT_HEADER, 0);
 
-// copie la ressource
+// copie le gestionnaire
 $ch2 = curl_copy_handle($ch);
 
 // attrape l'URL (http://www.example.com/) et le passe au navigateur

--- a/reference/curl/functions/curl-exec.xml
+++ b/reference/curl/functions/curl-exec.xml
@@ -17,7 +17,7 @@
    Exécute la session cURL fournie.
   </para>
   <para>
-   Cette fonction doit être appelée après l'initialisation et le
+   Cette fonction devrait être appelée après l'initialisation et le
    paramétrage de la session cURL.
   </para>
  </refsect1>

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une session cURL en cas de succès, &false; si une erreur survient.
+   Retourne un gestionnaire cURL en cas de succès, &false; si une erreur survient.
   </para>
  </refsect1>
 

--- a/reference/curl/functions/curl-multi-add-handle.xml
+++ b/reference/curl/functions/curl-multi-add-handle.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.curl-multi-add-handle" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_add_handle</refname>
-  <refpurpose>Ajoute une ressource cURL à un cURL multiple</refpurpose>
+  <refpurpose>Ajoute un gestionnaire cURL normal à un gestionnaire cURL multiple</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Ajoute la session <parameter>handle</parameter> au gestionnaire multiple
+   Ajoute le gestionnaire <parameter>handle</parameter> au gestionnaire multiple
    <parameter>multi_handle</parameter>
   </para>
  </refsect1>

--- a/reference/curl/functions/curl-multi-close.xml
+++ b/reference/curl/functions/curl-multi-close.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.curl-multi-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_close</refname>
-  <refpurpose>Supprimer tous les handles cURL d'un handle multi</refpurpose>
+  <refpurpose>Supprimer tous les gestionnaires cURL d'un gestionnaire multi</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
    comme si <function>curl_multi_remove_handle</function> avait été appelé pour chacun d'eux.
   </para>
   <para>
-   Avant PHP 8.0.0, cette fonction fermait également la ressource de handle multi cURL, la rendant inutilisable.
+   Antérieur à PHP 8.0.0, cette fonction fermait également la ressource du gestionnaire multi cURL, la rendant inutilisable.
   </para>
  </refsect1>
 

--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -76,7 +76,7 @@
    <example>
     <title>Exemple avec <function>curl_multi_exec</function></title>
     <para>
-     Cet exemple créera des handles cURL pour une liste d'URLs, les ajoutera à un gestionnaire
+     Cet exemple créera des gestionnaires cURL pour une liste d'URLs, les ajoutera à un gestionnaire
      multiple, et les exécutera de façon asynchrone.
     </para>
     <programlisting role="php">

--- a/reference/curl/functions/curl-multi-info-read.xml
+++ b/reference/curl/functions/curl-multi-info-read.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>int</type><parameter role="reference">queued_messages</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Appelle le gestionnaire multiple s'il y a des messages ou des informations
+   Demande au gestionnaire multi s'il y a des messages ou des informations
    issus des transferts individuels. Les messages peuvent inclure des informations
    comme un code erreur du transfert, ou juste le fait que le transfert est terminé.
   </para>

--- a/reference/curl/functions/curl-multi-init.xml
+++ b/reference/curl/functions/curl-multi-init.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.curl-multi-init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_init</refname>
-  <refpurpose>Retourne un nouveau cURL multiple</refpurpose>
+  <refpurpose>Retourne un nouveau gestionnaire cURL multiple</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -45,7 +45,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Cette fonction retourne désormais une instance de <classname>CurlMultiHandle</classname>;
+       En cas de succès, cette fonction retourne désormais une instance de <classname>CurlMultiHandle</classname>;
        auparavant, une <type>resource</type> était retournée.
       </entry>
      </row>

--- a/reference/curl/functions/curl-multi-remove-handle.xml
+++ b/reference/curl/functions/curl-multi-remove-handle.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.curl-multi-remove-handle" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_remove_handle</refname>
-  <refpurpose>Retire un gestionnaire d'un ensemble de handles cURL</refpurpose>
+  <refpurpose>Retire un gestionnaire d'un ensemble de gestionnaires cURL</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/curl/functions/curl-reset.xml
+++ b/reference/curl/functions/curl-reset.xml
@@ -67,7 +67,7 @@ curl_setopt($ch, CURLOPT_USERAGENT, "Mon user-agent de test");
 // Ré-initialise toutes les options définies précédemment
 curl_reset($ch);
 
-// Envoi la requête HTTP
+// Envoie la requête HTTP
 curl_setopt($ch, CURLOPT_URL, 'http://example.com/');
 curl_exec($ch); // le user-agent précédemment défini ne sera pas envoyé, il a été ré-initialisé par la fonction curl_reset
 ?>

--- a/reference/curl/functions/curl-setopt-array.xml
+++ b/reference/curl/functions/curl-setopt-array.xml
@@ -29,7 +29,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       Un tableau spécifiant quelles options à fixer avec leurs valeurs. Les
+       Un &array; spécifiant les options à fixer ainsi que leurs valeurs. Les
        clés devraient être des constantes valides de
        <function>curl_setopt</function> ou leur entier équivalent.
       </para>

--- a/reference/curl/functions/curl-share-close.xml
+++ b/reference/curl/functions/curl-share-close.xml
@@ -74,8 +74,8 @@
    <example>
     <title>Exemple avec <function>curl_share_setopt</function></title>
     <para>
-     Cet exemple va créer un gestionnaire partagé cURL, y ajoute deux gestionnaires
-     cURL, puis, va les exécuter avec les cookies de données partagés.
+     Cet exemple va créer un gestionnaire partagé cURL, y ajouter deux gestionnaires
+     cURL, puis va les exécuter avec les cookies de données partagés.
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/curl/functions/curl-share-setopt.xml
+++ b/reference/curl/functions/curl-share-setopt.xml
@@ -74,8 +74,8 @@
    <example>
     <title>Exemple avec <function>curl_share_setopt</function></title>
     <para>
-     Cet exemple va créer un gestionnaire partagé cURL, y ajoute deux gestionnaires
-     cURL, puis, les exécute avec des cookies de données partagées.
+     Cet exemple va créer un gestionnaire partagé cURL, y ajouter deux gestionnaires
+     cURL, puis les exécuter avec des cookies de données partagées.
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/curl/functions/curl-strerror.xml
+++ b/reference/curl/functions/curl-strerror.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.curl-strerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_strerror</refname>
-  <refpurpose>Retourne la chaîne descriptive du code erreur fourni</refpurpose>
+  <refpurpose>Retourne la chaîne descriptive du code d'erreur fourni</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>int</type><parameter>error_code</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne le message d'erreur décrivant le code erreur fourni.
+   Retourne le message d'erreur décrivant le code d'erreur fourni.
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
     <listitem>
      <para>
       Une constante parmi les constantes
-      <link xlink:href="&url.curl.error;">des codes erreurs cURL</link>.
+      <link xlink:href="&url.curl.error;">des codes d'erreur cURL</link>.
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la description de l'erreur ou &null; pour un code erreur invalide.
+   Retourne la description de l'erreur ou &null; pour un code d'erreur invalide.
   </para>
  </refsect1>
 
@@ -52,7 +52,7 @@
 // Crée un gestionnaire curl avec une erreur dans le protocole de l'URL utilisée
 $ch = curl_init("htp://example.com/");
 
-// Envoi la requête
+// Envoie la requête
 curl_exec($ch);
 
 // Vérifie les erreurs et affiche le message d'erreur
@@ -80,7 +80,7 @@ cURL error (1):
    <simplelist>
     <member><function>curl_errno</function></member>
     <member><function>curl_error</function></member>
-    <member><link xlink:href="&url.curl.error;">Les codes erreurs Curl</link></member>
+    <member><link xlink:href="&url.curl.error;">Les codes d'erreur cURL</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/curl/functions/curl-unescape.xml
+++ b/reference/curl/functions/curl-unescape.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.curl-unescape" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_unescape</refname>
-  <refpurpose>Décode l'URL fourni</refpurpose>
+  <refpurpose>Décode une chaîne encodée URL</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cette fonction décode l'URL fournie.
+   Cette fonction décode la chaîne encodée URL fournie.
   </para>
  </refsect1>
 
@@ -69,7 +69,7 @@
 // Création d'un gestionnaire curl
 $ch = curl_init('http://example.com/redirect.php');
 
-// Envoi une requête HTTP et suit les redirections
+// Envoie une requête HTTP et suit les redirections
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 curl_exec($ch);
 

--- a/reference/curl/functions/curl-version.xml
+++ b/reference/curl/functions/curl-version.xml
@@ -39,7 +39,7 @@
      <tbody>
       <row>
        <entry>version_number</entry>
-       <entry>numéro de version cURL 24 bit</entry>
+       <entry>numéro de version cURL sur 24 bits</entry>
       </row>
       <row>
        <entry>version</entry>
@@ -47,7 +47,7 @@
       </row>
       <row>
        <entry>ssl_version_number</entry>
-       <entry>numéro de version OpenSSL 24 bit</entry>
+       <entry>numéro de version OpenSSL sur 24 bits</entry>
       </row>
       <row>
        <entry>ssl_version</entry>

--- a/reference/datetime/book.xml
+++ b/reference/datetime/book.xml
@@ -13,7 +13,7 @@
   <para>
    <classname>DateTimeImmutable</classname> et les classes associées permettent
    de représenter les informations de date et d'heure. Les objets peuvent être créés en passant les
-   informations de date et d'heure via une chaîne de caractères, ou à partir de l'heure du système 
+   informations de date et d'heure via une chaîne de caractères, ou à partir de l'heure du système
    utilisé.
   </para>
   <para>
@@ -21,12 +21,12 @@
    ainsi que la gestion des fuseaux horaires et des transitions DST.
   </para>
   <para>
-   Les fonctionnalités de date/heure de PHP implémentent le calendrier ISO 8601, 
+   Les fonctionnalités de date/heure de PHP implémentent le calendrier ISO 8601,
    qui est un <link xlink:href="&url.proleptic-gregorian-calendar;">calendrier
-   Grégorien proleptique</link> implémentant les règles actuelles des jours 
-   bissextiles d'avant la mise en place du calendrier grégorien, et inclut 
-   également l'année <literal>0</literal> comme numéro d'année comprise entre 
-   <literal>-1 avant l'ère commune</literal> et <literal>1 de l'ère commune</literal>. 
+   grégorien proleptique</link> implémentant les règles actuelles des jours
+   bissextiles d'avant la mise en place du calendrier grégorien, et inclut
+   également l'année <literal>0</literal> comme numéro d'année comprise entre
+   <literal>-1 avant l'ère commune</literal> et <literal>1 de l'ère commune</literal>.
    Les secondes intercalaires ne sont pas prises en charge.
   </para>
   <para>
@@ -43,18 +43,18 @@
   </note>
  </preface>
  <!-- }}} -->
- 
+
  &reference.datetime.setup;
  &reference.datetime.constants;
  &reference.datetime.examples;
- 
+
  &reference.datetime.datetime;
  &reference.datetime.datetimeimmutable;
  &reference.datetime.datetimeinterface;
  &reference.datetime.datetimezone;
  &reference.datetime.dateinterval;
  &reference.datetime.dateperiod;
- 
+
  &reference.datetime.reference;
  <article xml:id="datetime.error.tree">
   <title>Erreurs et Exceptions Date/Heure</title>

--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -55,7 +55,7 @@
    </term>
    <listitem>
     <simpara>
-     Heures en tant que nombre à point flottant (exemple <literal>8.75</literal>)
+     Heures en tant que nombre à virgule flottante (exemple <literal>8.75</literal>)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/datetime/dateinterval/construct.xml
+++ b/reference/datetime/dateinterval/construct.xml
@@ -98,13 +98,13 @@
         grands aux plus petits. Ainsi, les années doivent
         être présentes avant les mois, les mois avant les jours,
         les jours avant les minutes, etc.
-        Aussi, une année et 4 jours doit être représenté comme
+        Aussi, une année et 4 jours doivent être représentés comme
         <literal>P1Y4D</literal>, et non <literal>P4D1Y</literal>.
        </para>
       </note>
       <para>
        Cette spécification peut également être représentée sous
-       la forme d'une durée. Aussi, une année et 4 jours peut
+       la forme d'une date avec heure. Aussi, une année et 4 jours peuvent
        être <literal>P0001-00-04T00:00:00</literal>.
        Mais les valeurs de ce format ne peuvent pas excéder
        une période donnée (c.-à-d. <literal>25</literal> heures est invalide).

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -111,7 +111,7 @@
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-// Chacun de ces intervalles sont égaux.
+// Chacun de ces intervalles est égal.
 $i = new DateInterval('P1D');
 $i = DateInterval::createFromDateString('1 day');
 

--- a/reference/datetime/dateinvalidoperationexception.xml
+++ b/reference/datetime/dateinvalidoperationexception.xml
@@ -18,7 +18,7 @@
    <para>
     Un exemple d'opération non supportée est l'utilisation d'un objet
     <classname>DateInterval</classname> représentant des spécifications de temps
-    tel que <literal>next weekday</literal>, car aucune déclaration logique inversée ne
+    relatives telles que <literal>next weekday</literal>, car aucune déclaration logique inversée ne
     peut être construite.
    </para>
   </section>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -50,7 +50,7 @@
   <para>
    La classe des objets renvoyés est équivalente à la classe ancêtre
    <classname>DateTimeImmutable</classname> ou <classname>DateTime</classname>
-   fournis par l'objet <parameter>start</parameter>.
+   fournie par l'objet <parameter>start</parameter>.
   </para>
  </refsect1>
 
@@ -129,12 +129,12 @@
       </para>
       <para>
        Peut être configuré à <constant>DatePeriod::EXCLUDE_START_DATE</constant>
-       pour exclure la date de début du jeu de dates de récursion dans
+       pour exclure la date de début du jeu de dates de récurrence dans
        la période.
       </para>
       <para>
        Peut être configuré à <constant>DatePeriod::INCLUDE_END_DATE</constant>
-       pour inclure la date de fin du jeu de dates de récursion dans
+       pour inclure la date de fin du jeu de dates de récurrence dans
        la période.
       </para>
      </listitem>
@@ -243,7 +243,7 @@ $period = new DatePeriod($start, $interval, $end,
                          DatePeriod::EXCLUDE_START_DATE);
 
 // En parcourant l'objet DatePeriod,
-// toutes les dates de récursion pour la période sont affichées.
+// toutes les dates de récurrence pour la période sont affichées.
 // Notez que, dans ce cas, 2012-07-01 ne sera pas affiché.
 foreach ($period as $date) {
     echo $date->format('Y-m-d')."\n";
@@ -302,7 +302,7 @@ Thursday 2022-12-29
  <refsect1 role="notes">
   &reftitle.notes;
   <simpara>
-   Les nombres de répétitions non liés spécifiés dans la section 4.5 
+   Les nombres de répétitions non bornés spécifiés dans la section 4.5
    "Intervalle de temps récurrent" de la norme ISO 8601 ne sont pas 
    supportés, c'est-à-dire ni <literal>"R/..."</literal> comme 
    <parameter>isostr</parameter> ni &null; comme 

--- a/reference/datetime/dateperiod/getenddate.xml
+++ b/reference/datetime/dateperiod/getenddate.xml
@@ -30,8 +30,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &null; si la <classname>DatePeriod</classname> n'a pas de date de fin. 
-   Par exemple, lorsqu'elle est initialisée avec le paramètre <parameter>recurrences</parameter>, 
+   Retourne &null; si la <classname>DatePeriod</classname> n'a pas de date de fin.
+   Par exemple, lorsqu'elle est initialisée avec le paramètre <parameter>recurrences</parameter>,
    ou avec le paramètre <parameter>isostr</parameter> sans date de fin.
   </para>
   <para>

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -104,7 +104,7 @@
       </row>
       <row>
        <entry>7.1.0</entry>
-       <entry>Désormais les microsecondes sont remplis avec leur valeur actuelle. Et non '00000'.</entry>
+       <entry>Désormais les microsecondes sont remplies avec leur valeur actuelle. Et non '00000'.</entry>
       </row>
      </tbody>
     </tgroup>
@@ -173,7 +173,7 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 $date = new DateTimeImmutable('2000-01-01', new DateTimeZone('Pacific/Nauru'));
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
-// date/time courant dans le fuseau horaire de votre ordinateur.
+// date/time courant dans le fuseau horaire par défaut de PHP.
 $date = new DateTimeImmutable();
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
@@ -181,11 +181,11 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 $date = new DateTimeImmutable('now', new DateTimeZone('Pacific/Nauru'));
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
-// Utilisant un horodatage UNIX. Notez que le résultat est dans le fuseau horaire UTC.
+// Utilisant un horodatage UNIX. Il est à noter que le résultat est dans le fuseau horaire UTC.
 $date = new DateTimeImmutable('@946684800');
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
-// Valeurs inexistantes sont reportées.
+// Les valeurs inexistantes sont reportées.
 $date = new DateTimeImmutable('2000-02-30');
 echo $date->format('Y-m-d H:i:sP') . "\n";
 ]]>

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -172,16 +172,18 @@
          <row>
           <entry><literal>X</literal> et <literal>x</literal></entry>
           <entry>
-           Une représentation numérique complète d'une année, 
-           <emphasis>jusqu'à</emphasis> 19 chiffres, éventuellement préfixée par 
+           Une représentation numérique complète d'une année,
+           <emphasis>jusqu'à</emphasis> 19 chiffres, éventuellement préfixée par
            <literal>+</literal> ou <literal>-</literal>
           </entry>
-          <entry>Exemples : <literal>1999</literal> ou <literal>2003</literal></entry>
+          <entry>Exemples : <literal>0055</literal>, <literal>787</literal>,
+           <literal>1999</literal>, <literal>-2003</literal>,
+           <literal>+10191</literal></entry>
          </row>
          <row>
           <entry><literal>Y</literal></entry>
           <entry>Une représentation complète de l'année, <emphasis>jusqu'à</emphasis> 4 chiffres</entry>
-          <entry>Exemples: <literal>25</literal> (comme <literal>0025</literal>),
+          <entry>Exemples : <literal>25</literal> (comme <literal>0025</literal>),
            <literal>787</literal>, <literal>1999</literal>, <literal>2003</literal></entry>
          </row>
          <row>
@@ -251,7 +253,7 @@
           <entry><literal>v</literal></entry>
           <entry>Les millisecondes (jusqu'à 3 chiffres)</entry>
           <entry>
-           Exemple: <literal>12</literal> (<literal>0.12</literal>
+           Exemple : <literal>12</literal> (<literal>0.12</literal>
            secondes), <literal>345</literal> (<literal>0.345</literal>
            secondes)
           </entry>
@@ -302,7 +304,7 @@
          <row>
           <entry><literal> </literal> (espace)</entry>
           <entry>Zéro ou plusieurs espaces, tabulations, caractères NBSP (U+A0), ou NNBSP (U+202F)</entry>
-          <entry>Exemple: <literal>"\t"</literal>, <literal>"  "</literal></entry>
+          <entry>Exemple : <literal>"\t"</literal>, <literal>"  "</literal></entry>
          </row>
          <row>
           <entry><literal>#</literal></entry>
@@ -348,7 +350,8 @@
            seconde ainsi que les informations quant au fuseau horaire) à
            des valeurs similaires à zéro (<literal>0</literal> pour heure,
            minute, seconde et fraction, <literal>1</literal> pour mois et jour,
-           <literal>1970</literal> pour l'année et le fuseau horaire par défaut)
+           <literal>1970</literal> pour l'année et <literal>UTC</literal>
+           pour les informations de fuseau horaire)
           </entry>
           <entry>Sans le caractère <literal>!,</literal> tous les champs seront
           définis à la date et heure courante.</entry>
@@ -474,8 +477,8 @@
       <row>
        <entry>8.2.0</entry>
        <entry>
-        Les spécificateurs <literal>X</literal> et <literal>x</literal>
-        <parameter>format</parameter> ont été ajoutés.
+        Les spécificateurs de <parameter>format</parameter>
+        <literal>X</literal> et <literal>x</literal> ont été ajoutés.
        </entry>
       </row>
       <row>
@@ -585,7 +588,7 @@ Format: i; 2022-06-02 00:15:00
   </example>
 
   <example>
-   <title>Texte de Format avec des caractères littéraux</title>
+   <title>Chaîne de format avec des caractères littéraux</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -616,7 +619,7 @@ Sat, 04 Jun 2022 17:01:37 +0000
    </screen>
    <para>
     Bien que le résultat semble étrange, il est correct, 
-    car les débordements suivants se produisent:
+    car les débordements suivants se produisent :
    </para>
    <orderedlist>
     <listitem>
@@ -664,7 +667,7 @@ Mon, 10 Aug 2020 01:00:00 +0000
    </screen>
    <para>
     Bien que le résultat semble étrange, il est correct, 
-    car les débordements suivants se produisent:
+    car les débordements suivants se produisent :
    </para>
    <orderedlist>
     <listitem>

--- a/reference/datetime/datetimeimmutable/getlasterrors.xml
+++ b/reference/datetime/datetimeimmutable/getlasterrors.xml
@@ -98,11 +98,11 @@ Failed to parse time string (asdfasdf) at position 0 (a): The timezone could not
 ]]>
    </screen>
    <para>
-    Les index 6, et 0 dans la sortie de l'exemple réfèrent à l'index du
+    Les index 6, et 0 dans la sortie de l'exemple font référence à l'index du
     caractère dans la chaîne où l'erreur s'est produite.
    </para>
   </example>
-    <example>
+  <example>
    <title>Détecter les dates invalides</title>
    <programlisting role="php">
 <![CDATA[

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="datetimeimmutable.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setTimestamp</refname>
-  <refpurpose>Définit la date et l'heure basé sur un horodatage Unix</refpurpose>
+  <refpurpose>Définit la date et l'heure basées sur un horodatage Unix</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -94,7 +94,7 @@
           <row>
            <entry><literal>N</literal></entry>
            <entry>Représentation numérique ISO 8601 du jour de la semaine</entry>
-           <entry><literal>1</literal> (pour Lundi) à <literal>7</literal> (pour Dimanche)</entry>
+           <entry><literal>1</literal> (pour lundi) à <literal>7</literal> (pour dimanche)</entry>
           </row>
           <row>
            <entry><literal>S</literal></entry>
@@ -163,7 +163,7 @@
           </row>
           <row>
            <entry><literal>L</literal></entry>
-           <entry>Est ce que l'année est bissextile</entry>
+           <entry>Est-ce que l'année est bissextile</entry>
            <entry><literal>1</literal> si bissextile, <literal>0</literal> sinon.</entry>
           </row>
           <row>
@@ -278,7 +278,7 @@
             Millisecondes. Même note que pour
             <literal>u</literal>.
            </entry>
-           <entry>Exemple: <literal>654</literal></entry>
+           <entry>Exemple : <literal>654</literal></entry>
           </row>
           <row>
            <entry align="center"><emphasis>Fuseau horaire</emphasis></entry>

--- a/reference/datetime/datetimeinterface/getoffset.xml
+++ b/reference/datetime/datetimeinterface/getoffset.xml
@@ -70,7 +70,8 @@ echo $summer->getOffset() . "\n";
 -18000
 -14400
 ]]>
-   </screen>   <para>&style.procedural;</para>
+   </screen>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/datetimezone/getoffset.xml
+++ b/reference/datetime/datetimezone/getoffset.xml
@@ -22,9 +22,9 @@
   </methodsynopsis>
   <para>
    <function>timezone_offset_get</function> retourne le décalage horaire par
-   rapport au GMT pour le paramètre <parameter>datetime</parameter>. Le 
-   décalage GMT est calculé à partir des informations de fuseau horaire 
-   contenues dans l'objet <classname>DateTime</classname>.
+   rapport au GMT pour le paramètre <parameter>datetime</parameter>. Le
+   décalage GMT est calculé à partir des informations de fuseau horaire
+   contenues dans l'objet <classname>DateTimeZone</classname> utilisé.
   </para>
  </refsect1>
 

--- a/reference/datetime/datetimezone/gettransitions.xml
+++ b/reference/datetime/datetimezone/gettransitions.xml
@@ -95,7 +95,7 @@
       <row>
        <entry><literal>isdst</literal></entry>
        <entry><type>bool</type></entry>
-       <entry>Si l'heure d'été est activée</entry>
+       <entry>Indique si l'heure d'été est active</entry>
       </row>
       <row>
        <entry><literal>abbr</literal></entry>

--- a/reference/datetime/datetimezone/listabbreviations.xml
+++ b/reference/datetime/datetimezone/listabbreviations.xml
@@ -22,8 +22,8 @@
   <para>
    La liste des abréviations retournée contient tous les usages historiques
    des abréviations, ce qui peut amener à des entrées correctes, mais
-   confuses. Il y a aussi des conflits, car <literal>PST</literal> est utilisé à la fois dans
-   les États-Unis et les Philippines.
+   confuses. Il y a aussi des conflits, car <literal>PST</literal> est utilisé à la fois aux
+   États-Unis et aux Philippines.
   </para>
   <para>
    La liste que cette fonction retourne n'est par conséquent pas adaptée pour

--- a/reference/datetime/datetimezone/listidentifiers.xml
+++ b/reference/datetime/datetimezone/listidentifiers.xml
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne le &array; des identificateurs des fuseaux horaires.
+   Retourne le &array; des identifiants des fuseaux horaires.
    Seuls les éléments non obsolètes sont retournés. Pour tout obtenir,
    y compris les identifiants de fuseau horaire obsolètes, utiliser
    <literal>DateTimeZone::ALL_WITH_BC</literal> comme valeur pour

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -7,7 +7,7 @@
  &reftitle.examples;
 
  <section xml:id="datetime.examples-arithmetic">
-  <title>Arithmétique avec DateTime </title>
+  <title>Arithmétique avec DateTime</title>
   <para>
    Les exemples suivants montrent quelques pièges de l'arithmétique de DateTime 
    en ce qui concerne les transitions DST et les mois ayant un nombre différent 
@@ -15,7 +15,7 @@
   </para>
   <para>
    <example>
-    <title>DateTimeImmutable::add/sub ajout d'un intervalle de temps écoulé.</title>
+    <title>DateTimeImmutable::add/sub ajout d'un intervalle de temps écoulé</title>
     <simpara>
      Ajouter PT24H au-delà d'une transition DST semblera ajouter 23/25 heures
      (pour la plupart des fuseaux horaires).
@@ -69,8 +69,8 @@ End:   2015-11-02 00:00:00 -05:00
     <title>L'ajout ou la soustraction de dates/heures peut dépasser 
      (en plus ou en moins) des dates</title>
     <simpara>
-     Comme pour 31 Janvier + 1 mois donnera comme résultat 2 Mars (année bisextile) ou
-     3 Mars (année normale).
+     Comme pour 31 janvier + 1 mois donnera comme résultat 2 mars (année bissextile) ou
+     3 mars (année normale).
     </simpara>
     <programlisting role="php">
 <![CDATA[

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -32,9 +32,9 @@
  <orderedlist>
   <listitem>
    <simpara>
-    L'analyseur, permet à chaque unité (année, mois, jour, heure, minute, seconde)
+    L'analyseur permet à chaque unité (année, mois, jour, heure, minute, seconde)
     la plage entière de valeurs. Pour une année c'est juste 4 chiffres, pour un
-    mois c'est 0-12, pour un jour 0-31 et pour l'heure et les minutes c'est 0-59.
+    mois c'est 0-12, pour un jour 0-31, pour une heure c'est 0-24, et pour une minute c'est 0-59.
    </simpara>
   </listitem>
   <listitem>
@@ -226,7 +226,7 @@ object(DateTimeImmutable)#1 (3) {
      </row>
      <row>
       <entry>Heures et minutes, avec méridien</entry>
-      <entry><literal>hh</literal> [.:] <literal>MM</literal> <literal>space</literal>? <literal>méridien</literal></entry>
+      <entry><literal>hh</literal> [.:] <literal>MM</literal> <literal>espace</literal>? <literal>méridien</literal></entry>
       <entry>"4:08 am", "7:19P.M."</entry>
      </row>
      <row>
@@ -236,7 +236,7 @@ object(DateTimeImmutable)#1 (3) {
      </row>
      <row>
       <entry>MS SQL (Heures, minutes, secondes et fraction avec méridien)</entry>
-      <entry><literal>hh</literal> ":" <literal>MM</literal> ":" <literal>II</literal> [.:] [0-9]+ <literal>meridian</literal></entry>
+      <entry><literal>hh</literal> ":" <literal>MM</literal> ":" <literal>II</literal> [.:] [0-9]+ <literal>méridien</literal></entry>
       <entry>"4:08:39:12313am"</entry>
      </row>
     </tbody>
@@ -276,7 +276,7 @@ object(DateTimeImmutable)#1 (3) {
      </row>
      <row>
       <entry>Heures, minutes, secondes et fuseau horaire</entry>
-      <entry>'t'? <literal>HH</literal> [.:] <literal>MM</literal> [.:] <literal>II</literal> <literal>space</literal>? ( <literal>tzcorrection</literal> | <literal>tz</literal> )</entry>
+      <entry>'t'? <literal>HH</literal> [.:] <literal>MM</literal> [.:] <literal>II</literal> <literal>espace</literal>? ( <literal>tzcorrection</literal> | <literal>tz</literal> )</entry>
       <entry>"040837CEST", "T191919-0700"</entry>
      </row>
      <row>
@@ -388,7 +388,7 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <table>
-   <title>Standards Formats</title>
+   <title>Formats standards</title>
    <tgroup cols="2">
     <thead>
      <row>
@@ -857,7 +857,7 @@ object(DateTimeImmutable)#1 (3) {
     est sensible à la casse ; l'on ne peut utiliser que la majuscule "W".
    </para>
    <para>
-    Le "T" dans les formats SOAP, XMRPC et WDDX est sensible à la casse ; utiliser toujours
+    Le "T" dans les formats SOAP, XMLRPC et WDDX est sensible à la casse ; utiliser toujours
     la majuscule "T".
    </para>
    <para>

--- a/reference/datetime/functions/date-parse-from-format.xml
+++ b/reference/datetime/functions/date-parse-from-format.xml
@@ -85,8 +85,8 @@
    <literal>errors</literal>. Le premier indique le nombre 
    d'erreurs. Les clés du tableau <literal>errors</literal> indiquent 
    la position dans le paramètre <parameter>datetime</parameter> où l'erreur
-   s'est produite, avec la valeur de chaîne décrivant l'avertissement 
-   lui-même. Un exemple ci-dessous montre un tel avertissement.
+   s'est produite, avec la valeur de chaîne décrivant l'erreur
+   elle-même. Un exemple ci-dessous montre une telle erreur.
   </para>
   <warning>
    <para>
@@ -231,7 +231,7 @@ foreach ($parsed['errors'] as $position => $message) {
 <![CDATA[
 Errors count: 3
 	On position 15: A two digit hour could not be found
-	On position 19: Data missing
+	On position 19: Not enough data available to satisfy format
 ]]>
     </screen>
    </example>

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -234,7 +234,7 @@ array(16) {
     </screen>
    </example>
    <example>
-    <title><function>date_parse</function> avec des informations abrégées sur le fuseau horaire</title>
+    <title><function>date_parse</function> avec des informations d'identifiant de fuseau horaire</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -333,7 +333,7 @@ array(12) {
   <para>
    <link linkend="datetime.formats.relative">Les formats relatifs</link>
    n'influencent pas les valeurs analysées depuis des formats absolus, mais
-   sont analysées dans l'élément "relatif".
+   sont analysés dans l'élément "relative".
    <example>
     <title>Exemple avec <function>date_parse</function> et des formats relatifs</title>
     <programlisting role="php">
@@ -388,7 +388,7 @@ array(13) {
     int(0)
   }
 }
-)]]>
+]]>
     </screen>
    </example>
   </para>

--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -60,7 +60,7 @@
      <term><literal>sunrise</literal></term>
      <listitem>
       <simpara>
-       L'horodatage du lever du soleil (angle de zenith = 90°35').
+       L'horodatage du lever du soleil (angle de zénith = 90°35').
       </simpara>
      </listitem> 
     </varlistentry>
@@ -68,7 +68,7 @@
      <term><literal>sunset</literal></term>
      <listitem>
       <simpara>
-       L'horodatage du coucher du soleil (angle de zenith = 90°35').
+       L'horodatage du coucher du soleil (angle de zénith = 90°35').
       </simpara>
      </listitem> 
     </varlistentry>
@@ -85,7 +85,7 @@
      <term><literal>civil_twilight_begin</literal></term>
      <listitem>
       <simpara>
-       Le début de l'aube civile (angle de zenith = 96°). Il termine au 
+       Le début de l'aube civile (angle de zénith = 96°). Elle se termine au
        <literal>sunrise</literal>.
       </simpara>
      </listitem> 
@@ -94,7 +94,7 @@
      <term><literal>civil_twilight_end</literal></term>
      <listitem>
       <simpara>
-       La fin du crépuscule civil (angle de zenith = 96°). Elle commence au 
+       La fin du crépuscule civil (angle de zénith = 96°). Elle commence au
        <literal>sunset</literal>.
       </simpara>
      </listitem> 
@@ -103,7 +103,7 @@
      <term><literal>nautical_twilight_begin</literal></term>
      <listitem>
       <simpara>
-       Le début de l'aube nautique (angle de zenith = 102°). Il termine au
+       Le début de l'aube nautique (angle de zénith = 102°). Elle se termine au
        <literal>civil_twilight_begin</literal>.
       </simpara>
      </listitem> 
@@ -112,7 +112,7 @@
      <term><literal>nautical_twilight_end</literal></term>
      <listitem>
        <simpara>
-       La fin du crépuscule nautique (angle de zenith = 102°). Elle commence au
+       La fin du crépuscule nautique (angle de zénith = 102°). Elle commence au
        <literal>civil_twilight_end</literal>.
       </simpara>
      </listitem> 
@@ -121,7 +121,7 @@
      <term><literal>astronomical_twilight_begin</literal></term>
      <listitem>
       <simpara>
-       Le début de l'aube astronomique (angle de zenith = 108°). Il termine au
+       Le début de l'aube astronomique (angle de zénith = 108°). Elle se termine au
        <literal>nautical_twilight_begin</literal>.
       </simpara>
      </listitem> 
@@ -130,7 +130,7 @@
      <term><literal>astronomical_twilight_end</literal></term>
      <listitem>
       <simpara>
-       La fin du crépuscule astronomique (angle de zenith = 108°). Elle commence au
+       La fin du crépuscule astronomique (angle de zénith = 108°). Elle commence au
        <literal>nautical_twilight_end</literal>.
       </simpara>
      </listitem> 
@@ -139,9 +139,9 @@
   </para>
   <para> 
    Les valeurs des éléments du tableau sont soit des
-   timestamps UNIX, &false;, si le soleil est sous le zenith
+   horodatages UNIX, &false;, si le soleil est sous le zénith
    respectif pour la journée entière, ou &true;, si le soleil
-   est au-dessus du zenith respectif pour toute la journée.
+   est au-dessus du zénith respectif pour toute la journée.
   </para>
  </refsect1>
 
@@ -234,7 +234,6 @@ never: sunset
 16:42:48 AKST: nautical_twilight_end
 07:40:47 AKST: astronomical_twilight_begin
 18:03:49 AKST: astronomical_twilight_end
-
 ]]>
     </screen>
    </example>
@@ -242,7 +241,7 @@ never: sunset
 
   <para>
    <example>
-    <title>Soleil de minuit (Tromso, Norvège)</title>
+    <title>Soleil de minuit (Tromsø, Norvège)</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -53,7 +53,7 @@
      <listitem>
       <para>
        <table>
-        <title>Constantes pour le paramètre <parameter>format</parameter></title>
+        <title>Constantes pour le paramètre <parameter>returnFormat</parameter></title>
         <tgroup cols="2">
          <thead>
           <row>
@@ -106,8 +106,8 @@
      <term><parameter>zenith</parameter></term>
      <listitem>
       <para>
-<parameter>zenith</parameter> est l'angle entre le centre du
-       soleil et la ligne perpendiculaire à la surface de la terre. Par défaut 
+       <parameter>zenith</parameter> est l'angle entre le centre du
+       soleil et la ligne perpendiculaire à la surface de la terre. Par défaut
        <link linkend="ini.date.sunrise-zenith">date.sunrise_zenith</link>
        <table>
         <title>Valeurs courantes de l'angle <parameter>zenith</parameter></title>
@@ -121,20 +121,19 @@
          <tbody>
           <row>
            <entry>90°50'</entry>
-           <entry>Levé du soleil: le point où le soleil devient visible.</entry>
+           <entry>Lever du soleil : le point où le soleil devient visible.</entry>
           </row>
           <row>
            <entry>96°</entry>
-           <entry>Crépuscule civil: conventionnellement utilisé pour signifier le début de l'aube.</entry>
+           <entry>Crépuscule civil : conventionnellement utilisé pour signifier le début de l'aube.</entry>
           </row>
           <row>
            <entry>102°</entry>
-           <entry>Crépuscule nautique: le point où l'horizon commence à être visible en mer.</entry>
+           <entry>Crépuscule nautique : le point où l'horizon commence à être visible en mer.</entry>
           </row>
           <row>
            <entry>108°</entry>
-           <entry>Crépuscule astronomique: le point où le soleil commence à être la source de toute illumination.
-</entry>
+           <entry>Crépuscule astronomique : le point où le soleil commence à être la source de toute illumination.</entry>
           </row>
          </tbody>
         </tgroup>
@@ -233,7 +232,7 @@ Mon Dec 20 2004, sunrise time : 08:54
     </screen>
    </example>
    <example>
-    <title>Pas de levé de soleil</title>
+    <title>Pas de lever de soleil</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -91,7 +91,7 @@
      <term><parameter>latitude</parameter></term>
      <listitem>
       <para>
-       Par défaut, c'est le Nord. Passez une valeur négative pour le Sud.
+       Par défaut, c'est le Nord. Une valeur négative doit être passée pour le Sud.
        Voir aussi <link linkend="ini.date.default-latitude">date.default_latitude</link>.
       </para>
      </listitem>
@@ -100,7 +100,7 @@
      <term><parameter>longitude</parameter></term>
      <listitem>
       <para>
-       Par défaut, c'est l'Est. Passez une valeur négative pour l'Ouest.
+       Par défaut, c'est l'Est. Une valeur négative doit être passée pour l'Ouest.
        Voir aussi <link linkend="ini.date.default-longitude">date.default_longitude</link>.
       </para>
      </listitem>
@@ -125,19 +125,19 @@
          <tbody>
           <row>
            <entry>90°50'</entry>
-           <entry>Coucher du soleil: Le point où le soleil devient invisible.</entry>
+           <entry>Coucher du soleil : le point où le soleil devient invisible.</entry>
           </row>
           <row>
            <entry>96°</entry>
-           <entry>Crépuscule civil: conventionnellement utilisé pour signifier la fin du crépuscule.</entry>
+           <entry>Crépuscule civil : conventionnellement utilisé pour signifier la fin du crépuscule.</entry>
           </row>
           <row>
            <entry>102°</entry>
-           <entry>Crépuscule nautique: le point de fin de l'horizon étant visible en mer.</entry>
+           <entry>Crépuscule nautique : le point où l'horizon cesse d'être visible en mer.</entry>
           </row>
           <row>
            <entry>108°</entry>
-           <entry>Crépuscule astronomique: le point où le soleil finit d'être la source de toute illumination.</entry>
+           <entry>Crépuscule astronomique : le point où le soleil cesse d'être la source de toute illumination.</entry>
           </row>
          </tbody>
         </tgroup>
@@ -215,7 +215,7 @@
 <![CDATA[
 <?php
 
-     /* Calcul l'heure du coucher du soleil pour Lisbonne, Portugal
+     /* Calcule l'heure du coucher du soleil pour Lisbonne, Portugal
 Latitude: 38.4 North
 Longitude: 9 West
 Zenith ~= 90

--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -25,8 +25,8 @@
   <warning>
    <para>
     Les horodatages Unix ne gèrent pas les fuseaux horaires. Utiliser
-    la classe <classname>DateTimeImmutable</classname>, et sa méthode de 
-    formatage <methodname>DateTimeInterface::format</methodname> pour 
+    la classe <classname>DateTimeImmutable</classname>, et sa méthode de
+    formatage <methodname>DateTimeInterface::format</methodname> pour
     formater les informations de date/heure avec un fuseau horaire attaché.
    </para>
   </warning>
@@ -44,9 +44,9 @@
      <note>
       <simpara>
        <function>date</function> générera toujours
-       <literal>000000</literal> pour les microsecondes puisqu'il prend un 
+       <literal>000000</literal> pour les microsecondes puisqu'il prend un
        paramètre <type>int</type>, alors que <methodname>DateTimeInterface::format</methodname>
-       prend en charge les microsecondes si un objet de type <interfacename>DateTimeInterface</interfacename>
+       supporte les microsecondes si un objet de type <interfacename>DateTimeInterface</interfacename>
        a été créé avec des microsecondes.
       </simpara>
      </note>
@@ -156,7 +156,7 @@ echo date('l \t\h\e jS');
     <programlisting role="php">
 <![CDATA[
 <?php
-// Aujourd'hui, le 10 Mars 2001, 5:16:18 pm, Fuseau horaire 
+// Aujourd'hui, le 10 mars 2001, 5:16:18 pm, Fuseau horaire
 // Mountain Standard Time (MST)
  
 date_default_timezone_set("America/Phoenix");

--- a/reference/datetime/functions/getdate.xml
+++ b/reference/datetime/functions/getdate.xml
@@ -71,7 +71,7 @@
       <row>
        <entry><literal>"wday"</literal></entry>
        <entry>Représentation numérique du jour de la semaine courante</entry>
-       <entry><literal>0</literal> (pour Dimanche) à <literal>6</literal> (pour Samedi)</entry>
+       <entry><literal>0</literal> (pour dimanche) à <literal>6</literal> (pour samedi)</entry>
       </row>
       <row>
        <entry><literal>"mon"</literal></entry>
@@ -156,6 +156,7 @@ Array
 (
     [seconds] => 40
     [minutes] => 58
+    [hours] => 21
     [mday] => 17
     [wday] => 2
     [mon] => 6

--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -68,7 +68,7 @@
       <para>
        Le nombre de secondes depuis le début de la minute <parameter>minute</parameter>.
        Les valeurs négatives font référence aux secondes de la minute précédente.
-       Les valeurs supérieures à 59 font références aux secondes associées à
+       Les valeurs supérieures à 59 font référence aux secondes associées à
        la(les) minute(s) suivante(s).
       </para>
      </listitem>
@@ -171,7 +171,7 @@ echo "July 1, 2000 is on a " . date("l", gmmktime(0, 0, 0, 7, 1, 2000));
 <![CDATA[
 July 1, 2000 is on a Saturday
 ]]>
-    </screen> 
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/gmstrftime.xml
+++ b/reference/datetime/functions/gmstrftime.xml
@@ -27,7 +27,7 @@
    <function>gmstrftime</function> se comporte exactement comme
    <function>strftime</function> hormis le fait que l'heure utilisée
    est celle de Greenwich (<literal>Greenwich Mean Time</literal>, GMT).
-   Par exemple, dans la zone <literal>Eastern Standard Time</literal> 
+   Par exemple, lorsque la zone <literal>Eastern Standard Time</literal>
    (est des USA) est GMT -0500, la première ligne de l'exemple ci-dessous
    affiche <literal>"Dec 31 1998 20:00:00"</literal>, tandis que
    la seconde affiche <literal>"Jan 01 1999 01:00:00"</literal>.
@@ -63,15 +63,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une &string; formatée suivant le format donné par le
-   paramètre <parameter>timestamp</parameter> ou la date courante
-   si aucun paramètre <parameter>timestamp</parameter> n'est fourni.
+   Retourne une &string; formatée suivant la chaîne de format donnée,
+   en utilisant le paramètre <parameter>timestamp</parameter> donné
+   ou l'heure locale courante si aucun horodatage n'est fourni.
    Les noms des mois, des jours de la semaine et des autres chaînes
    dépendant d'une localisation donnée, respectent la localisation
    courante définie par la fonction <function>setlocale</function>.
    En cas d'échec, &false; est retourné.
-    </para>
-  </refsect1>
+  </para>
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;

--- a/reference/datetime/functions/idate.xml
+++ b/reference/datetime/functions/idate.xml
@@ -68,12 +68,12 @@
            <entry>Minutes</entry>
           </row>
           <row>
-           <entry><literal>I</literal>(i, en majuscule)</entry>
+           <entry><literal>I</literal> (i, en majuscule)</entry>
            <entry>Retourne <literal>1</literal> si l'heure d'été est activée,
             <literal>0</literal> sinon</entry>
           </row>
           <row>
-           <entry><literal>L</literal>(l, en majuscule)</entry>
+           <entry><literal>L</literal> (l, en majuscule)</entry>
            <entry>Retourne <literal>1</literal> pour une année bissextile,
             <literal>0</literal> sinon</entry>
           </row>
@@ -98,21 +98,21 @@
           </row>
           <row>
            <entry><literal>t</literal></entry>
-           <entry>Jour du mois courant</entry>
+           <entry>Nombre de jours dans le mois courant</entry>
           </row>
           <row>
            <entry><literal>U</literal></entry>
-           <entry>Secondes depuis l'époque Unix - 1 Janvier 1970 00:00:00 UTC -
+           <entry>Secondes depuis l'époque Unix - 1 janvier 1970 00:00:00 UTC -
             c'est la même chose que la fonction <function>time</function></entry>
           </row>
           <row>
            <entry><literal>w</literal></entry>
-           <entry>Jour de la semaine (<literal>0</literal> pour Dimanche)</entry>
+           <entry>Jour de la semaine (<literal>0</literal> pour dimanche)</entry>
           </row>
           <row>
            <entry><literal>W</literal></entry>
            <entry>Le numéro de semaine de l'année ; selon l'ISO-8601, les semaines débutent
-            le Lundi</entry>
+            le lundi</entry>
           </row>
           <row>
            <entry><literal>y</literal></entry>

--- a/reference/datetime/functions/localtime.xml
+++ b/reference/datetime/functions/localtime.xml
@@ -49,7 +49,7 @@
    Si <parameter>associative</parameter> est défini à &true; alors
    <function>localtime</function> retourne un tableau associatif contenant
    les éléments de la structure retournée par l'appel de la
-   fonction localtime de C
+   fonction localtime de C.
    Les clés du tableau associatif sont les suivantes :
   </para>
   <para>

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -47,7 +47,7 @@
   <para>
    Par défaut, <function>microtime</function> retourne une &string; au
    format "msec sec", où <literal>sec</literal> est le nombre de secondes
-   depuis l'époque Unix (1 Janvier 1970, 00:00:00 GMT),
+   depuis l'époque Unix (1 janvier 1970, 00:00:00 GMT),
    et <literal>msec</literal> est le nombre de microsecondes qui se sont écoulées
    depuis <literal>sec</literal>, exprimé en secondes sous forme de fraction 
    décimale.

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -24,7 +24,7 @@
    <function>mktime</function> retourne un horodatage UNIX
    correspondant aux arguments fournis. Cet horodatage est un
    entier long, contenant le nombre de secondes entre le début
-   de l'époque UNIX (1er Janvier 1970 00:00:00 GMT) et le temps
+   de l'époque UNIX (1er janvier 1970 00:00:00 GMT) et le temps
    spécifié.
   </para>
   <para>
@@ -58,8 +58,8 @@
       <para>
        Le nombre d'heures depuis le début de la journée fixée par les paramètres
        <parameter>month</parameter>, <parameter>day</parameter> et <parameter>year</parameter>.
-       Les valeurs négatives font références aux heures avant minuit du jour en question.
-       Les valeurs supérieures à 23 font références aux heures associées pour le(s)
+       Les valeurs négatives font référence aux heures avant minuit du jour en question.
+       Les valeurs supérieures à 23 font référence aux heures associées pour le(s)
        jour(s) suivant(s).
       </para>
      </listitem>
@@ -69,8 +69,8 @@
      <listitem>
       <para>
        Le nombre de minutes depuis le début de l'heure <parameter>hour</parameter>.
-       Les valeurs négatives font références aux minutes de l'heure précédente.
-       Les valeurs supérieures à 59 font références aux minutes associées
+       Les valeurs négatives font référence aux minutes de l'heure précédente.
+       Les valeurs supérieures à 59 font référence aux minutes associées
        pour l'(les) heure(s) suivante(s).
       </para>
      </listitem>
@@ -80,8 +80,8 @@
      <listitem>
       <para>
        Le nombre de secondes depuis le début de la minute <parameter>minute</parameter>.
-       Les valeurs négatives font références aux secondes de la minute précédente.
-       Les valeurs supérieures à 59 font références aux secondes associées à
+       Les valeurs négatives font référence aux secondes de la minute précédente.
+       Les valeurs supérieures à 59 font référence aux secondes associées à
        la(les) minute(s) suivante(s).
       </para>
      </listitem>
@@ -91,11 +91,11 @@
      <listitem>
       <para>
        Le nombre de mois depuis la fin de l'année précédente.
-       Les valeurs comprises entre 1 et 12 font références aux mois
+       Les valeurs comprises entre 1 et 12 font référence aux mois
        du calendrier normal de l'année en question. Les valeurs inférieures à
-       1 (y compris les valeurs négatives) font références aux mois de l'année
+       1 (y compris les valeurs négatives) font référence aux mois de l'année
        précédente dans l'ordre inverse, aussi, 0 correspond à décembre, -1 à novembre, etc.
-       Les valeurs supérieures à 12 font références au mois correspondant dans l'(les) année(s)
+       Les valeurs supérieures à 12 font référence au mois correspondant dans l'(les) année(s)
        suivante(s).
       </para>
      </listitem>
@@ -105,11 +105,11 @@
      <listitem>
       <para>
        Le nombre de jours depuis la fin du mois précédent. Les valeurs comprises
-       entre 1 et 28, 29, 30, 31 (suivant le mois) font références aux jours normaux
+       entre 1 et 28, 29, 30, 31 (suivant le mois) font référence aux jours normaux
        dans le mois courant. Les valeurs inférieures à 1 (y compris les valeurs négatives)
-       font références aux jours du mois précédent, aussi, 0 correspond au dernier jour du
+       font référence aux jours du mois précédent, aussi, 0 correspond au dernier jour du
        mois précédent, -1, le jour d'avant, etc. Les valeurs supérieures au nombre
-       de jours du mois courant font références aux jours correspondants du(des) mois suivant(s).
+       de jours du mois courant font référence aux jours correspondants du(des) mois suivant(s).
       </para>
      </listitem>
     </varlistentry>
@@ -120,7 +120,7 @@
        L'année, peut être sur deux ou quatre chiffres, avec des valeurs
        allant de 0 à 69, correspondant aux valeurs 2000 à 2069 et 70 à 100,
        correspondant aux valeurs 1970 à 2000. Sur les systèmes où time_t
-       un entier signé sur 32bits, ce qui est le plus courant de nos jours,
+       est un entier signé sur 32bits, ce qui est le plus courant de nos jours,
        la période valide pour <parameter>year</parameter> est
        quelque part près de 1901 et 2038.
       </para>
@@ -270,7 +270,7 @@ print date('c', $nextyear) . "\n";
      Le dernier jour d'un mois peut être décrit comme
      le jour "0" du mois suivant, et non pas le jour -1. Les deux
      exemples suivants vont donner :
-     "Le dernier jour de Février 2000 est: 29".
+     "Le dernier jour de février 2000 est : 29".
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -25,8 +25,8 @@
   </methodsynopsis>
   <para>
    Formate une date et/ou une heure suivant la localisation locale. Les noms
-   des mois, des jours de la semaine mais aussi d'autres chaînes dépendant
-   de la location, respecteront la localisation courante définie par la fonction
+   des mois, des jours de la semaine mais aussi d'autres chaînes dépendantes
+   de la langue, respecteront la localisation courante définie par la fonction
    <function>setlocale</function>.
   </para>
   <warning>
@@ -38,7 +38,7 @@
     début de l'époque Unix. Cela signifie que  
     <literal>%e</literal>, <literal>%T</literal>, <literal>%R</literal> et <literal>%D</literal> 
     (et peut-être d'autres) et les dates antérieures au
-    <literal>1er Janvier 1970</literal> ne fonctionneront pas sous Windows,
+    <literal>1er janvier 1970</literal> ne fonctionneront pas sous Windows,
     sur certaines distributions de Linux, et sur certains systèmes d'exploitation.
     Pour Windows, une liste complète des options de conversion est disponible
     sur le <link xlink:href="&url.strftime.win32;">site de <acronym>MSDN</acronym></link>.
@@ -101,12 +101,12 @@
           <row>
            <entry><literal>%u</literal></entry>
            <entry>Représentation ISO-8601 du jour de la semaine</entry>
-           <entry>De <literal>1</literal> (pour Lundi) à <literal>7</literal> (pour Dimanche)</entry>
+           <entry>De <literal>1</literal> (pour lundi) à <literal>7</literal> (pour dimanche)</entry>
           </row>
           <row>
            <entry><literal>%w</literal></entry>
            <entry>Représentation numérique du jour de la semaine</entry>
-           <entry>De <literal>0</literal> (pour Dimanche) à <literal>6</literal> (pour Samedi)</entry>
+           <entry>De <literal>0</literal> (pour dimanche) à <literal>6</literal> (pour samedi)</entry>
           </row>
           <row>
            <entry align="center"><emphasis>Semaine</emphasis></entry>
@@ -116,23 +116,23 @@
           <row>
            <entry><literal>%U</literal></entry>
            <entry>Numéro de la semaine de l'année donnée, en commençant par le premier
-            Lundi comme première semaine</entry>
+            lundi comme première semaine</entry>
            <entry><literal>13</literal> (pour la 13ème semaine pleine de l'année)</entry>
           </row>
           <row>
            <entry><literal>%V</literal></entry>
            <entry>Numéro de la semaine de l'année, suivant la norme ISO-8601:1988,
             en commençant comme première semaine, la semaine de l'année contenant au moins
-            4 jours, et où Lundi est le début de la semaine</entry>
+            4 jours, et où lundi est le début de la semaine</entry>
            <entry>De <literal>01</literal> à <literal>53</literal> (où 53
             compte comme semaine de chevauchement)</entry>
           </row>
           <row>
            <entry><literal>%W</literal></entry>
            <entry>Une représentation numérique de la semaine de l'année, en commençant
-            par le premier Lundi de la première semaine</entry>
+            par le premier lundi de la première semaine</entry>
            <entry><literal>46</literal> (pour la 46ème semaine de la semaine commençant
-            par un Lundi)</entry>
+            par un lundi)</entry>
           </row>
           <row>
            <entry align="center"><emphasis>Mois</emphasis></entry>
@@ -157,7 +157,7 @@
           <row>
            <entry><literal>%m</literal></entry>
            <entry>Mois, sur 2 chiffres</entry>
-           <entry>De <literal>01</literal> (pour Janvier) à <literal>12</literal> (pour Décembre)</entry>
+           <entry>De <literal>01</literal> (pour janvier) à <literal>12</literal> (pour décembre)</entry>
           </row>
           <row>
            <entry align="center"><emphasis>Année</emphasis></entry>
@@ -177,7 +177,7 @@
           <row>
            <entry><literal>%G</literal></entry>
            <entry>La version complète à quatre chiffres de %g</entry>
-           <entry>Exemple : <literal>2009</literal> pour la semaine du 3 janvier 2009</entry>
+           <entry>Exemple : <literal>2008</literal> pour la semaine du 3 janvier 2009</entry>
           </row>
           <row>
            <entry><literal>%y</literal></entry>
@@ -287,7 +287,7 @@
           <row>
            <entry><literal>%c</literal></entry>
            <entry>Date et heure préférées, basées sur la locale</entry>
-           <entry>Exemple : <literal>Tue Feb 5 00:45:10 2009</literal> pour
+           <entry>Exemple : <literal>Tue Feb  5 00:45:10 2009</literal> pour
             le 5 février 2009 à 12:45:10 AM</entry>
           </row>
           <row>
@@ -340,7 +340,7 @@
       <warning>
        <simpara>
         Contrairement à la norme <literal>ISO-9899:1999</literal>, Sun Solaris
-        commence avec le Dimanche à 1. Aussi, le format <literal>%u</literal> 
+        commence avec le dimanche à 1. Aussi, le format <literal>%u</literal>
         ne fonctionnera pas tel que décrit dans ce manuel.
        </simpara>
       </warning>
@@ -381,8 +381,11 @@
    Retourne une &string; formatée suivant le paramètre <parameter>format</parameter>
    donné, en utilisant le paramètre <parameter>timestamp</parameter> ou la date locale
    courante si aucun timestamp n'est fourni. Les noms des mois, des jours de la
-   semaine mais aussi d'autres chaînes dépendant de la location, respecteront
+   semaine mais aussi d'autres chaînes dépendantes de la langue, respecteront
    la localisation courante définie par la fonction <function>setlocale</function>.
+   La fonction retourne &false; si <parameter>format</parameter> est vide, contient
+   des spécificateurs de conversion non supportés, ou si la longueur de la chaîne
+   retournée serait supérieure à <literal>4095</literal>.
   </para>
  </refsect1>
  
@@ -547,17 +550,17 @@ $strftimeFormats = array(
     'R' => 'Identique à "%H:%M"',
     'S' => 'Une représentation sur 2 chiffres des secondes',
     'T' => 'Identique à "%H:%M:%S"',
-    'U' => 'Numéro de la semaine pour l\'année courante, en commençant par le premier Dimanche comme première semaine',
-    'V'  => 'ISO-8601:1988 numéro de la semaine de l\'année courante, commençant par la première semaine de l\'année avec au moins 4 jours de semaine, avec le Lundi comme début de semaine',
-    'W' => 'Une représentation numérique de la semaine de l\'année, en commençant par le premier Lundi comme première semaine',
+    'U' => 'Numéro de la semaine pour l\'année courante, en commençant par le premier dimanche comme première semaine',
+    'V'  => 'ISO-8601:1988 numéro de la semaine de l\'année courante, commençant par la première semaine de l\'année avec au moins 4 jours de semaine, avec le lundi comme début de semaine',
+    'W' => 'Une représentation numérique de la semaine de l\'année, en commençant par le premier lundi comme première semaine',
     'X' => 'Représentation préférée pour l\'heure, basée sur la locale, sans la date',
     'Y' => 'Une représentation sur 4 chiffres de l\'année',
-    'Z' => 'L\'abréviation du décalage horaire, non fournie par %z (dépend sur système d\'exploitation)',
+    'Z' => 'L\'abréviation du décalage horaire, non fournie par %z (dépend du système d\'exploitation)',
     'a' => 'L\'abréviation de la représentation textuelle du jour',
     'b' => 'L\'abréviation du nom du mois, basée sur la locale',
     'c' => 'Timestamp préféré basé sur la locale',
     'd' => 'Jour du mois sur 2 chiffres (avec le zéro initial)',
-    'e' => 'Jour du mois, avec un espace précédent un seul chiffre',
+    'e' => 'Jour du mois, avec un espace précédant un seul chiffre',
     'f' => '',
     'g' => 'Une représentation sur 2 chiffres de l\'année au format ISO-8601:1988 (voir %V)',
     'h' => 'Abréviation du nom du mois, basée sur la locale (alias de %b)',
@@ -615,11 +618,11 @@ Format connu : 'H' = '11'                ( Une représentation sur 2 chiffres de
 Format connu : 'I' = '11'                ( Une représentation sur 2 chiffres de l'heure au format 12-heures )
 Format connu : 'M' = '24'                ( Une représentation sur 2 chiffres des minutes )
 Format connu : 'S' = '44'                ( Une représentation sur 2 chiffres des secondes )
-Format connu : 'U' = '48'                ( Numéro de la semaine pour l'année courante, en commençant par le premier Dimanche comme première semaine )
-Format connu : 'W' = '48'                ( Une représentation numérique de la semaine de l'année, en commençant par le premier Lundi comme première semaine )
+Format connu : 'U' = '48'                ( Numéro de la semaine pour l'année courante, en commençant par le premier dimanche comme première semaine )
+Format connu : 'W' = '48'                ( Une représentation numérique de la semaine de l'année, en commençant par le premier lundi comme première semaine )
 Format connu : 'X' = '11:24:44'          ( Représentation préférée pour l'heure, basée sur la locale, sans la date )
 Format connu : 'Y' = '2010'              ( Une représentation sur 4 chiffres de l'année )
-Format connu : 'Z' = 'GMT Standard Time' ( L'abréviation du décalage horaire, non fournie par %z (dépend sur système d'exploitation )
+Format connu : 'Z' = 'GMT Standard Time' ( L'abréviation du décalage horaire, non fournie par %z (dépend du système d'exploitation) )
 Format connu : 'a' = 'Fri'               ( L'abréviation de la représentation textuelle du jour )
 Format connu : 'b' = 'Dec'               ( L'abréviation du nom du mois, basée sur la locale )
 Format connu : 'c' = '12/03/10 11:24:44' ( Timestamp préféré basé sur la locale )
@@ -646,8 +649,8 @@ Format inconnu : 'P'                       ( "am" ou "pm" (en minuscule) basé s
 Format inconnu : 'Q'
 Format inconnu : 'R'                       ( Identique à "%H:%M" )
 Format inconnu : 'T'                       ( Identique à "%H:%M:%S" )
-Format inconnu : 'V'                       ( ISO-8601:1988 numéro de la semaine de l'année courante, commençant par la première semaine de l'année avec au moins 4 jours de semaine, avec le Lundi comme début de semaine )
-Format inconnu : 'e'                       ( Jour du mois, avec un espace précédent un seul chiffre )
+Format inconnu : 'V'                       ( ISO-8601:1988 numéro de la semaine de l'année courante, commençant par la première semaine de l'année avec au moins 4 jours de semaine, avec le lundi comme début de semaine )
+Format inconnu : 'e'                       ( Jour du mois, avec un espace précédant un seul chiffre )
 Format inconnu : 'f'
 Format inconnu : 'g'                       ( Une représentation sur 2 chiffres de l'année au format ISO-8601:1988 (voir %V) )
 Format inconnu : 'h'                       ( Abréviation du nom du mois, basée sur la locale (alias de %b) )

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -15,9 +15,9 @@
   </methodsynopsis>
   <simpara>
    La fonction <function>strtotime</function> essaye de lire une
-   date au format anglais fournie par le paramètre <parameter>time</parameter>,
+   date au format anglais fournie par le paramètre <parameter>datetime</parameter>,
    et de la transformer en timestamp Unix (le nombre de secondes depuis
-   le 1er Janvier 1970 à 00:00:00 UTC), relativement au timestamp
+   le 1er janvier 1970 à 00:00:00 UTC), relativement au timestamp
    <parameter>baseTimestamp</parameter>, ou à la date courante si ce dernier
    est omis. L'analyse de la chaîne de date est définie dans 
    <link linkend="datetime.formats">les formats de date et d'heure</link> 
@@ -165,7 +165,7 @@ if (($timestamp = strtotime($str)) === false) {
   <note>
    <para>
     L'intervalle de validité d'un timestamp va du 
-    Vendredi 13 Décembre 1901 20:45:54 UTC au Mardi 19 Janvier 2038 03:14:07 UTC.
+    vendredi 13 décembre 1901 20:45:54 UTC au mardi 19 janvier 2038 03:14:07 UTC.
     (Cela correspond aux dates maximales et minimales pour un
     entier de 32 bits signé).
    </para>

--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -22,7 +22,7 @@
    <para>
     Les horodatages Unix ne contiennent aucune information concernant le fuseau horaire local.
     Il est recommandé d'utiliser la classe <classname>DateTimeImmutable</classname> pour manipuler
-    les informations relatives à la date et à l'heure afin d'éviter les écueils liés aux seuls timestamps Unix.
+    les informations relatives à la date et à l'heure afin d'éviter les écueils liés aux seuls horodatages Unix.
    </para>
   </note>
  </refsect1>

--- a/reference/datetime/functions/timezone-name-from-abbr.xml
+++ b/reference/datetime/functions/timezone-name-from-abbr.xml
@@ -32,7 +32,7 @@
      <term><parameter>utcOffset</parameter></term>
      <listitem>
       <para>
-       Décalage à partir du GMT en seconde. La valeur par défaut est -1 ce qui
+       Décalage à partir du GMT en secondes. La valeur par défaut est -1 ce qui
        signifie que le premier fuseau horaire trouvé correspondant à
        <parameter>abbr</parameter> est retourné.
        Autrement, le décalage exact est recherché et seulement s'il n'est pas

--- a/reference/datetime/functions/timezone-version-get.xml
+++ b/reference/datetime/functions/timezone-version-get.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une &string;. au format <literal>YYYY.increment</literal>, 
+   Retourne une &string; au format <literal>YYYY.increment</literal>,
    tel que <literal>2022.2</literal>.
   </para>
   <para>
@@ -35,7 +35,7 @@
    (par exemple, elle n'affiche pas l'année en cours), il est possible de mettre à jour 
    les informations de fuseau horaire en mettant à jour la version de PHP ou 
    en installant le package PECL <link xlink:href="&url.pecl.package;timezonedb">
-   timezonedb</link> PECL package.
+   timezonedb</link>.
   </para>
   <para>
    Certaines distributions Linux corrigent le support date/heure de PHP pour 

--- a/reference/datetime/ini.xml
+++ b/reference/datetime/ini.xml
@@ -96,7 +96,7 @@
     </term>
     <listitem>
      <para>
-      L'heure de lever du soleil par défaut.
+      L'angle de zénith du lever du soleil par défaut.
      </para>
      <para>
       La valeur par défaut est 90°50'. Les 50' supplémentaires
@@ -113,7 +113,7 @@
     </term>
     <listitem>
      <para>
-      L'heure du coucher du soleil par défaut.
+      L'angle de zénith du coucher du soleil par défaut.
      </para>
     </listitem>
    </varlistentry>
@@ -125,11 +125,11 @@
     </term>
     <listitem>
      <para>
-      Le décalage horaire par défaut utilisé par toutes les fonctions date/heure.
-      L'ordre des décalages horaires utilisés si aucun n'est spécifié est
+      Le fuseau horaire par défaut utilisé par toutes les fonctions date/heure.
+      L'ordre des fuseaux horaires utilisés si aucun n'est spécifié est
       explicitement décrit dans la page de documentation sur la fonction
       <function>date_default_timezone_get</function>.
-      Voir <xref linkend="timezones"/> pour une liste complète des décalages
+      Voir <xref linkend="timezones"/> pour une liste complète des fuseaux
       horaires supportés.
      </para>
     </listitem>

--- a/reference/dba/dba.connection.xml
+++ b/reference/dba/dba.connection.xml
@@ -20,16 +20,12 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <packagesynopsis>
-    <package>Dba</package>
-
-    <classsynopsis class="class">
-     <ooclass>
-      <modifier>final</modifier>
-      <classname>Connection</classname>
-     </ooclass>
-    </classsynopsis>
-   </packagesynopsis>
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Dba\Connection</classname>
+    </ooclass>
+   </classsynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/dba/functions/dba-handlers.xml
+++ b/reference/dba/functions/dba-handlers.xml
@@ -35,16 +35,16 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un tableau de gestionnaires disponibles. Si
+   Retourne un tableau des gestionnaires de base de données. Si
    <parameter>full_info</parameter> est défini à &true;, le tableau sera
-   associé avec les noms des gestionnaires en tant que clés, et les informations
-   en tant que valeurs. Sinon, le résultat sera un tableau indexé par les noms
+   associatif avec les noms des gestionnaires en tant que clés, et les informations
+   de version en tant que valeurs. Sinon, le résultat sera un tableau indexé par les noms
    des gestionnaires.
   </simpara>
   <note>
    <simpara>
-    Lorsque la bibliothèque interne cdb est utilisée, il faut voir avec
-    <literal>cdb</literal> et <literal>cdb_make</literal>.
+    Lorsque la bibliothèque interne cdb est utilisée, les gestionnaires
+    <literal>cdb</literal> et <literal>cdb_make</literal> apparaîtront.
    </simpara>
   </note>
  </refsect1>

--- a/reference/dba/functions/dba-open.xml
+++ b/reference/dba/functions/dba-open.xml
@@ -164,8 +164,8 @@
      <simpara>
       Le nom du <link linkend="dba.requirements">gestionnaire</link>
       qui doit être utilisé pour accéder à <parameter>path</parameter>.
-      C'est passé à tous les paramètres facultatifs donnés à
-      <function>dba_open</function> et peut agir au nom d'eux.
+      Tous les paramètres facultatifs donnés à
+      <function>dba_open</function> lui sont passés et il peut agir en leur nom.
       Si le paramètre <parameter>handler</parameter> est &null;,
       alors le gestionnaire par défaut est invoqué.
      </simpara>
@@ -185,16 +185,6 @@
       <literal>gdbm</literal>,
       <literal>ndbm</literal> et <literal>lmdb</literal> prennent en charge le
       paramètre <parameter>permission</parameter>.
-     </simpara>
-     <simpara>
-      Le pilote <literal>lmdb</literal> supporte deux paramètres additionnels.
-      Le premier permet de définir le <literal>$filemode</literal>
-      (voir description ci-dessus), et le second permet de définir la
-      <literal>$mapsize</literal>, dont la valeur devrait être un multiple de
-      la taille de page du système d'exploitation, ou zéro pour utiliser la
-      mapsize par défaut.
-      Le paramètre <literal>$mapsize</literal> est supporté à partir de
-      PHP 7.3.14 et 7.4.2, respectivement.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/dba/functions/dba-popen.xml
+++ b/reference/dba/functions/dba-popen.xml
@@ -22,7 +22,7 @@
   <simpara>
    <function>dba_popen</function> établit une connexion persistante
    à la base repérée par <parameter>path</parameter>
-   avec le mode <parameter>mode</parameter>, en utilisant l'identifiant
+   avec le mode <parameter>mode</parameter>, en utilisant le gestionnaire
    <parameter>handler</parameter>.
   </simpara>
  </refsect1>

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -125,7 +125,7 @@
         fonctions <function>dba_firstkey</function> et <function>dba_nextkey</function>
         retournent une chaîne de caractères représentant la clé, il y a une
         nouvelle fonction, <function>dba_key_split</function>,
-        qui permet de convertir les clés en tableaux sans déperdition.
+        qui permet de convertir les clés en tableaux sans perdre &false;.
        </entry>
       </row>
 
@@ -223,7 +223,7 @@
  <section xml:id="dba.resources">
   &reftitle.resources;
   <simpara>
-   Antérieur à PHP 8.4.0, la plupart des fonctions DBA opèrent sur ou renvoient des ressources (par exemple, <function>dba_open</function>
+   Antérieurement à PHP 8.4.0, la plupart des fonctions DBA opèrent sur ou renvoient des ressources (par exemple, <function>dba_open</function>
    renvoie un identifiant de lien DBA positif requis par la plupart des fonctions DBA).
   </simpara>
  </section>

--- a/reference/dbase/functions/dbase-delete-record.xml
+++ b/reference/dbase/functions/dbase-delete-record.xml
@@ -17,9 +17,7 @@
    <methodparam><type>int</type><parameter>number</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dbase_delete_record</function> marque l'enregistrement
-   <parameter>record</parameter> pour l'effacement, dans la base
-   <parameter>dbase_identifier</parameter>.
+   Marque l'enregistrement donné pour être effacé de la base de données.
   </para>
   <note>
    <para>

--- a/reference/dbase/functions/dbase-get-header-info.xml
+++ b/reference/dbase/functions/dbase-get-header-info.xml
@@ -100,7 +100,7 @@
    </variablelist>
   </para>
   <para>
-   Si les informations d'en-têtes de la base de données ne peuvent pas
+   Si les informations d'en-tête de la base de données ne peuvent pas
    être lues, &false; est retourné.
   </para>
  </refsect1>
@@ -132,7 +132,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Affiche les informations d'en-têtes pour un fichier de base de données dBase</title>
+    <title>Affiche les informations d'en-tête pour un fichier de base de données dBase</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/dbase/functions/dbase-get-record-with-names.xml
+++ b/reference/dbase/functions/dbase-get-record-with-names.xml
@@ -94,7 +94,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Ouverture en mode lecture seul
+// Ouverture en mode lecture seule
 $db = dbase_open('/tmp/test.dbf', 0);
                    
 if ($db) {

--- a/reference/dbase/functions/dbase-get-record.xml
+++ b/reference/dbase/functions/dbase-get-record.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    <function>dbase_get_record</function> retourne les données de
-   l'enregistrement <parameter>record</parameter> dans un tableau.
+   l'enregistrement <parameter>number</parameter> dans un tableau.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/dbase/functions/dbase-numfields.xml
+++ b/reference/dbase/functions/dbase-numfields.xml
@@ -15,8 +15,7 @@
    <methodparam><type>resource</type><parameter>database</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dbase_numfields</function> retourne le nombre de champs (colonnes)
-   de la base de données <parameter>dbase_identifier</parameter>.
+   Retourne le nombre de champs (colonnes) de la base de données spécifiée.
   </para>
   <note>
    <para>

--- a/reference/dbase/functions/dbase-pack.xml
+++ b/reference/dbase/functions/dbase-pack.xml
@@ -15,12 +15,11 @@
    <methodparam><type>resource</type><parameter>database</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dbase_pack</function> compacte la base de données
-   <parameter>dbase_identifier</parameter> (effacement définitif
-   de tous les enregistrements marqués pour l'effacement
-   à l'aide de la fonction <function>dbase_delete_record</function>).
+   Compacte la base de données spécifiée en supprimant définitivement tous
+   les enregistrements marqués pour l'effacement à l'aide de
+   <function>dbase_delete_record</function>.
    Il est à noter que le fichier sera tronqué après un compactage réussi
-   (contrairement à la commande PACK de dBASE III). 
+   (contrairement à la commande PACK de dBASE III).
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/dio/book.xml
+++ b/reference/dio/book.xml
@@ -16,7 +16,7 @@
    I/O de bas niveau par rapport aux fonctions
    C-Language stream I/O (<function>fopen</function>,
    <function>fread</function>,..). L'utilisation des fonctions
-   DIO doit être considérée uniquement lorsqu'un contrôle direct
+   DIO devrait être considérée uniquement lorsqu'un contrôle direct
    d'un périphérique est nécessaire. Dans tous les autres cas,
    les fonctions standard de <link linkend="book.filesystem">système
    de fichiers</link> sont plus adéquates.

--- a/reference/dio/functions/dio-open.xml
+++ b/reference/dio/functions/dio-open.xml
@@ -43,7 +43,7 @@
        <emphasis>doit</emphasis> inclure une constante parmi
        <constant>O_RDONLY</constant>, <constant>O_WRONLY</constant>,
        ou <constant>O_RDWR</constant>. À cette constante, il est possible
-       d'y ajouter n'importe quel drapeaux depuis cette liste.
+       d'y ajouter n'importe quels drapeaux depuis cette liste.
        <itemizedlist>
         <listitem>
           <para>

--- a/reference/dio/functions/dio-seek.xml
+++ b/reference/dio/functions/dio-seek.xml
@@ -70,8 +70,8 @@
           <constant>SEEK_END</constant> : spécifie que
           <parameter>pos</parameter> est un nombre de caractères à partir de
           la fin du fichier. Une valeur négative spécifie une position à
-          l'intérieur du domaine courant du fichier; une valeur positive
-          spécifie une position passée de la fin courante. Si l'on spécifie
+          l'intérieur de l'étendue courante du fichier ; une valeur positive
+          spécifie une position au-delà de la fin courante. Si l'on spécifie
           une position après la fin et que l'on y écrit des données, cela
           va agrandir le fichier avec des zéros jusqu'à cette position.
          </para>

--- a/reference/dio/functions/dio-stat.xml
+++ b/reference/dio/functions/dio-stat.xml
@@ -31,7 +31,7 @@
      <term><parameter>fd</parameter></term>
      <listitem>
       <para>
-       La ressource de fichier retournée par <function>dio_open</function>.
+       Le descripteur de fichier retourné par <function>dio_open</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -61,7 +61,7 @@
     </listitem>
     <listitem>
      <para>
-      "nlink" : nombre de liens
+      "nlink" : nombre de liens physiques
      </para>
     </listitem>
     <listitem>

--- a/reference/dio/functions/dio-tcsetattr.xml
+++ b/reference/dio/functions/dio-tcsetattr.xml
@@ -32,7 +32,7 @@
      <term><parameter>fd</parameter></term>
      <listitem>
       <para>
-       La ressource de fichier retournée par <function>dio_open</function>.
+       Le descripteur de fichier retourné par <function>dio_open</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dio/functions/dio-truncate.xml
+++ b/reference/dio/functions/dio-truncate.xml
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dio_truncate</function> tronque un fichier d'au moins
+   <function>dio_truncate</function> tronque un fichier à au plus
    <parameter>offset</parameter> octets, en taille.
   </para>
   <para>

--- a/reference/dio/functions/dio-write.xml
+++ b/reference/dio/functions/dio-write.xml
@@ -36,7 +36,7 @@
      <term><parameter>fd</parameter></term>
      <listitem>
       <para>
-       La ressource de fichier retournée par <function>dio_open</function>.
+       Le descripteur de fichier retourné par <function>dio_open</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -52,8 +52,8 @@
      <term><parameter>len</parameter></term>
      <listitem>
       <para>
-       La grandeur des données à écrire en octets. S'il n'est pas spécifié, la
-       fonction écrit toutes les données au fichier spécifié.
+       La longueur des données à écrire en octets. Si elle n'est pas spécifiée, la
+       fonction écrit toutes les données dans le fichier spécifié.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dio/setup.xml
+++ b/reference/dio/setup.xml
@@ -15,7 +15,7 @@
   &reftitle.resources;
   <para>
    Un type de ressource est défini par cette extension :
-   un pointeur de fichier, retourné par la fonction
+   un descripteur de fichier, retourné par la fonction
    <function>dio_open</function>.
   </para>
  </section>

--- a/reference/dir/functions/chdir.xml
+++ b/reference/dir/functions/chdir.xml
@@ -29,7 +29,7 @@
      <term><parameter>directory</parameter></term>
      <listitem>
       <para>
-       Le nouveau répertoire courant
+       Le nouveau dossier courant
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dir/functions/dir.xml
+++ b/reference/dir/functions/dir.xml
@@ -79,7 +79,7 @@
     <para>
      Il est à noter la façon dont la valeur de retour de <function>Directory::read</function>
      est vérifiée dans l'exemple suivant. Nous testons si la valeur est
-     identique (égale et de même type que -- voyez <link
+     identique (égale et de même type que - voyez <link
      linkend="language.operators.comparison">opérateurs de comparaison</link>
      pour plus de détails) à &false; sinon, toute entrée de dossier dont le nom
      s'évalue à &false; causera l'arrêt de la boucle.

--- a/reference/dir/functions/opendir.xml
+++ b/reference/dir/functions/opendir.xml
@@ -101,7 +101,7 @@
     <function>readdir</function> retourne &false; lorsqu'il a lu toutes les
     entrées d'un dossier, il faut utiliser 
     <link linkend="language.operators.comparison">l'opérateur de comparaison</link>
-    <literal>===</literal> pour distinguer proprement une entrée de dossier
+    <literal>===</literal> pour distinguer correctement une entrée de dossier
     dont le nom est "faux" d'une entrée de dossier qui a été lue
     et qui est &false;.
    </simpara>

--- a/reference/dir/functions/rewinddir.xml
+++ b/reference/dir/functions/rewinddir.xml
@@ -35,7 +35,8 @@
    </varlistentry>
   </variablelist>
  </refsect1>
-  <refsect1 role="returnvalues">
+
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
    &return.void;


### PR DESCRIPTION
Sous-ensemble de #139 : reference/componere, ctype, cubrid, curl, datetime, dba, dbase, dio, dir (dom exclu). Mêmes modifications, sur 116 fichiers.